### PR TITLE
feat(inspector): profile, page, and execution drawer

### DIFF
--- a/Sources/Chrome/InspectorDrawer.swift
+++ b/Sources/Chrome/InspectorDrawer.swift
@@ -9,13 +9,54 @@ struct InspectorDrawer: View {
         Group {
             if store.selection.sourceID == nil {
                 drawerNote("Select a source to inspect its options.")
-            } else if store.selection.noun == nil {
-                drawerNote("Select something in the play place to inspect it.")
             } else {
-                drawerNote("Inspector sections arrive with the Inspector lane.")
+                let snapshot = InspectorSnapshot(
+                    sourceKind: store.selectedSource?.kind,
+                    nounKind: store.selection.noun?.kind
+                )
+                if snapshot.inspectorSections.isEmpty {
+                    drawerNote("Select a source to inspect its options.")
+                } else {
+                    Form {
+                        ForEach(snapshot.inspectorSections) { section in
+                            Section(section.title) {
+                                sectionBody(section)
+                            }
+                        }
+                    }
+                    .formStyle(.grouped)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func sectionBody(_ section: InspectorSection) -> some View {
+        switch section.id {
+        case InspectorSectionID.profile:
+            if let item = store.selectedSource, case .local(let source) = item {
+                ProfileSection(source: source)
+            } else {
+                Text("Profile is available for local sources.")
+                    .foregroundStyle(.secondary)
+            }
+        case InspectorSectionID.page:
+            if let item = store.selectedSource,
+               case .local(let source) = item,
+               let noun = store.selection.noun,
+               noun.kind == InspectorNounKind.page
+            {
+                PageSection(source: source, noun: noun)
+            } else {
+                Text("Select a page in the play place.")
+                    .foregroundStyle(.secondary)
+            }
+        case InspectorSectionID.execution:
+            ExecutionSection()
+        default:
+            EmptyView()
+        }
     }
 
     private func drawerNote(_ message: String) -> some View {

--- a/Sources/Inspector/ExecutionSection.swift
+++ b/Sources/Inspector/ExecutionSection.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Machine-local execution knobs. These write UserDefaults only — never
+/// `boris.json` (D2).
+struct ExecutionSection: View {
+    @AppStorage(Self.jobsKey) private var jobs = 1
+    @AppStorage(Self.incrementalKey) private var incremental = false
+    @AppStorage(Self.quietKey) private var quiet = false
+
+    static let jobsKey = "solipsist.execution.jobs"
+    static let incrementalKey = "solipsist.execution.incremental"
+    static let quietKey = "solipsist.execution.quiet"
+    static let jobsRange = 1...64
+
+    var body: some View {
+        Stepper(value: $jobs, in: Self.jobsRange) {
+            LabeledContent("Jobs", value: "\(clampedJobs)")
+        }
+        .onChange(of: jobs) { _, newValue in
+            if !Self.jobsRange.contains(newValue) {
+                jobs = min(max(newValue, Self.jobsRange.lowerBound), Self.jobsRange.upperBound)
+            }
+        }
+        Toggle("Incremental", isOn: $incremental)
+        Toggle("Quiet", isOn: $quiet)
+        Text("Machine-local. Not written to boris.json.")
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var clampedJobs: Int {
+        min(max(jobs, Self.jobsRange.lowerBound), Self.jobsRange.upperBound)
+    }
+}

--- a/Sources/Inspector/Inspectable.swift
+++ b/Sources/Inspector/Inspectable.swift
@@ -10,3 +10,34 @@ struct InspectorSection: Identifiable, Sendable {
 protocol Inspectable {
     var inspectorSections: [InspectorSection] { get }
 }
+
+enum InspectorSectionID {
+    static let profile = "profile"
+    static let page = "page"
+    static let execution = "execution"
+}
+
+enum InspectorNounKind {
+    static let page = "page"
+    static let profile = "profile"
+}
+
+/// Sections implied by the current selection. The drawer reads this;
+/// it does not write `WorkspaceStore.selection`.
+struct InspectorSnapshot: Inspectable {
+    var sourceKind: SourceKind?
+    var nounKind: String?
+
+    var inspectorSections: [InspectorSection] {
+        guard let sourceKind else { return [] }
+        var sections: [InspectorSection] = []
+        if sourceKind == .local {
+            sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Profile"))
+        }
+        if nounKind == InspectorNounKind.page {
+            sections.append(InspectorSection(id: InspectorSectionID.page, title: "Page"))
+        }
+        sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
+        return sections
+    }
+}

--- a/Sources/Inspector/InspectorCompletion.swift
+++ b/Sources/Inspector/InspectorCompletion.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Loads `<source>/.boris/completion.json` into the shared `Completion`
+/// mirror. Missing or unreadable files degrade to `nil` (D8).
+enum InspectorCompletion {
+    static func url(in root: URL) -> URL {
+        root
+            .appendingPathComponent(".boris", isDirectory: true)
+            .appendingPathComponent("completion.json", isDirectory: false)
+    }
+
+    static func load(from root: URL) -> Completion? {
+        let fileURL = url(in: root)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return try? JSONDecoder().decode(Completion.self, from: data)
+    }
+}

--- a/Sources/Inspector/InspectorProfile.swift
+++ b/Sources/Inspector/InspectorProfile.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Inspector-local slice of `boris.json`. Fields are read from
+/// `PublicationProfile` when it decodes; Save overlays only these keys
+/// onto the existing object so `targets` / `editions` / `nostr` survive
+/// (encoding the shared type would drop `nostr`).
+struct InspectorProfileFields: Equatable, Sendable {
+    var input: String = ""
+    var inputFormat: String = "markdown"
+    var siteTitle: String = ""
+    var siteURL: String = ""
+    var publicationTarget: String = ""
+
+    static let empty = InspectorProfileFields()
+}
+
+enum InspectorProfileError: Error, Sendable {
+    case notAnObject
+}
+
+enum InspectorProfile {
+    static let fileName = "boris.json"
+    static let inputFormats = ["markdown", "textile", "cook"]
+    static let publicationTargets = ["github-pages", "standard-site"]
+
+    static func url(in root: URL) -> URL {
+        root.appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    static func load(from root: URL) throws -> (fields: InspectorProfileFields, data: Data)? {
+        let fileURL = url(in: root)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        let data = try Data(contentsOf: fileURL)
+        if let profile = try? JSONDecoder().decode(PublicationProfile.self, from: data) {
+            return (fields(from: profile), data)
+        }
+        // Typed decode failed (D8). Still offer the keys we edit if the
+        // file is a JSON object, so a missing Models field cannot crash.
+        return (fields(from: try jsonObject(from: data)), data)
+    }
+
+    static func save(to root: URL, original: Data, fields: InspectorProfileFields) throws {
+        let object = try jsonObject(from: original)
+        let merged = overlay(object, fields: fields)
+        let data = try encode(merged)
+        try data.write(to: url(in: root), options: .atomic)
+    }
+
+    static func fields(from profile: PublicationProfile) -> InspectorProfileFields {
+        InspectorProfileFields(
+            input: profile.input ?? "",
+            inputFormat: profile.input_format ?? "markdown",
+            siteTitle: profile.site?.title ?? "",
+            siteURL: profile.site?.url ?? "",
+            publicationTarget: profile.publication?.target ?? ""
+        )
+    }
+
+    static func fields(from object: [String: Any]) -> InspectorProfileFields {
+        let site = object["site"] as? [String: Any] ?? [:]
+        let publication = object["publication"] as? [String: Any] ?? [:]
+        return InspectorProfileFields(
+            input: string(object["input"]),
+            inputFormat: {
+                let value = string(object["input_format"])
+                return value.isEmpty ? "markdown" : value
+            }(),
+            siteTitle: string(site["title"]),
+            siteURL: string(site["url"]),
+            publicationTarget: string(publication["target"])
+        )
+    }
+
+    static func overlay(_ root: [String: Any], fields: InspectorProfileFields) -> [String: Any] {
+        var object = root
+        setOrRemove(&object, key: "input", string: fields.input)
+        setOrRemove(&object, key: "input_format", string: fields.inputFormat)
+
+        var site = object["site"] as? [String: Any] ?? [:]
+        setOrRemove(&site, key: "title", string: fields.siteTitle)
+        setOrRemove(&site, key: "url", string: fields.siteURL)
+        if site.isEmpty {
+            object.removeValue(forKey: "site")
+        } else {
+            object["site"] = site
+        }
+
+        if var publication = object["publication"] as? [String: Any] {
+            setOrRemove(&publication, key: "target", string: fields.publicationTarget)
+            if publication.isEmpty {
+                object.removeValue(forKey: "publication")
+            } else {
+                object["publication"] = publication
+            }
+        } else if !fields.publicationTarget.isEmpty {
+            object["publication"] = ["target": fields.publicationTarget]
+        }
+        return object
+    }
+
+    private static func jsonObject(from data: Data) throws -> [String: Any] {
+        let value = try JSONSerialization.jsonObject(with: data)
+        guard let object = value as? [String: Any] else {
+            throw InspectorProfileError.notAnObject
+        }
+        return object
+    }
+
+    private static func encode(_ object: [String: Any]) throws -> Data {
+        var data = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+        if let text = String(data: data, encoding: .utf8), !text.hasSuffix("\n") {
+            data = Data((text + "\n").utf8)
+        }
+        return data
+    }
+
+    private static func setOrRemove(_ object: inout [String: Any], key: String, string: String) {
+        if string.isEmpty {
+            object.removeValue(forKey: key)
+        } else {
+            object[key] = string
+        }
+    }
+
+    private static func string(_ value: Any?) -> String {
+        value as? String ?? ""
+    }
+}

--- a/Sources/Inspector/PageSection.swift
+++ b/Sources/Inspector/PageSection.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Read-only page minutiae. Fields come from the selected noun plus
+/// `.boris/completion.json` when play has produced it. Frontmatter is
+/// not parsed out of markdown.
+struct PageSection: View {
+    let source: LocalSource
+    let noun: WorkspaceNoun
+
+    @State private var completion: Completion?
+    @State private var note: String?
+
+    var body: some View {
+        Group {
+            LabeledContent("Title", value: displayTitle)
+            LabeledContent("ID", value: noun.id)
+            LabeledContent("Parent", value: display(entity?.parent))
+            LabeledContent("Status", value: display(entity?.status))
+            LabeledContent("Tags", value: displayTags)
+            if let completion {
+                vocabulary("Relation kinds", completion.relation_kinds)
+                vocabulary("Layout slots", completion.layout_slots)
+            } else if let note {
+                Text(note)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .textSelection(.enabled)
+        .task(id: taskID) {
+            load()
+        }
+    }
+
+    private var entity: CompletionEntity? {
+        completion?.entities.first { $0.id == noun.id }
+    }
+
+    private var displayTitle: String {
+        let title = entity?.title ?? noun.title
+        return title.isEmpty ? "—" : title
+    }
+
+    private var displayTags: String {
+        let tags = entity?.tags ?? []
+        return tags.isEmpty ? "—" : tags.joined(separator: ", ")
+    }
+
+    private var taskID: String {
+        "\(source.id.raw.uuidString)|\(noun.id)"
+    }
+
+    private func display(_ value: String?) -> String {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "—" : trimmed
+    }
+
+    @ViewBuilder
+    private func vocabulary(_ title: String, _ values: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Text(values.isEmpty ? "—" : values.joined(separator: ", "))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func load() {
+        completion = nil
+        note = nil
+        guard source.isAvailable else {
+            note = "This folder is no longer reachable."
+            return
+        }
+        do {
+            let root = try source.resolve().url
+            if let index = InspectorCompletion.load(from: root) {
+                completion = index
+            } else {
+                note = "Completion arrives when the IR build writes .boris/completion.json."
+            }
+        } catch {
+            note = String(describing: error)
+        }
+    }
+}

--- a/Sources/Inspector/ProfileSection.swift
+++ b/Sources/Inspector/ProfileSection.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+/// Form over `boris.json`. Every control maps 1:1 to a profile key; Save
+/// writes the file. Execution knobs do not live here.
+struct ProfileSection: View {
+    let source: LocalSource
+
+    @State private var fields = InspectorProfileFields.empty
+    @State private var loaded = InspectorProfileFields.empty
+    @State private var originalData: Data?
+    @State private var status: Status = .idle
+    @State private var note: String?
+
+    var body: some View {
+        Group {
+            switch status {
+            case .idle:
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            case .unavailable:
+                quiet("This folder is no longer reachable.")
+            case .missing:
+                quiet("No publication profile (boris.json) in this folder.")
+            case .invalid:
+                quiet(note ?? "boris.json is not a JSON object.")
+            case .ready:
+                form
+            }
+        }
+        .task(id: source.id.raw) {
+            reload()
+        }
+    }
+
+    private var form: some View {
+        Group {
+            TextField("Title", text: $fields.siteTitle)
+            TextField("URL", text: $fields.siteURL)
+            TextField("Input", text: $fields.input)
+            Picker("Input format", selection: $fields.inputFormat) {
+                ForEach(InspectorProfile.inputFormats, id: \.self) { format in
+                    Text(format).tag(format)
+                }
+            }
+            Picker("Publication target", selection: $fields.publicationTarget) {
+                if loaded.publicationTarget.isEmpty {
+                    Text("None").tag("")
+                }
+                ForEach(InspectorProfile.publicationTargets, id: \.self) { target in
+                    Text(Self.label(forTarget: target)).tag(target)
+                }
+            }
+            HStack {
+                Button("Save") { save() }
+                    .disabled(!isDirty)
+                if let note {
+                    Text(note)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+    }
+
+    private var isDirty: Bool { fields != loaded }
+
+    private func reload() {
+        note = nil
+        guard source.isAvailable else {
+            status = .unavailable
+            return
+        }
+        do {
+            let root = try source.resolve().url
+            guard let loaded = try InspectorProfile.load(from: root) else {
+                status = .missing
+                return
+            }
+            fields = loaded.fields
+            self.loaded = loaded.fields
+            originalData = loaded.data
+            status = .ready
+        } catch {
+            status = .invalid
+            note = String(describing: error)
+        }
+    }
+
+    private func save() {
+        guard let originalData else { return }
+        do {
+            let root = try source.resolve().url
+            try InspectorProfile.save(to: root, original: originalData, fields: fields)
+            if let reloaded = try InspectorProfile.load(from: root) {
+                fields = reloaded.fields
+                loaded = reloaded.fields
+                self.originalData = reloaded.data
+            } else {
+                loaded = fields
+            }
+            note = "Saved"
+        } catch {
+            note = String(describing: error)
+        }
+    }
+
+    private func quiet(_ message: String) -> some View {
+        Text(message)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private static func label(forTarget target: String) -> String {
+        switch target {
+        case "github-pages": return "GitHub Pages"
+        case "standard-site": return "Standard Site"
+        default: return target
+        }
+    }
+
+    private enum Status {
+        case idle
+        case unavailable
+        case missing
+        case invalid
+        case ready
+    }
+}


### PR DESCRIPTION
M3 inspector. Stacked on #2 (Engine S0) so it can use `PublicationProfile` / `Completion`.

- Drawer reads `store.selection`; it does not own it
- Profile form writes `boris.json` as a key overlay (does not drop unknown keys)
- Page section is read-only
- `jobs` / `incremental` / `quiet` in UserDefaults only

`make build` succeeded in the authoring tree. No Play / Engine / Models edits.