### PR TITLE
docs: parallel-lane work pile for the external agent

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -33,7 +33,8 @@ pin; bump when we vendor a newer kit.
 | [`docs/MISSION.md`](docs/MISSION.md) | One-page why |
 | [`docs/BORIS-CAPABILITIES.md`](docs/BORIS-CAPABILITIES.md) | What the engine can do |
 | [`docs/ENGINE-CONTRACTS.md`](docs/ENGINE-CONTRACTS.md) | Probed machine contracts |
-| [`docs/cards/`](docs/cards/) | Session briefs — pick one |
+| [`docs/cards/`](docs/cards/) | Grind-lane briefs |
+| [`docs/cards/parallel/`](docs/cards/parallel/) | External agent — PR cop, Boris issues, busy cards off the grind paths |
 | [`docs/issues/`](docs/issues/) | Ready-to-paste boris issues |
 
 ## Build

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -51,3 +51,9 @@ Same worktree + five agents = they will fight over `git status` and
 `make generate` even when the cards are disjoint. Clone or
 `git worktree add` per card. Merge M4 before the inspector can show
 real completion/profile fields.
+
+## Parallel lane (external agent)
+
+Background pile that must not touch Play / Inspector / Engine /
+Models / Spike / `MainWindow`. PR cop + Boris issue filing + the
+cards under [`parallel/`](parallel/README.md).

--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -1,0 +1,86 @@
+# Parallel lane — stay busy, stay out of the way
+
+For the external agent (PR cop + background cards). The grind lane
+owns Play, Inspector, Engine, Models, Spike, and `MainWindow`. You do
+not.
+
+先读这个。**禁止**改这些路径：
+
+- `Sources/Play/`
+- `Sources/Inspector/`
+- `Sources/Engine/`
+- `Sources/Models/`
+- `Spike/`
+- `Sources/Chrome/MainWindow.swift`
+- `Sources/Chrome/InspectorDrawer.swift`
+- `Sources/Workspace/`（除了只读）
+- 任何 `boris` 仓库（只提 issue，禁止 PR / 禁止改代码）
+
+可以改：`Sources/Companions/`、`Tests/`、`site/`、`.github/`（在现有
+CI 上加 job，不要拆 `spike`/`app`）、`scripts/`（不要改
+`embed-boris.sh` 的搜索顺序）、`docs/cards/parallel/`、
+`docs/issues/` 新草稿。
+
+每个 card 一个 branch / worktree，对 **`main`** 开 PR。不要
+`git add -A`。不要提交 `SUPPORT-NOT-FOR-GITHUB/`。
+
+---
+
+## Standing job — PR cop
+
+You own the open PRs against `main`. Grind lane will keep shipping
+new ones.
+
+1. Rebase onto `origin/main` when CI is stale or the branch drifted.
+2. Do not merge red CI. Do not bypass branch protection.
+3. Stacked PRs: merge the base first (`#2` engine, then retarget
+   inspector `#3` onto `main`). Play `#5` is independent.
+4. If GitHub 5xx, wait and retry. Do not force-push `main`.
+5. Review comments that are factual (wrong path, failed gate) get a
+   fixup commit. Taste arguments leave for the grind lane.
+
+## Standing job — Boris issues
+
+Anything the compiler does wrong or underspecifies is a **draft in
+`docs/issues/`**, then a GitHub issue on `drawmeanelephant/boris`.
+Never a patch to boris.
+
+File these first (bodies are ready):
+
+1. [A1](../../issues/boris-A1-watch-events.md) `--watch-json` + `serve-started`
+2. [A14](../../issues/boris-A14-editor-launch-contract.md) editor URL + SIGTERM
+3. [A7](../../issues/boris-A7-workspace-rule.md) containment docs
+
+Then A5 as a **discussion**, not a patch.
+
+If you hit a new defect (exact stderr, exit code, command line), write
+`docs/issues/boris-A<N>-<slug>.md` in the same shape and open the
+issue. Record the number at the top of the draft. The owner will get
+it fixed.
+
+Do **not** file: unifying `compiler`/`compiler_id`/`compilerId`,
+library mode, relaxing editor CSP/token, shipping `boris-editor` in
+the agent-pack, `plan --out`.
+
+---
+
+## Board (pick from the top when idle)
+
+| # | Card | Owns | Gate |
+|---|------|------|------|
+| 0 | PR cop + file A1/A14/A7 | `docs/issues/` headers only | issues exist on boris; PRs green or restacked |
+| 1 | [contract-fixtures](contract-fixtures.md) | `Tests/`, `Project.yml` test target only | `xcodebuild` test target decodes checked-in JSON |
+| 2 | [preview-shell](preview-shell.md) | `Sources/Companions/Preview/` | Preview window loads a typed URL; no `Process` |
+| 3 | [editor-shell](editor-shell.md) | `Sources/Companions/Editor/` | Parses `BORIS_EDITOR_URL=`; no spawn |
+| 4 | [lint](lint.md) | `.swiftformat` / `.swiftlint.yml`, CI job `lint` | lint job on PRs; no mass reformat of grind paths in the same PR |
+| 5 | [assets](assets.md) | `Sources/Assets.xcassets` or `Solipsist/Assets.xcassets` | app has an icon; `make build` still works |
+| 6 | [P-subdomain](../P-subdomain.md) | `site/` | public URL, no GitHub required |
+| 7 | [help-sheet](help-sheet.md) | `docs/help.md` + Help menu opening it | Help → Solipsist Help shows the sheet |
+| 8 | [dependabot](dependabot.md) | `.github/dependabot.yml` | weekly Actions bumps |
+| 9 | [issue-templates](issue-templates.md) | `.github/ISSUE_TEMPLATE/` | bug + boris-relay templates |
+
+Skip: fart app (`make fart` must keep failing). Skip GitHub-as-source.
+Skip publication flows. Skip Wasm in the app.
+
+When a card would need `BorisEngine` to grow a method, **stop** and
+write a note on the PR — grind lane adds Engine methods.

