### PR TITLE
ci: spike + app on PRs, reserve the fart job

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Card
+
+<!-- M3-play / M4-engine / M3-inspector / P / other -->
+
+## What
+
+## Gate
+
+- [ ] `make spike` (or `make build`) locally
+- [ ] CI `spike` + `app` green
+- [ ] Did not touch `boris/` or commit `SUPPORT-NOT-FOR-GITHUB/`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spike:
+    name: spike
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate project and compile spike
+        run: make spike
+      # Running the spike needs a boris binary. We do not vendor that.
+
+  app:
+    name: app
+    runs-on: macos-15
+    env:
+      SKIP_EMBED_BORIS: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate project and compile the app
+        run: make build
+
+  fart:
+    name: fart
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - run: echo "reserved — do not build the fart app"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 XCODEGEN := .tools/xcodegen/xcodegen/bin/xcodegen
 PROJECT  := Solipsist.xcodeproj
 
-.PHONY: tools generate build spike run-spike clean
+.PHONY: tools generate build spike run-spike clean fart
 
 tools:
 	@mkdir -p .tools
@@ -36,3 +36,7 @@ run-spike: spike
 
 clean:
 	rm -rf build Solipsist.xcodeproj
+
+# Reserved. Do not implement.
+fart:
+	@echo "the fart app is not a thing yet"; exit 1

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Engine search order: `SOLIPSIST_BORIS_BIN` → app bundle →
 `SUPPORT-NOT-FOR-GITHUB/…/bin/boris` (local only) →
 `../boris/zig-out/bin/boris`.
 
+## CI
+
+PRs to `main` run GitHub Actions (`spike` compile + `app` compile).
+There is no boris binary in CI, so the spike is compile-only and the
+app embeds nothing. A `fart` job is reserved and disabled.
+
 ## Boundaries
 
 - Never touch the boris repo from here. File issues; vendor the binary.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,6 +93,7 @@ No scraped prose. No homegrown graph. No third settings store.
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)
 - Cooklang recipe-scale as a first-class play pane (v1: available from
   the page inspector when the corpus has recipes)
+- The fart app (CI job reserved, `make fart` refuses; do not build it)
 
 ---
 

--- a/scripts/embed-boris.sh
+++ b/scripts/embed-boris.sh
@@ -52,6 +52,14 @@ if BIN="$(find_prebuilt)"; then
   exit 0
 fi
 
+# CI compiles the app without a bundled engine. Local `make build` still
+# requires a kit or a boris checkout.
+if [[ "${SKIP_EMBED_BORIS:-}" == "1" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  echo "embed-boris: no engine available — compiling without a bundle"
+  mkdir -p "$DEST_DIR"
+  exit 0
+fi
+
 BORIS_REPO="${BORIS_REPO_DIR:-$SRCROOT/../boris}"
 BIN="$BORIS_REPO/zig-out/bin/boris"
 


### PR DESCRIPTION
GitHub hygiene so `main` can actually be protected.

- `spike` compiles the M1 tool (no boris binary in CI, so we do not run it)
- `app` compiles Solipsist with `SKIP_EMBED_BORIS=1`
- `fart` is a disabled job / `make fart` exits 1 — reserved, not built
- Embed script no longer fails the Xcode phase when Actions has no engine

After this is green, branch protection on `main` will require `spike` and `app`.