### PR TITLE
feat(engine): version, plan, validate, timings, and new contracts

### DIFF
--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -1,12 +1,15 @@
 import Foundation
 
 /// Result of a Boris IR build: exit code, decoded `build-report.json`, and —
-/// when the build succeeded — the decoded `manifest.json` / `graph.json`.
+/// when the build succeeded — the decoded `manifest.json` / `graph.json` /
+/// `completion.json`. `--timings` (when requested) is optional stdout JSON.
 public struct BorisBuild: Sendable {
     public let exitCode: Int32
     public let report: BuildReport
     public let manifest: Manifest?
     public let graph: Graph?
+    public let completion: Completion?
+    public let timings: TimingsReport?
     public let stderr: String
 }
 
@@ -21,6 +24,29 @@ public struct BorisHTMLBuild: Sendable {
 public struct BorisAnalysis: Sendable {
     public let exitCode: Int32
     public let report: AnalysisReport
+}
+
+/// Result of `boris --version`.
+public struct BorisVersion: Sendable {
+    public let exitCode: Int32
+    public let line: String
+}
+
+/// Result of `boris plan --profile`. Exit 2/3 when the profile is missing or
+/// invalid; `plan` is then nil and stdout/stderr carry the engine's output.
+public struct BorisPlan: Sendable {
+    public let exitCode: Int32
+    public let plan: PublicationPlan?
+    public let stdout: String
+    public let stderr: String
+}
+
+/// Result of `boris validate --report`. The report is written on success and
+/// content/I/O failure; usage errors may produce no file.
+public struct BorisValidate: Sendable {
+    public let exitCode: Int32
+    public let report: HTMLBuildReport?
+    public let stderr: String
 }
 
 public enum BorisEngineError: Error, Sendable, CustomStringConvertible {
@@ -60,8 +86,8 @@ public actor BorisEngine {
 
     /// Runs `boris --out <dir> --input <root> --quiet` (IR mode) and decodes
     /// the published artifacts (`build-report.json` always; `manifest.json` /
-    /// `graph.json` only on success — Boris deletes them on content failure;
-    /// `completion.json` exists on afterparty but is not yet modeled).
+    /// `graph.json` / `completion.json` only on success — Boris deletes them
+    /// on content failure).
     ///
     /// Afterparty constrains **output trees** to the process workspace and
     /// rejects absolute output paths in IR mode (verified: `--out /abs/…`
@@ -69,17 +95,28 @@ public actor BorisEngine {
     /// The input root may live anywhere. So we run from the output's parent
     /// and pass a **relative** output path. For the app this means
     /// `cwd = project folder`, `--out .boris` — the D1 defaults.
-    public func buildIR(contentRoot: URL, outDir: URL) throws -> BorisBuild {
+    ///
+    /// Pass `timings: true` to add `--timings` and optionally decode the
+    /// `boris-timings` JSON on stdout.
+    public func buildIR(
+        contentRoot: URL,
+        outDir: URL,
+        timings: Bool = false
+    ) throws -> BorisBuild {
         try FileManager.default.createDirectory(
             at: outDir, withIntermediateDirectories: true
         )
+        var arguments = [
+            "--out", outDir.lastPathComponent,
+            "--input", contentRoot.path,
+            "--quiet",
+        ]
+        if timings {
+            arguments.append("--timings")
+        }
         let out = try BorisRunner.run(
             binary: binaryURL,
-            arguments: [
-                "--out", outDir.lastPathComponent,
-                "--input", contentRoot.path,
-                "--quiet",
-            ],
+            arguments: arguments,
             workingDirectory: outDir.deletingLastPathComponent()
         )
         let report = try decode(
@@ -89,6 +126,7 @@ public actor BorisEngine {
         )
         var manifest: Manifest?
         var graph: Graph?
+        var completion: Completion?
         if report.ok {
             manifest = try? decode(
                 Manifest.self,
@@ -100,12 +138,25 @@ public actor BorisEngine {
                 from: outDir.appendingPathComponent("graph.json"),
                 artifact: "graph.json"
             )
+            completion = try? decode(
+                Completion.self,
+                from: outDir.appendingPathComponent("completion.json"),
+                artifact: "completion.json"
+            )
+        }
+        let timingsReport: TimingsReport?
+        if timings {
+            timingsReport = decodeJSON(TimingsReport.self, from: out.stdout)
+        } else {
+            timingsReport = nil
         }
         return BorisBuild(
             exitCode: out.exitCode,
             report: report,
             manifest: manifest,
             graph: graph,
+            completion: completion,
+            timings: timingsReport,
             stderr: out.stderrText
         )
     }
@@ -172,6 +223,54 @@ public actor BorisEngine {
         return BorisAnalysis(exitCode: out.exitCode, report: report)
     }
 
+    // MARK: Version / plan / validate
+
+    /// Runs `boris --version` and returns the stdout line (e.g. `boris/0.8.1`).
+    public func version() throws -> BorisVersion {
+        let out = try BorisRunner.run(binary: binaryURL, arguments: ["--version"])
+        let line = out.stdoutText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return BorisVersion(exitCode: out.exitCode, line: line)
+    }
+
+    /// Runs `boris plan --profile PATH` with cwd = the profile's parent
+    /// (the publication workspace). Does not invent a profile.
+    public func plan(profileURL: URL) throws -> BorisPlan {
+        let out = try BorisRunner.run(
+            binary: binaryURL,
+            arguments: ["plan", "--profile", profileURL.lastPathComponent],
+            workingDirectory: profileURL.deletingLastPathComponent()
+        )
+        return BorisPlan(
+            exitCode: out.exitCode,
+            plan: decodeJSON(PublicationPlan.self, from: out.stdout),
+            stdout: out.stdoutText,
+            stderr: out.stderrText
+        )
+    }
+
+    /// Runs `boris validate --input … --report PATH` and decodes the
+    /// `html-build-report-0.1.0` file when written. `--report` may be absolute.
+    public func validate(contentRoot: URL, reportURL: URL) throws -> BorisValidate {
+        let out = try BorisRunner.run(binary: binaryURL, arguments: [
+            "validate",
+            "--input", contentRoot.path,
+            "--report", reportURL.path,
+        ])
+        var report: HTMLBuildReport?
+        if FileManager.default.fileExists(atPath: reportURL.path) {
+            report = try decode(
+                HTMLBuildReport.self,
+                from: reportURL,
+                artifact: "validate report"
+            )
+        }
+        return BorisValidate(
+            exitCode: out.exitCode,
+            report: report,
+            stderr: out.stderrText
+        )
+    }
+
     // MARK: Probe
 
     /// Sanity probe: runs `boris --help` and returns the first lines.
@@ -198,5 +297,12 @@ public actor BorisEngine {
         } catch {
             throw BorisEngineError.decodeFailed(artifact: artifact, reason: String(describing: error))
         }
+    }
+
+    /// Optional stdout decode (plan / timings). Empty or unknown shape → nil
+    /// rather than a crash (D8).
+    private func decodeJSON<T: Decodable>(_ type: T.Type, from data: Data) -> T? {
+        guard !data.isEmpty else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
     }
 }

--- a/Sources/Models/BorisContracts.swift
+++ b/Sources/Models/BorisContracts.swift
@@ -6,10 +6,13 @@ import Foundation
 ///   boris/docs/contracts/ir-schema.md      (manifest / graph / build-report)
 ///   boris/docs/contracts/diagnostics.md    (diagnostic objects + codes)
 ///   boris/docs/contracts/                  (documentation-intelligence reports)
+///   boris/docs/contracts/publication-profile.md
+///   boris/docs/contracts/schemas/          (completion, HTML report, profile)
 ///
 /// All structs are `Sendable` so they can cross actor boundaries freely.
 /// Decode defensively: fields the contracts mark nullable are `Optional`, and
-/// consumers must branch on `schemaVersion` before trusting a shape.
+/// consumers must branch on `schemaVersion` / `schema_version` before trusting
+/// a shape (D8: unknown/newer degrades, never crashes).
 /// If a required field is missing, decoding fails loudly — never guess.
 
 // MARK: - Diagnostics
@@ -42,12 +45,31 @@ public struct Diagnostic: Codable, Sendable {
 /// published and any prior copies are removed.
 public struct BuildReport: Codable, Sendable {
     public var schemaVersion: String
-    /// Present on success paths (e.g. "boris/0.8.0").
+    /// IR artifacts may name the compiler as `compiler`, `compiler_id`, or
+    /// `compilerId` (A3). Accept all three; do not unify them.
     public var compiler: String?
+    public var compiler_id: String?
+    public var compilerId: String?
     public var ok: Bool
     public var contentRoot: String?
     public var outDir: String?
     public var pageCount: Int?
+    public var errorCount: Int?
+    public var diagnostics: [Diagnostic]
+
+    public var errors: [Diagnostic] { diagnostics.filter(\.isError) }
+}
+
+// MARK: - HTML build report (`html-build-report-0.1.0`)
+
+/// Written by `boris build --report PATH` and `boris validate --report PATH`
+/// on success and failure. No `pageCount` — only errors/diagnostics.
+public struct HTMLBuildReport: Codable, Sendable {
+    public var schemaVersion: String
+    public var compilerId: String?
+    public var ok: Bool
+    public var contentRoot: String?
+    public var outDir: String?
     public var errorCount: Int?
     public var diagnostics: [Diagnostic]
 
@@ -180,4 +202,168 @@ public struct AnalysisFinding: Codable, Sendable {
 public struct AnalysisImpact: Codable, Sendable {
     public var type: String
     public var value: String
+}
+
+// MARK: - Completion (`boris-completion-index`, schema_version integer 1)
+
+/// `completion.json` — editor completion surface published on a successful IR
+/// freeze. `schema_version` is an integer, unlike the IR string `schemaVersion`.
+public struct Completion: Codable, Sendable {
+    public var format: String
+    public var schema_version: Int?
+    public var compiler_id: String?
+    public var frozen: Bool?
+    public var entities: [CompletionEntity]
+    public var relation_kinds: [String]
+    public var parent_targets: [String]
+    public var layout_slots: [String]
+}
+
+public struct CompletionEntity: Codable, Sendable {
+    public var id: String
+    public var title: String?
+    public var parent: String?
+    public var role: String?
+    public var status: String?
+    public var tags: [String]
+    public var relations: [CompletionRelation]
+}
+
+public struct CompletionRelation: Codable, Sendable {
+    public var kind: String
+    public var target: String
+}
+
+// MARK: - Publication profile (`boris-publication-profile`, schema v1)
+
+/// Strict mirror of profile schema v1. Unknown keys are ignored on decode
+/// (D8); do not invent keys when encoding.
+public struct PublicationProfile: Codable, Sendable {
+    public var format: String
+    public var schema_version: Int?
+    public var input: String?
+    public var input_format: String?
+    public var site: PublicationSite?
+    public var publication: PublicationDeclaration?
+    public var targets: [PublicationTarget]?
+    public var editions: PublicationEditions?
+}
+
+public struct PublicationSite: Codable, Sendable {
+    public var url: String?
+    public var title: String?
+    public var description: String?
+}
+
+public struct PublicationDeclaration: Codable, Sendable {
+    public var target: String
+    public var base_url: String
+    public var origin: String
+    public var base_path: String
+    public var site_kind: String?
+    public var did: String?
+    public var pds: String?
+    public var pds_origin: String?
+    public var name: String?
+    public var description: String?
+    public var show_in_discover: Bool?
+    public var include: [String]?
+    public var exclude: [String]?
+    public var prune: Bool?
+}
+
+public struct PublicationLayoutRule: Codable, Sendable {
+    public var selector: String
+    public var layout: String
+}
+
+public struct PublicationPathOutput: Codable, Sendable {
+    public var path: String
+    public var limit: Int?
+}
+
+public struct PublicationTarget: Codable, Sendable {
+    public var name: String
+    public var output: String
+    public var `public`: Bool?
+    public var theme: String?
+    public var layout: String?
+    public var layout_rules: [PublicationLayoutRule]?
+    public var sitemap: PublicationPathOutput?
+    public var rss: PublicationPathOutput?
+    public var llms: PublicationPathOutput?
+}
+
+public struct PublicationEdition: Codable, Sendable {
+    public var output: String
+}
+
+public struct PublicationRagEdition: Codable, Sendable {
+    public var output: String
+    public var scope: String?
+    public var split_size: Int?
+    public var bundles_only: Bool?
+}
+
+public struct PublicationContextEdition: Codable, Sendable {
+    public var output: String
+    public var scope: String?
+    public var split_size: Int?
+}
+
+public struct PublicationEditions: Codable, Sendable {
+    public var ir: PublicationEdition?
+    public var rag: PublicationRagEdition?
+    public var context: PublicationContextEdition?
+}
+
+// MARK: - Publication plan (`boris-publication-plan`, schema v1)
+
+/// Normalized declaration emitted on stdout by `boris plan --profile PATH`.
+public struct PublicationPlan: Codable, Sendable {
+    public var format: String
+    public var schema_version: Int?
+    public var input: String?
+    public var input_format: String?
+    public var site: PublicationSite?
+    public var publication: PublicationDeclaration?
+    public var targets: [PublicationPlanTarget]?
+    public var editions: PublicationEditions?
+}
+
+public struct PublicationPlanTarget: Codable, Sendable {
+    public var name: String
+    public var output: String
+    public var `public`: Bool?
+    public var theme: String?
+    public var layout: String?
+    public var layout_rules: [PublicationLayoutRule]?
+    public var projections: PublicationProjections?
+}
+
+public struct PublicationProjections: Codable, Sendable {
+    public var html: Bool?
+    public var sitemap: PublicationPathOutput?
+    public var rss: PublicationPathOutput?
+    public var llms: PublicationPathOutput?
+}
+
+// MARK: - Timings (`boris-timings`)
+
+/// Optional observational report printed on stdout when `--timings` is set.
+public struct TimingsReport: Codable, Sendable {
+    public var format: String
+    public var schemaVersion: String?
+    public var mode: String?
+    public var phases: [String: Int]?
+    public var counters: TimingsCounters?
+    public var totalNs: Int?
+}
+
+public struct TimingsCounters: Codable, Sendable {
+    public var page_reads: Int?
+    public var include_reads: Int?
+    public var hash_bytes: Int?
+    public var link_resolutions: Int?
+    public var fast_path_hits: Int?
 }

--- a/Spike/main.swift
+++ b/Spike/main.swift
@@ -1,13 +1,15 @@
 import Foundation
 
-// Solipsist M1 engine spike.
+// Solipsist M1 / M4-S0 engine spike.
 //
 //   1. locate the `boris` binary (SOLIPSIST_BORIS_BIN, app bundle, or the
 //      dev checkout at ../boris)
-//   2. run an IR build on the Boris sample content
-//   3. decode build-report.json / manifest.json / graph.json
-//   4. run `boris check` and `boris impact`, decode the reports
-//   5. print a human-readable summary
+//   2. print `boris --version`
+//   3. attempt `boris plan --profile` (do not invent a profile)
+//   4. run `boris validate --report` and decode html-build-report-0.1.0
+//   5. run an IR build (with --timings); decode IR artifacts + completion
+//   6. run `boris check` and `boris impact`, decode the reports
+//   7. print a human-readable summary
 //
 // Usage:
 //   boris-spike [content-root]
@@ -42,12 +44,78 @@ let engine = try BorisEngine(binaryURL: binary)
 print("boris binary : \(binary.path)")
 print("content root : \(contentRoot.path)")
 
+// --- 0. version -----------------------------------------------------------
+print("\n== boris --version ==")
+let version = try await engine.version()
+print("version      : \(version.line)")
+print("exit code    : \(version.exitCode)")
+
+// --- 0b. plan -------------------------------------------------------------
+// Use a real profile if one sits next to (or inside) the content root.
+// Dogfood may have none — still invoke plan and surface the exit; never
+// write a fake boris.json.
+let profileURL: URL
+if fm.fileExists(atPath: contentRoot.appendingPathComponent("boris.json").path) {
+    profileURL = contentRoot.appendingPathComponent("boris.json")
+} else if fm.fileExists(atPath: contentRoot.deletingLastPathComponent().appendingPathComponent("boris.json").path) {
+    profileURL = contentRoot.deletingLastPathComponent().appendingPathComponent("boris.json")
+} else {
+    profileURL = contentRoot.appendingPathComponent("boris.json")
+}
+print("\n== boris plan --profile \(profileURL.lastPathComponent) ==")
+print("profile      : \(profileURL.path) (exists: \(fm.fileExists(atPath: profileURL.path)))")
+let planned = try await engine.plan(profileURL: profileURL)
+print("exit code    : \(planned.exitCode)")
+if let plan = planned.plan {
+    print("format       : \(plan.format)")
+    print("schema       : \(plan.schema_version.map(String.init) ?? "n/a")")
+    print("input        : \(plan.input ?? "n/a")")
+    print("input_format : \(plan.input_format ?? "n/a")")
+    print("targets      : \(plan.targets?.count ?? 0)")
+} else {
+    let err = planned.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !err.isEmpty {
+        print("stderr       : \(err)")
+    }
+    let out = planned.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !out.isEmpty {
+        print("stdout       : \(out)")
+    }
+}
+
+// --- 0c. validate --report ------------------------------------------------
+let validateReportURL = fm.temporaryDirectory
+    .appendingPathComponent("solipsist-spike-validate-\(UUID().uuidString).json")
+defer { try? fm.removeItem(at: validateReportURL) }
+print("\n== boris validate --input … --report ==")
+let validated = try await engine.validate(
+    contentRoot: contentRoot,
+    reportURL: validateReportURL
+)
+print("exit code    : \(validated.exitCode)")
+if let report = validated.report {
+    print("ok           : \(report.ok)")
+    print("schema       : \(report.schemaVersion)")
+    print("compilerId   : \(report.compilerId ?? "n/a")")
+    print("errors       : \(report.errorCount ?? -1)")
+    for d in report.diagnostics {
+        let loc = "\(d.sourcePath ?? "-"):\(d.line.map(String.init) ?? "-"):\(d.column.map(String.init) ?? "-")"
+        print("  [\(d.severity)] \(d.code) \(loc) \(d.message)")
+    }
+} else {
+    print("report       : not written")
+    let err = validated.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !err.isEmpty {
+        print("stderr       : \(err)")
+    }
+}
+
 // --- 1. IR build ----------------------------------------------------------
 let outDir = fm.temporaryDirectory.appendingPathComponent("solipsist-spike-\(UUID().uuidString)")
 defer { try? fm.removeItem(at: outDir) }
 
-print("\n== IR build (boris --out … --input … --quiet) ==")
-let build = try await engine.buildIR(contentRoot: contentRoot, outDir: outDir)
+print("\n== IR build (boris --out … --input … --quiet --timings) ==")
+let build = try await engine.buildIR(contentRoot: contentRoot, outDir: outDir, timings: true)
 print("exit code    : \(build.exitCode)")
 print("ok           : \(build.report.ok)")
 print("schema       : \(build.report.schemaVersion)")
@@ -86,6 +154,30 @@ if let graph = build.graph {
     print("nav          : \(graph.nav.count) entries")
     if let first = graph.edges.first {
         print("sample edge  : \(first.from.value) -(\(first.kind))-> \(first.to.value)")
+    }
+}
+
+if let completion = build.completion {
+    print("\n== completion.json ==")
+    print("format       : \(completion.format)")
+    print("schema       : \(completion.schema_version.map(String.init) ?? "n/a")")
+    print("compiler_id  : \(completion.compiler_id ?? "n/a")")
+    print("frozen       : \(completion.frozen.map { $0 ? "true" : "false" } ?? "n/a")")
+    print("entities     : \(completion.entities.count)")
+    print("relation_kinds: \(completion.relation_kinds.joined(separator: ", "))")
+    print("parent_targets: \(completion.parent_targets.count)")
+    print("layout_slots : \(completion.layout_slots.count)")
+}
+
+if let timings = build.timings {
+    print("\n== boris-timings ==")
+    print("format       : \(timings.format)")
+    print("schema       : \(timings.schemaVersion ?? "n/a")")
+    print("mode         : \(timings.mode ?? "n/a")")
+    print("totalNs      : \(timings.totalNs.map(String.init) ?? "n/a")")
+    if let phases = timings.phases {
+        let names = phases.keys.sorted().joined(separator: ", ")
+        print("phases       : \(names)")
     }
 }
 


### PR DESCRIPTION
M4 Engine S0. Additive coordinator verbs and Codable mirrors. No SwiftUI.

- `BorisEngine.version()`, `plan(profileURL:)`, `validate(… --report)`, optional `--timings` on IR
- `Completion`, `PublicationProfile`, `HTMLBuildReport`, `PublicationPlan`, `TimingsReport`
- Spike prints version, attempts plan (dogfood has no `boris.json` → exit 3, surfaced), decodes validate report, still `SPIKE OK`

Gate run against the kit binary and `/Users/tbuddy/dev/drawmeanelephant/boris/main/content`.