--- a/docs/cards/parallel/assets.md
+++ b/docs/cards/parallel/assets.md
@@ -1,0 +1,21 @@
+# Parallel — app icon and asset catalog
+
+**Owns:** `Solipsist/Assets.xcassets` (or `Sources/Assets.xcassets`)
+and the one `Project.yml` key that points at it
+(`INFOPLIST` / `asset catalog` path). Do not otherwise edit
+`Project.yml`.
+
+## Do
+
+1. Add an asset catalog with `AppIcon` for a macOS app.
+2. A simple, original mark — not a copy of Apple’s, not a downloaded
+   “AI whale”. Geometric, 1024 ready. If you cannot ship a real
+   image, a solid SF-style vector exported to the required sizes is
+   fine.
+3. Wire `ASSETCATALOG_COMPILER_APPICON_NAME` if not already set.
+4. No third-party icon packs with messy licenses.
+
+## Gate
+
+`make build` (local, with or without engine). The built app shows the
+icon in Finder. Diff is the catalog + the one Project.yml line.

--- a/docs/cards/parallel/contract-fixtures.md
+++ b/docs/cards/parallel/contract-fixtures.md
@@ -1,0 +1,38 @@
+# Parallel — contract fixture tests
+
+**Owns:** `Tests/Fixtures/`, `Tests/ContractTests/`, and **only** the
+new test target stanza in `Project.yml`.
+**Do not touch:** `Sources/Models/` shapes. Decode the types that
+already exist.
+
+## Why
+
+CI cannot run `boris`. We can still refuse to break Codable mirrors
+by checking in real JSON.
+
+## Do
+
+1. Add a `ContractTests` macOS unit-test target in `Project.yml`
+   (Swift 6, same deployment). Sources: `Tests/ContractTests` +
+   `Sources/Models` only.
+2. Check in small fixtures under `Tests/Fixtures/`:
+   - IR `build-report.json` (ok true and ok false)
+   - `manifest.json` (few pages)
+   - `graph.json` (few nodes/edges)
+   - `html-build-report-0.1.0` if the type exists on `main`; skip if not
+   - `completion.json` if `Completion` exists on `main`; skip if not
+3. Harvest fixtures from a **local** kit run if you have
+   `SUPPORT-NOT-FOR-GITHUB/`; otherwise hand-minify samples that match
+   `docs/ENGINE-CONTRACTS.md` and the existing structs. No invented
+   fields.
+4. Tests: decode succeeds; `ok` / counts / first diagnostic code
+   asserted. Unknown extra JSON keys must not crash (keep using
+   Codable as-is).
+5. Add `make test` → `xcodebuild test -scheme ContractTests` (or the
+   generated scheme). Add a CI job `fixtures` that runs `make test`.
+   Do not remove `spike` / `app`.
+
+## Gate
+
+`make test` passes without a boris binary. `make spike` still
+compiles. No diff under `Sources/Engine`, `Play`, `Inspector`.

