### PR TITLE
feat(coordinate): Plan, Validate, Build, Check, Impact, Stop

### DIFF
--- a/Sources/App/AppRuntime.swift
+++ b/Sources/App/AppRuntime.swift
@@ -9,6 +9,7 @@ final class AppRuntime {
     let engine: BorisEngine?
     let enginePath: String?
     let engineError: String?
+    let coordinator = Coordinator()
 
     init() {
         if let url = BorisBinary.locate() {
@@ -28,9 +29,12 @@ final class AppRuntime {
     }
 
     var statusLine: String {
+        let engineBit: String
         if let enginePath {
-            return "engine \(URL(fileURLWithPath: enginePath).lastPathComponent)"
+            engineBit = "engine \(URL(fileURLWithPath: enginePath).lastPathComponent)"
+        } else {
+            engineBit = "engine not found"
         }
-        return "engine not found"
+        return "\(coordinator.summary) · \(engineBit)"
     }
 }

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Menu bar. If it is not here, it is not a feature.
 struct SolipsistCommands: Commands {
     @Bindable var store: WorkspaceStore
+    var runtime: AppRuntime
     @Binding var inspectorPresented: Bool
     @Environment(\.openWindow) private var openWindow
 
@@ -19,6 +20,52 @@ struct SolipsistCommands: Commands {
                 }
             }
             .disabled(store.selection.sourceID == nil)
+        }
+
+        CommandMenu("Boris") {
+            Button("Plan") {
+                runtime.coordinator.run(.plan, store: store, runtime: runtime)
+            }
+            .keyboardShortcut("l", modifiers: [.command, .shift])
+            .disabled(!hasSource || runtime.coordinator.isRunning)
+
+            Button("Validate") {
+                runtime.coordinator.run(.validate, store: store, runtime: runtime)
+            }
+            .keyboardShortcut("k", modifiers: [.command, .shift])
+            .disabled(!hasSource || runtime.coordinator.isRunning)
+
+            Button("Build IR") {
+                runtime.coordinator.run(.buildIR, store: store, runtime: runtime)
+            }
+            .keyboardShortcut("b", modifiers: .command)
+            .disabled(!hasSource || runtime.coordinator.isRunning)
+
+            Button("Build HTML") {
+                runtime.coordinator.run(.buildHTML, store: store, runtime: runtime)
+            }
+            .keyboardShortcut("b", modifiers: [.command, .shift])
+            .disabled(!hasSource || runtime.coordinator.isRunning)
+
+            Divider()
+
+            Button("Check") {
+                runtime.coordinator.run(.check, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || runtime.coordinator.isRunning)
+
+            Button("Impact") {
+                runtime.coordinator.run(.impact, store: store, runtime: runtime)
+            }
+            .disabled(!hasPage || runtime.coordinator.isRunning)
+
+            Divider()
+
+            Button("Stop") {
+                runtime.coordinator.stop(runtime: runtime)
+            }
+            .keyboardShortcut(".", modifiers: .command)
+            .disabled(!runtime.coordinator.isRunning)
         }
 
         CommandGroup(after: .sidebar) {
@@ -40,4 +87,8 @@ struct SolipsistCommands: Commands {
             .keyboardShortcut("e", modifiers: [.command, .shift])
         }
     }
+
+    private var hasSource: Bool { store.selectedSource != nil }
+
+    private var hasPage: Bool { store.selection.noun?.kind == "page" }
 }

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Observation
+
+enum CoordinatorVerb: String, Sendable {
+    case plan
+    case validate
+    case buildIR
+    case buildHTML
+    case check
+    case impact
+}
+
+struct ProblemItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let severity: String
+    let code: String
+    let message: String
+    let path: String?
+    let line: Int?
+    let column: Int?
+
+    init(
+        severity: String,
+        code: String,
+        message: String,
+        path: String? = nil,
+        line: Int? = nil,
+        column: Int? = nil
+    ) {
+        self.id = "\(code)|\(path ?? "")|\(line ?? -1)|\(column ?? -1)|\(message)"
+        self.severity = severity
+        self.code = code
+        self.message = message
+        self.path = path
+        self.line = line
+        self.column = column
+    }
+}
+
+/// Menu verbs against `BorisEngine`. One job at a time. Play and the
+/// status bar read this; they do not spawn `boris`.
+@MainActor
+@Observable
+final class Coordinator {
+    private(set) var isRunning = false
+    private(set) var verb: CoordinatorVerb?
+    private(set) var summary = "idle"
+    private(set) var exitCode: Int32?
+    private(set) var problems: [ProblemItem] = []
+    private var task: Task<Void, Never>?
+
+    func run(_ verb: CoordinatorVerb, store: WorkspaceStore, runtime: AppRuntime) {
+        guard !isRunning else { return }
+        guard let engine = runtime.engine else {
+            finish(
+                verb: verb,
+                exit: nil,
+                summary: runtime.engineError ?? "engine not found",
+                problems: []
+            )
+            return
+        }
+        guard case .local(let source) = store.selectedSource, source.isAvailable else {
+            finish(verb: verb, exit: nil, summary: "no local source", problems: [])
+            return
+        }
+
+        isRunning = true
+        self.verb = verb
+        summary = "\(verb.rawValue)…"
+        exitCode = nil
+        problems = []
+
+        let pageID = store.selection.noun?.kind == "page" ? store.selection.noun?.id : nil
+        task = Task {
+            let result = await Self.perform(verb, source: source, pageID: pageID, engine: engine)
+            guard !Task.isCancelled else {
+                self.finish(verb: verb, exit: result.exit, summary: "cancelled", problems: result.problems)
+                return
+            }
+            self.finish(
+                verb: verb,
+                exit: result.exit,
+                summary: result.summary,
+                problems: result.problems
+            )
+        }
+    }
+
+    func stop(runtime: AppRuntime) {
+        task?.cancel()
+        task = nil
+        if let engine = runtime.engine {
+            Task { await engine.interrupt() }
+        }
+        if isRunning {
+            summary = "stopping…"
+        }
+    }
+
+    private func finish(
+        verb: CoordinatorVerb,
+        exit: Int32?,
+        summary: String,
+        problems: [ProblemItem]
+    ) {
+        self.verb = nil
+        isRunning = false
+        exitCode = exit
+        self.summary = summary
+        self.problems = problems
+        task = nil
+    }
+
+    private struct JobResult: Sendable {
+        var exit: Int32?
+        var summary: String
+        var problems: [ProblemItem]
+    }
+
+    private static func perform(
+        _ verb: CoordinatorVerb,
+        source: LocalSource,
+        pageID: String?,
+        engine: BorisEngine
+    ) async -> JobResult {
+        do {
+            switch verb {
+            case .plan:
+                guard let profile = source.profileURL() else {
+                    return JobResult(exit: 3, summary: "plan: no boris.json", problems: [])
+                }
+                let result = try await engine.plan(profileURL: profile)
+                let summary = result.plan == nil
+                    ? "plan exit \(result.exitCode)"
+                    : "plan ok (\(result.plan?.format ?? "declaration"))"
+                let problems: [ProblemItem]
+                if result.plan == nil, !result.stderr.isEmpty {
+                    problems = [
+                        ProblemItem(
+                            severity: "error",
+                            code: "plan",
+                            message: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                        )
+                    ]
+                } else {
+                    problems = []
+                }
+                return JobResult(exit: result.exitCode, summary: summary, problems: problems)
+
+            case .validate:
+                let reportURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("solipsist-validate-\(UUID().uuidString).json")
+                defer { try? FileManager.default.removeItem(at: reportURL) }
+                let result = try await engine.validate(
+                    contentRoot: source.contentRoot(),
+                    reportURL: reportURL
+                )
+                let items = Self.problems(from: result.report)
+                let count = result.report?.errorCount ?? items.filter { $0.severity == "error" }.count
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: "validate exit \(result.exitCode) · \(count) error(s)",
+                    problems: items
+                )
+
+            case .buildIR:
+                let outDir = try source.artifactDirectory(named: ".boris")
+                let result = try await engine.buildIR(
+                    contentRoot: source.contentRoot(),
+                    outDir: outDir,
+                    timings: true
+                )
+                let items = result.report.diagnostics.map(Self.problem(from:))
+                let pages = result.report.pageCount.map { "\($0) pages" } ?? "IR"
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: "IR exit \(result.exitCode) · \(pages) · \(result.report.errorCount ?? items.count) error(s)",
+                    problems: items
+                )
+
+            case .buildHTML:
+                let htmlDir = try source.artifactDirectory(named: "dist")
+                let reportURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("solipsist-html-\(UUID().uuidString).json")
+                defer { try? FileManager.default.removeItem(at: reportURL) }
+                let result = try await engine.buildHTML(
+                    contentRoot: source.contentRoot(),
+                    htmlDir: htmlDir,
+                    reportURL: reportURL
+                )
+                let items = Self.problems(from: result.report)
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: "HTML exit \(result.exitCode) · \(result.report?.errorCount ?? items.count) error(s)",
+                    problems: items
+                )
+
+            case .check:
+                let result = try await engine.check(contentRoot: source.contentRoot())
+                let items = result.report.findings.map {
+                    ProblemItem(
+                        severity: "info",
+                        code: $0.code,
+                        message: "\($0.type) \($0.value) (count \($0.count))"
+                    )
+                }
+                let s = result.report.summary
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: "check exit \(result.exitCode) · \(s.pages) pages · \(s.unreferencedPages) unreferenced",
+                    problems: items
+                )
+
+            case .impact:
+                guard let pageID else {
+                    return JobResult(exit: 2, summary: "impact: select a page", problems: [])
+                }
+                let result = try await engine.impact(
+                    contentRoot: source.contentRoot(),
+                    pageID: pageID
+                )
+                let items = (result.report.impact ?? []).map {
+                    ProblemItem(severity: "info", code: $0.type, message: $0.value)
+                }
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: "impact \(pageID) · \(items.count) item(s)",
+                    problems: items
+                )
+            }
+        } catch {
+            return JobResult(exit: nil, summary: String(describing: error), problems: [])
+        }
+    }
+
+    private static func problems(from report: HTMLBuildReport?) -> [ProblemItem] {
+        (report?.diagnostics ?? []).map(problem(from:))
+    }
+
+    private static func problem(from diagnostic: Diagnostic) -> ProblemItem {
+        ProblemItem(
+            severity: diagnostic.severity,
+            code: diagnostic.code,
+            message: diagnostic.message,
+            path: diagnostic.sourcePath,
+            line: diagnostic.line,
+            column: diagnostic.column
+        )
+    }
+}

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -16,6 +16,7 @@ struct SolipsistApp: App {
         .commands {
             SolipsistCommands(
                 store: store,
+                runtime: runtime,
                 inspectorPresented: $inspectorPresented
             )
         }

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -26,6 +26,30 @@ struct MainWindow: View {
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
                 Button {
+                    runtime.coordinator.run(.validate, store: store, runtime: runtime)
+                } label: {
+                    Label("Validate", systemImage: "checkmark.circle")
+                }
+                .help("Validate")
+                .disabled(store.selectedSource == nil || runtime.coordinator.isRunning)
+
+                Button {
+                    runtime.coordinator.run(.buildIR, store: store, runtime: runtime)
+                } label: {
+                    Label("Build IR", systemImage: "hammer")
+                }
+                .help("Build IR")
+                .disabled(store.selectedSource == nil || runtime.coordinator.isRunning)
+
+                Button {
+                    runtime.coordinator.stop(runtime: runtime)
+                } label: {
+                    Label("Stop", systemImage: "stop.fill")
+                }
+                .help("Stop")
+                .disabled(!runtime.coordinator.isRunning)
+
+                Button {
                     openWindow(id: CompanionID.preview)
                 } label: {
                     Label("Preview", systemImage: "safari")

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -13,10 +13,11 @@ public struct BorisBuild: Sendable {
     public let stderr: String
 }
 
-/// Result of a Boris HTML build (exit code + stderr; HTML mode publishes no
-/// JSON artifacts).
+/// Result of a Boris HTML build. Optional `--report` decodes
+/// `html-build-report-0.1.0` when the file is written.
 public struct BorisHTMLBuild: Sendable {
     public let exitCode: Int32
+    public let report: HTMLBuildReport?
     public let stderr: String
 }
 
@@ -71,6 +72,7 @@ public enum BorisEngineError: Error, Sendable, CustomStringConvertible {
 /// builds in one process; we serialize across processes too).
 public actor BorisEngine {
     public let binaryURL: URL
+    private let runHandle = RunHandle()
 
     public init(binaryURL: URL? = nil) throws {
         if let binaryURL {
@@ -114,8 +116,7 @@ public actor BorisEngine {
         if timings {
             arguments.append("--timings")
         }
-        let out = try BorisRunner.run(
-            binary: binaryURL,
+        let out = try run(
             arguments: arguments,
             workingDirectory: outDir.deletingLastPathComponent()
         )
@@ -164,21 +165,44 @@ public actor BorisEngine {
     /// Runs an HTML site build: `boris --input <root> --html-dir <dir> --quiet`.
     ///
     /// Same afterparty containment rule as `buildIR`: run from the output's
-    /// parent and pass a relative path.
-    public func buildHTML(contentRoot: URL, htmlDir: URL) throws -> BorisHTMLBuild {
+    /// parent and pass a relative path. Optional `--report` is a single file
+    /// (absolute allowed).
+    public func buildHTML(
+        contentRoot: URL,
+        htmlDir: URL,
+        reportURL: URL? = nil
+    ) throws -> BorisHTMLBuild {
         try FileManager.default.createDirectory(
             at: htmlDir, withIntermediateDirectories: true
         )
-        let out = try BorisRunner.run(
-            binary: binaryURL,
-            arguments: [
-                "--input", contentRoot.path,
-                "--html-dir", htmlDir.lastPathComponent,
-                "--quiet",
-            ],
+        var arguments = [
+            "--input", contentRoot.path,
+            "--html-dir", htmlDir.lastPathComponent,
+            "--quiet",
+        ]
+        if let reportURL {
+            arguments += ["--report", reportURL.path]
+        }
+        let out = try run(
+            arguments: arguments,
             workingDirectory: htmlDir.deletingLastPathComponent()
         )
-        return BorisHTMLBuild(exitCode: out.exitCode, stderr: out.stderrText)
+        var report: HTMLBuildReport?
+        if let reportURL, FileManager.default.fileExists(atPath: reportURL.path) {
+            report = try? decode(
+                HTMLBuildReport.self,
+                from: reportURL,
+                artifact: "html-build-report"
+            )
+        }
+        return BorisHTMLBuild(exitCode: out.exitCode, report: report, stderr: out.stderrText)
+    }
+
+    /// SIGTERM the in-flight process, if any. One-shot builds die; watch
+    /// exits 0. The app treats `terminationReason == .uncaughtSignal` as
+    /// cancel when we inspect it; here we surface the resulting exit.
+    public func interrupt() {
+        runHandle.terminate()
     }
 
     // MARK: Analysis
@@ -194,7 +218,7 @@ public actor BorisEngine {
         let reportURL = fm.temporaryDirectory
             .appendingPathComponent("boris-check-\(UUID().uuidString).json")
         defer { try? fm.removeItem(at: reportURL) }
-        let out = try BorisRunner.run(binary: binaryURL, arguments: [
+        let out = try run(arguments: [
             "check",
             "--input", contentRoot.path,
             "--format", "json",
@@ -212,7 +236,7 @@ public actor BorisEngine {
         let reportURL = fm.temporaryDirectory
             .appendingPathComponent("boris-impact-\(UUID().uuidString).json")
         defer { try? fm.removeItem(at: reportURL) }
-        let out = try BorisRunner.run(binary: binaryURL, arguments: [
+        let out = try run(arguments: [
             "impact", pageID,
             "--input", contentRoot.path,
             "--format", "json",
@@ -227,7 +251,7 @@ public actor BorisEngine {
 
     /// Runs `boris --version` and returns the stdout line (e.g. `boris/0.8.1`).
     public func version() throws -> BorisVersion {
-        let out = try BorisRunner.run(binary: binaryURL, arguments: ["--version"])
+        let out = try run(arguments: ["--version"])
         let line = out.stdoutText.trimmingCharacters(in: .whitespacesAndNewlines)
         return BorisVersion(exitCode: out.exitCode, line: line)
     }
@@ -235,8 +259,7 @@ public actor BorisEngine {
     /// Runs `boris plan --profile PATH` with cwd = the profile's parent
     /// (the publication workspace). Does not invent a profile.
     public func plan(profileURL: URL) throws -> BorisPlan {
-        let out = try BorisRunner.run(
-            binary: binaryURL,
+        let out = try run(
             arguments: ["plan", "--profile", profileURL.lastPathComponent],
             workingDirectory: profileURL.deletingLastPathComponent()
         )
@@ -251,7 +274,7 @@ public actor BorisEngine {
     /// Runs `boris validate --input … --report PATH` and decodes the
     /// `html-build-report-0.1.0` file when written. `--report` may be absolute.
     public func validate(contentRoot: URL, reportURL: URL) throws -> BorisValidate {
-        let out = try BorisRunner.run(binary: binaryURL, arguments: [
+        let out = try run(arguments: [
             "validate",
             "--input", contentRoot.path,
             "--report", reportURL.path,
@@ -275,7 +298,7 @@ public actor BorisEngine {
 
     /// Sanity probe: runs `boris --help` and returns the first lines.
     public func probe() throws -> String {
-        let out = try BorisRunner.run(binary: binaryURL, arguments: ["--help"])
+        let out = try run(arguments: ["--help"])
         let head = out.stdoutText
             .split(separator: "\n")
             .prefix(3)
@@ -284,6 +307,18 @@ public actor BorisEngine {
     }
 
     // MARK: Helpers
+
+    private func run(
+        arguments: [String],
+        workingDirectory: URL? = nil
+    ) throws -> RunOutput {
+        try BorisRunner.run(
+            binary: binaryURL,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            handle: runHandle
+        )
+    }
 
     private func decode<T: Decodable>(_ type: T.Type, from url: URL, artifact: String) throws -> T {
         let data: Data

--- a/Sources/Engine/BorisRunner.swift
+++ b/Sources/Engine/BorisRunner.swift
@@ -29,12 +29,36 @@ public enum BorisRunnerError: Error, Sendable, CustomStringConvertible {
 /// files cannot deadlock (OS pipe buffers cap at ~64 KB and Boris JSON
 /// reports can exceed that) and need no concurrent reader threads. The
 /// child inherits the file descriptors; after exit we read the files back.
+/// Lets the engine interrupt an in-flight `Process` (Stop). Additive —
+/// capture/wait behavior is unchanged.
+public final class RunHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+
+    public init() {}
+
+    func attach(_ process: Process) {
+        lock.lock()
+        self.process = process
+        lock.unlock()
+    }
+
+    public func terminate() {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        guard let process, process.isRunning else { return }
+        process.terminate()
+    }
+}
+
 public enum BorisRunner {
 
     public static func run(
         binary: URL,
         arguments: [String],
-        workingDirectory: URL? = nil
+        workingDirectory: URL? = nil,
+        handle: RunHandle? = nil
     ) throws -> RunOutput {
         let fm = FileManager.default
         let tmpDir = fm.temporaryDirectory
@@ -66,6 +90,7 @@ public enum BorisRunner {
         process.standardOutput = stdoutHandle
         process.standardError = stderrHandle
 
+        handle?.attach(process)
         do {
             try process.run()
         } catch {

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -45,6 +45,13 @@ struct LocalPlay: PlaySurface {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle(source.title)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            VStack(spacing: 0) {
+                Divider()
+                ProblemsPane()
+                    .frame(minHeight: 88, idealHeight: 148, maxHeight: 220)
+            }
+        }
         .task(id: source.id) {
             await load()
         }
@@ -130,8 +137,15 @@ struct LocalPlay: PlaySurface {
         }
 
         state = .building
-        let contentRoot = Self.contentRoot(for: root)
-        let outDir = root.appendingPathComponent(".boris", isDirectory: true)
+        let contentRoot: URL
+        let outDir: URL
+        do {
+            contentRoot = try source.contentRoot()
+            outDir = try source.artifactDirectory(named: ".boris")
+        } catch {
+            state = .failed(String(describing: error))
+            return
+        }
 
         do {
             let build = try await engine.buildIR(contentRoot: contentRoot, outDir: outDir)
@@ -158,22 +172,6 @@ struct LocalPlay: PlaySurface {
     private func decodeGraph(at url: URL) throws -> Graph {
         let data = try Data(contentsOf: url)
         return try JSONDecoder().decode(Graph.self, from: data)
-    }
-
-    /// A folder with both `content/` and `boris.json` is a project root.
-    /// `--input content`, cwd = source, `--out .boris`.
-    private static func contentRoot(for sourceRoot: URL) -> URL {
-        let fm = FileManager.default
-        var isDirectory: ObjCBool = false
-        let content = sourceRoot.appendingPathComponent("content", isDirectory: true)
-        let profile = sourceRoot.appendingPathComponent("boris.json")
-        let hasContent = fm.fileExists(atPath: content.path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
-        let hasProfile = fm.fileExists(atPath: profile.path)
-        if hasContent && hasProfile {
-            return content
-        }
-        return sourceRoot
     }
 
     private enum LoadState {

--- a/Sources/Play/Local/ProblemsPane.swift
+++ b/Sources/Play/Local/ProblemsPane.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// Activity / problems under the graph list. Reads the coordinator only.
+struct ProblemsPane: View {
+    @Environment(AppRuntime.self) private var runtime
+    @Environment(WorkspaceStore.self) private var store
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                if runtime.coordinator.isRunning {
+                    ProgressView()
+                        .controlSize(.mini)
+                }
+                Text(runtime.coordinator.summary)
+                    .lineLimit(1)
+                Spacer()
+                if let exit = runtime.coordinator.exitCode {
+                    Text("exit \(exit)")
+                        .foregroundStyle(exit == 0 ? Color.secondary : Color.red)
+                        .monospacedDigit()
+                }
+            }
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+
+            if !runtime.coordinator.problems.isEmpty {
+                Divider()
+                List(runtime.coordinator.problems, selection: selectedProblem) { item in
+                    ProblemRow(item: item)
+                        .tag(item.id)
+                }
+                .listStyle(.inset(alternatesRowBackgrounds: true))
+            }
+        }
+    }
+
+    private var selectedProblem: Binding<String?> {
+        Binding(
+            get: { nil },
+            set: { id in
+                guard
+                    let id,
+                    let item = runtime.coordinator.problems.first(where: { $0.id == id }),
+                    let path = item.path
+                else { return }
+                let pageID = (path as NSString).deletingPathExtension
+                store.select(noun: WorkspaceNoun(kind: "page", id: pageID, title: pageID))
+            }
+        )
+    }
+}
+
+private struct ProblemRow: View {
+    let item: ProblemItem
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(item.severity)
+                .font(.caption2)
+                .foregroundStyle(item.severity == "error" ? Color.red : Color.secondary)
+                .frame(width: 44, alignment: .leading)
+            Text(item.code)
+                .font(.caption.monospaced())
+            Text(item.message)
+                .lineLimit(2)
+            Spacer(minLength: 8)
+            if let path = item.path {
+                Text(location(path: path, line: item.line, column: item.column))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private func location(path: String, line: Int?, column: Int?) -> String {
+        var text = path
+        if let line {
+            text += ":\(line)"
+            if let column {
+                text += ":\(column)"
+            }
+        }
+        return text
+    }
+}

--- a/Sources/Workspace/Local/LocalSource.swift
+++ b/Sources/Workspace/Local/LocalSource.swift
@@ -49,4 +49,37 @@ struct LocalSource: PublicationSource, Hashable, Sendable, Codable {
         next.id = id
         return next
     }
+
+    /// Folder the bookmark points at.
+    func workspaceRoot() throws -> URL {
+        try resolve().url.standardizedFileURL
+    }
+
+    /// `content/` when this looks like a project root (`content/` + `boris.json`).
+    func contentRoot() throws -> URL {
+        let root = try workspaceRoot()
+        return Self.isProjectRoot(root)
+            ? root.appendingPathComponent("content", isDirectory: true)
+            : root
+    }
+
+    func profileURL() -> URL? {
+        guard let root = try? workspaceRoot() else { return nil }
+        let url = root.appendingPathComponent("boris.json")
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    func artifactDirectory(named name: String) throws -> URL {
+        try workspaceRoot().appendingPathComponent(name, isDirectory: true)
+    }
+
+    static func isProjectRoot(_ root: URL) -> Bool {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        let content = root.appendingPathComponent("content", isDirectory: true)
+        let profile = root.appendingPathComponent("boris.json")
+        let hasContent = fm.fileExists(atPath: content.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+        return hasContent && fm.fileExists(atPath: profile.path)
+    }
 }

--- a/docs/cards/M4-coordinate.md
+++ b/docs/cards/M4-coordinate.md
@@ -1,0 +1,14 @@
+# Card M4 — Coordinator UI
+
+**Milestone:** M4 (the verbs). Engine S0 is already on `main`.
+**Lane:** `Sources/App/` (Commands, Coordinator), `Sources/Play/Local/`
+(activity / problems), small additive Engine (`interrupt`, optional
+`--report` on HTML). `Sources/Workspace/Local/` for shared root helpers.
+**Do not touch:** `Inspector/`, `Companions/`, `Spike/`.
+
+## Gate
+
+With a local source selected, File/Boris menu: Plan, Validate, Build IR,
+Build HTML, Check, Impact (page selected), Stop. Problems pane lists
+`--report` diagnostics (or check findings). Every exit code is visible
+in the status bar. `make build` succeeds.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -13,6 +13,7 @@ These cards win on *what to do now*; those docs win on *what we are*.
 | [P-subdomain](P-subdomain.md) | project site (`site/`) | everything | `https://<subdomain>` serves a Boris-built Solipsist page |
 | [M3-local-play](M3-local-play.md) | `Sources/Play/Local/`, `Workspace/Local/` | P, M4 | Open dogfood content → graph list → select a page |
 | [M4-engine-s0](M4-engine-s0.md) | `Sources/Engine/`, `Sources/Models/`, `Spike/` | P, M3-play | spike runs `plan` + `validate` + `--report` + `--timings` |
+| [M4-coordinate](M4-coordinate.md) | `App/Coordinator`, Play problems, menu verbs | after engine S0 | Plan / Validate / Build / Check / Impact / Stop |
 | [M3-inspector](M3-inspector.md) | `Sources/Inspector/`, `Chrome/InspectorDrawer.swift` | P, M3-play, M4 (do not edit `Models/`) | select a page → drawer shows fields; profile writes `boris.json` |
 | [ISSUES-file](ISSUES-file-A1-A14-A7.md) | `docs/issues/` | everything | A1, A14, A7 pasted when GitHub is back |
 


### PR DESCRIPTION
M4 coordinator UI on top of Engine S0.

- **Boris** menu: Plan, Validate, Build IR (⌘B), Build HTML (⌘⇧B), Check, Impact, Stop (⌘.)
- Toolbar: Validate, Build IR, Stop
- Problems pane under the graph list; click a diagnostic to select a page
- Status bar shows the last verb + exit
- \`interrupt()\` SIGTERMs the current process
- Plan with no \`boris.json\` is exit 3, surfaced, not faked

Inspector / Companions / Spike untouched.