--- a/docs/cards/parallel/dependabot.md
+++ b/docs/cards/parallel/dependabot.md
@@ -1,0 +1,12 @@
+# Parallel — Dependabot for Actions
+
+**Owns:** `.github/dependabot.yml` only.
+
+## Do
+
+Weekly updates for `github-actions`. Group patch/minor. Do not open
+Dependabot for Swift packages (we have none).
+
+## Gate
+
+File is valid YAML. A dry PR from Dependabot is not required.

--- a/docs/cards/parallel/editor-shell.md
+++ b/docs/cards/parallel/editor-shell.md
@@ -1,0 +1,29 @@
+# Parallel — Editor companion shell
+
+**Owns:** `Sources/Companions/Editor/`
+**Do not touch:** `Engine/`, `Play/`, `Inspector/`. Do not spawn
+`boris-editor`.
+
+## Why
+
+Same split as Preview. A14 will pin
+`BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=…`. You parse that
+line and load it. Grind lane will spawn the host later.
+
+## Do
+
+1. `EditorWindow`: WKWebView + a field that accepts a full
+   `BORIS_EDITOR_URL=…` line *or* the raw URL.
+2. Parser: prefix optional, URL must be `http://127.0.0.1:<port>/`
+   with a `#token=` fragment of hex. Reject anything else.
+3. Load that URL. Do not put the token into query or logs.
+4. Empty state: selected source title + “Editor host is not running.”
+5. Unit-test the parser in `Tests/` only if the fixtures card already
+   added a test target; otherwise a small `EditorURL` type in
+   `Companions/Editor/` with a comment is enough.
+
+## Gate
+
+Paste a well-formed `BORIS_EDITOR_URL=` → WebView navigates to that
+loopback URL. Bad input is refused. No `Process`. Diff only under
+`Sources/Companions/Editor/` (+ a test file if the target exists).

--- a/docs/cards/parallel/help-sheet.md
+++ b/docs/cards/parallel/help-sheet.md
@@ -1,0 +1,21 @@
+# Parallel — Help sheet
+
+**Owns:** `docs/help.md` and `Sources/App/` **only if** you add a
+`CommandGroup` in `Commands.swift` that opens the file. Do not
+restructure `SolipsistApp` or `MainWindow`.
+
+## Do
+
+1. `docs/help.md` — short: what the three columns are, File → Open,
+   View → Preview / Editor / Inspector, where diagnostics will live,
+   link to ROADMAP.
+2. Help menu item “Solipsist Help” opens that markdown in a small
+   `Window` or `NSWorkspace` to the file in the bundle. Prefer a
+   bundled resource over a web URL.
+3. If bundling requires a `Project.yml` resources entry, add only
+   that.
+
+## Gate
+
+Help → Solipsist Help shows the sheet. `make build`. No Play /
+Inspector / Engine diffs.

--- a/docs/cards/parallel/issue-templates.md
+++ b/docs/cards/parallel/issue-templates.md
@@ -1,0 +1,19 @@
+# Parallel — GitHub issue templates
+
+**Owns:** `.github/ISSUE_TEMPLATE/`
+
+## Do
+
+Two templates:
+
+1. **App bug** — macOS version, `boris --version`, what you opened,
+   expected / actual, exit code if any.
+2. **Boris relay** — “this is a compiler defect; draft lives in
+   `docs/issues/`”. Fields: command line, cwd, exit, stderr quote,
+   draft filename. Remind: do not patch boris here.
+
+No feature-request soup. No blank issue if you can disable it.
+
+## Gate
+
+Opening a new issue in the GitHub UI offers those two.

--- a/docs/cards/parallel/lint.md
+++ b/docs/cards/parallel/lint.md
@@ -1,0 +1,21 @@
+# Parallel — format and lint
+
+**Owns:** `.swiftformat`, `.swiftlint.yml`, CI job `lint`,
+`.swiftformatignore` / exclude lists.
+**Do not** reformat `Sources/Play`, `Inspector`, `Engine`, `Models`,
+or `Spike` in the same PR as adding the tool. Exclusions first.
+
+## Do
+
+1. SwiftFormat + SwiftLint configs that match Swift 6 / the existing
+   style (4-space, no forced unwrap crusades).
+2. Exclude the grind paths listed above until those PRs merge; then
+   a *follow-up* PR may format them alone.
+3. CI job `lint` on `macos-15` or `ubuntu-latest` (lint only). Do not
+   make `lint` required until it is green on `main`.
+4. `make lint` locally.
+
+## Gate
+
+`make lint` passes on `main` as it stands (because grind paths are
+excluded). A new file under `Companions/` would be linted.

--- a/docs/cards/parallel/preview-shell.md
+++ b/docs/cards/parallel/preview-shell.md
@@ -1,0 +1,32 @@
+# Parallel — Preview companion shell
+
+**Owns:** `Sources/Companions/Preview/`
+**Do not touch:** `Engine/`, `Play/`, `Inspector/`, `Workspace/`.
+
+## Why
+
+Preview is a companion window. The grind lane will later give
+`BorisEngine.previewStart/Stop`. You build the *window* so that
+method has somewhere to land.
+
+## Do
+
+1. `PreviewWindow` is a `WKWebView` plus a slim toolbar: URL field,
+   Reload, Open in Browser.
+2. It reads `WorkspaceStore.selection` only to show *which* source is
+   selected (title / path). It does not start `boris`.
+3. Until Engine grows preview, the web view loads `about:blank` and
+   the toolbar lets a human paste `http://127.0.0.1:<port>/__boris/`.
+   Validate loopback only (`127.0.0.1` / `localhost`). Refuse anything
+   else.
+4. Menu item already exists (View → Preview). Keep it.
+5. No `Process`. No stderr regex. When grind adds `serve-started` /
+   `previewStart`, they will set the URL. Leave a single
+   `func loadPreview(url: URL)` on the view for them.
+
+## Gate
+
+`make build`. Open Preview with no source → empty state. With a
+source → name shown, paste a loopback URL → WKWebView loads it.
+Non-loopback paste is rejected. Diff is only under
+`Sources/Companions/Preview/`.


### PR DESCRIPTION
Cards the grind lane will not take. Standing jobs: PR cop, file remaining Boris issues (A1 → A14 → A7), draft any new compiler defects instead of patching boris.

Then a queue: contract fixtures, preview/editor shells (no Process), lint, icon, help sheet, Dependabot, issue templates, P-subdomain.

Hard path ban is at the top of \`docs/cards/parallel/README.md\` (English + a short 中文 fence).