### PR TITLE
test: stunts, contract fixtures, delegation queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
       - name: Generate project and compile the app
         run: make build
 
+  fixtures:
+    name: fixtures
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Decode checked-in contract fixtures
+        run: make test
+
   fart:
     name: fart
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ zig-out/
 SUPPORT-NOT-FOR-GITHUB/
 /boris-agent-kit/
 *.tar.gz
+
+# Stunt harvest leftovers
+.stunt-harvest/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 XCODEGEN := .tools/xcodegen/xcodegen/bin/xcodegen
 PROJECT  := Solipsist.xcodeproj
 
-.PHONY: tools generate build spike run-spike clean fart
+.PHONY: tools generate build spike run-spike test harvest-fixtures clean fart
 
 tools:
 	@mkdir -p .tools
@@ -33,6 +33,13 @@ spike: generate
 
 run-spike: spike
 	build/Build/Products/Debug/boris-spike
+
+test: generate
+	xcodebuild -project $(PROJECT) -scheme ContractTests -configuration Debug \
+		-derivedDataPath build -destination 'platform=macOS' test
+
+harvest-fixtures:
+	bash scripts/harvest-stunt-fixtures.sh
 
 clean:
 	rm -rf build Solipsist.xcodeproj

--- a/Project.yml
+++ b/Project.yml
@@ -72,6 +72,20 @@ targets:
         PRODUCT_NAME: boris-spike
         GENERATE_INFOPLIST_FILE: YES
 
+  ContractTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: Tests/ContractTests
+      - path: Tests/Fixtures
+        type: folder
+      - path: Sources/Models
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: dev.drawmeanelephant.solipsist.contracttests
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_NAME: ContractTests
+
 schemes:
   Solipsist:
     build:
@@ -85,3 +99,10 @@ schemes:
         spike: all
     run:
       config: Debug
+  ContractTests:
+    build:
+      targets:
+        ContractTests: [test, run]
+    test:
+      targets:
+        - ContractTests

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Radio UserLand’s job in Mail’s body: sources on the left, play in the
 middle, inspector drawer on the right. Preview and the Svelte editor
 are companion windows we host. We do not invent a second compiler.
 
-**Status:** M2 chassis. File → Open… adds a local folder as a source.
-Next work is cards in [`docs/cards/`](docs/cards/README.md). Goals:
-[`docs/ROADMAP.md`](docs/ROADMAP.md).
+**Status:** M2 chassis + play list. File → Open… a folder under
+[`Stunts/`](Stunts/) (start with `happy/`). `make test` decodes
+checked-in fixtures (no boris binary). Delegation queue:
+[`docs/cards/queue/`](docs/cards/queue/README.md).
 
 ## Layout
 

--- a/Sources/Models/BorisContracts.swift
+++ b/Sources/Models/BorisContracts.swift
@@ -102,7 +102,8 @@ public struct PageSummary: Codable, Sendable {
     /// Trunk id for satellites; null for trunks.
     public var parent: String?
     public var title: String
-    public var status: String
+    /// Omitted in starter frontmatter; Boris emits JSON null.
+    public var status: String?
 
     public var isTrunk: Bool { role == .trunk }
 }
@@ -128,7 +129,8 @@ public struct GraphNode: Codable, Sendable {
     public var parent: String?
     public var parentIndex: Int?
     public var title: String
-    public var status: String
+    /// Omitted in starter frontmatter; Boris emits JSON null.
+    public var status: String?
     public var tags: [String]?
     /// Byte offset of the body start in the source file (IR has no bodies).
     public var bodyOffset: Int?

--- a/Sources/Play/Local/LocalPlayGraph.swift
+++ b/Sources/Play/Local/LocalPlayGraph.swift
@@ -32,7 +32,7 @@ enum LocalPlayGraph {
                 PlayPage(
                     id: node.id,
                     title: node.title,
-                    status: node.status,
+                    status: node.status ?? "",
                     role: node.role,
                     depth: depth
                 )

--- a/Stunts/README.md
+++ b/Stunts/README.md
@@ -1,0 +1,16 @@
+# Stunt projects
+
+Tiny Boris trees for Solipsist to open. Not product content. Not
+checked-in `dist/` or `.boris/` — harvest those into
+`Tests/Fixtures/` via `scripts/harvest-stunt-fixtures.sh` when you
+have a kit binary.
+
+| Stunt | What it is | Open in Solipsist as |
+|-------|------------|----------------------|
+| `happy/` | `boris init` shape: 3 pages, theme, `boris.json` | the **folder** (project root) |
+| `broken-frontmatter/` | unknown key `category` → `EFRONTMATTER` | the folder (content root) |
+| `broken-parent/` | `parent: does-not-exist` → `EPARENTMISSING` | the folder |
+| `cook-one/` | one `.cook` recipe | the folder; needs `--cooklang` later |
+
+Happy is the default dogfood. Broken stunts exist so Validate / Build
+IR have diagnostics to show. Do not “fix” the broken ones.

--- a/Stunts/broken-frontmatter/index.md
+++ b/Stunts/broken-frontmatter/index.md
@@ -1,0 +1,9 @@
+---
+title: Poisoned
+status: published
+category: nope
+---
+
+# Poisoned
+
+Unknown frontmatter key `category` must fail `EFRONTMATTER`.

--- a/Stunts/broken-parent/orphan.md
+++ b/Stunts/broken-parent/orphan.md
@@ -1,0 +1,9 @@
+---
+title: Orphan
+parent: does-not-exist
+status: published
+---
+
+# Orphan
+
+Parent id is missing. Expect `EPARENTMISSING`.

--- a/Stunts/cook-one/soup.cook
+++ b/Stunts/cook-one/soup.cook
@@ -1,0 +1,6 @@
+---
+title: Soup
+servings: 2
+---
+
+Mix @water{2%cups} and @salt{1%pinch}.

--- a/Stunts/happy/boris.json
+++ b/Stunts/happy/boris.json
@@ -1,0 +1,9 @@
+{
+  "format": "boris-publication-profile",
+  "schema_version": 1,
+  "input": "content",
+  "site": { "title": "My Boris Site" },
+  "targets": [
+    { "name": "public", "output": "dist", "public": true, "theme": "themes/boris" }
+  ]
+}

--- a/Stunts/happy/content/guides/getting-started.md
+++ b/Stunts/happy/content/guides/getting-started.md
@@ -1,0 +1,43 @@
+---
+title: Getting Started
+parent: index
+tags: [guides]
+---
+
+# Getting Started
+
+A page is one Markdown file with YAML frontmatter. The frontmatter
+`id` is derived from the path unless you write one; `title`, `tags`,
+and `parent` shape the graph.
+
+## Add a page
+
+Create `content/guides/example.md`:
+
+```markdown
+---
+title: Example
+parent: index
+tags: [guides]
+---
+
+# Example
+
+Hello from [[index]].
+```
+
+Rebuild with `boris --input content --html-dir dist --theme themes/boris`
+and the page appears in the nav forest, the breadcrumb chain, and the
+frozen graph.
+
+## Frontmatter at a glance
+
+- `title` — page title (`{{title}}`, search, and metadata).
+- `parent` — entity id of the structural parent (this page lives under
+  `index`).
+- `tags` — free-form list rendered into page metadata.
+- `relations` — semantic edges such as `[relates_to=target]`; see
+  [semantic relations](https://github.com/drawmeanelephant/boris/blob/afterparty/docs/contracts/semantic-relations.md).
+
+A wiki link `[[getting-started]]` is a real graph edge: a link to a
+missing page fails the build instead of rendering as dead prose.

--- a/Stunts/happy/content/guides/publishing.md
+++ b/Stunts/happy/content/guides/publishing.md
@@ -1,0 +1,38 @@
+---
+title: Publishing
+parent: index
+tags: [guides]
+relations: [relates_to=guides/getting-started]
+---
+
+# Publishing
+
+Boris treats the deployment URL as publication truth, not an incidental
+detail. The starter profile declares one public HTML target:
+
+```json
+{
+  "format": "boris-publication-profile",
+  "schema_version": 1,
+  "input": "content",
+  "targets": [
+    { "name": "public", "output": "dist", "public": true, "theme": "themes/boris" }
+  ]
+}
+```
+
+Inspect the normalized plan before publishing:
+
+```text
+boris plan --profile boris.json
+boris standard-site plan --profile standard-site.json
+```
+
+The official GitHub Pages workflow (see the repository's
+`docs/github-pages.md`) builds a verified target: it resolves the Pages
+location from `actions/configure-pages`, fails on any URL projection
+that disagrees with it, uploads only inventory-verified files, and
+retains a separate evidence artifact. Atmosphere publication uses
+`standard-site.json`: replace the obviously-fake DID and URL
+before `standard-site publish`. This starter page is related to
+[[guides/getting-started]] so the semantic graph has an edge to inspect.

--- a/Stunts/happy/content/index.md
+++ b/Stunts/happy/content/index.md
@@ -1,0 +1,30 @@
+---
+title: My Boris Site
+tags: [home]
+---
+
+# Welcome
+
+This is a fresh [Boris](https://github.com/drawmeanelephant/boris)
+documentation site. It already has a page graph: this trunk page,
+two guides beneath it, wiki links between them, and one semantic
+relation.
+
+Start here:
+
+- [[guides/getting-started]] — add your own pages and watch the graph grow.
+- [[guides/publishing]] — turn the site into a verified publication.
+
+## Anatomy of this starter
+
+The tree `boris init` created:
+
+```text
+content/
+  index.md                    trunk page (this one)
+  guides/getting-started.md   satellite, parent: index
+  guides/publishing.md        satellite, parent: index
+themes/boris/                 starter theme (closed layout slots)
+boris.json                    publication profile (GitHub Pages)
+standard-site.json            Atmosphere profile (edit the fake DID/URL)
+```

--- a/Stunts/happy/themes/boris/assets/css/boris.css
+++ b/Stunts/happy/themes/boris/assets/css/boris.css
@@ -1,0 +1,42 @@
+/* Starter theme for a Boris site. Replace or extend freely. */
+:root {
+  --ink: #1f2328;
+  --paper: #ffffff;
+  --muted: #59636e;
+  --accent: #0969da;
+  --rule: #d1d9e0;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0 auto;
+  max-width: 64rem;
+  padding: 1rem 1.5rem 3rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.site-header {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.site-title { font-size: 1.1rem; font-weight: 700; margin: 0 0 0.5rem; }
+
+.site-nav ul, .site-toc ul { list-style: none; padding-left: 1rem; }
+.site-nav a, .site-toc a, .site-breadcrumb a { color: var(--accent); text-decoration: none; }
+.site-nav a:hover, .site-toc a:hover, .site-breadcrumb a:hover { text-decoration: underline; }
+
+.site-breadcrumb { color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem; }
+.site-toc { border: 1px solid var(--rule); border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1.5rem; font-size: 0.95rem; }
+.site-toc:empty { display: none; }
+
+.site-content h1 { font-size: 1.8rem; margin-top: 0; }
+.site-content code { background: #f6f8fa; border-radius: 4px; padding: 0.1em 0.35em; }
+.site-content pre { background: #f6f8fa; border-radius: 6px; padding: 0.75rem 1rem; overflow-x: auto; }
+
+.site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: 0.9rem; }

--- a/Stunts/happy/themes/boris/layouts/main.html
+++ b/Stunts/happy/themes/boris/layouts/main.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{title}} · My Boris Site</title>
+  <link rel="stylesheet" href="{{asset-url assets/css/boris.css}}">
+  {{head}}
+</head>
+<body>
+<header class="site-header">
+  <p class="site-title">My Boris Site</p>
+  <nav class="site-nav">{{nav}}</nav>
+</header>
+<main class="site-body">
+  <div class="site-breadcrumb">{{breadcrumb}}</div>
+  <aside class="site-toc">{{toc}}</aside>
+  <article class="site-content">{{content}}</article>
+</main>
+<footer class="site-footer">{{footer}}</footer>
+</body>
+</html>

--- a/Tests/ContractTests/ContractDecodeTests.swift
+++ b/Tests/ContractTests/ContractDecodeTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+final class ContractDecodeTests: XCTestCase {
+    func testHappyIRBuildReport() throws {
+        let report = try decode(BuildReport.self, "happy-ir", "build-report.json")
+        XCTAssertTrue(report.schemaVersion.hasPrefix("0."))
+        XCTAssertTrue(report.ok)
+        XCTAssertEqual(report.pageCount, 3)
+        XCTAssertEqual(report.errorCount, 0)
+        XCTAssertTrue(report.diagnostics.isEmpty)
+    }
+
+    func testHappyManifest() throws {
+        let manifest = try decode(Manifest.self, "happy-ir", "manifest.json")
+        XCTAssertEqual(manifest.pages.count, 3)
+        XCTAssertEqual(manifest.pages.filter(\.isTrunk).count, 1)
+    }
+
+    func testHappyGraph() throws {
+        let graph = try decode(Graph.self, "happy-ir", "graph.json")
+        XCTAssertTrue(graph.frozen)
+        XCTAssertEqual(graph.nodes.count, 3)
+        XCTAssertFalse(graph.edges.isEmpty)
+    }
+
+    func testHappyCompletion() throws {
+        let completion = try decode(Completion.self, "happy-ir", "completion.json")
+        XCTAssertEqual(completion.format, "boris-completion-index")
+        XCTAssertEqual(completion.schema_version, 1)
+        XCTAssertEqual(completion.entities.count, 3)
+    }
+
+    func testHappyValidateReport() throws {
+        let report = try decode(HTMLBuildReport.self, "validate-happy", "html-build-report.json")
+        XCTAssertTrue(report.ok)
+        XCTAssertEqual(report.schemaVersion, "html-build-report-0.1.0")
+    }
+
+    func testHappyPlan() throws {
+        let plan = try decode(PublicationPlan.self, "plan-happy", "plan.json")
+        XCTAssertEqual(plan.format, "boris-publication-plan")
+        XCTAssertEqual(plan.targets?.count, 1)
+    }
+
+    func testBrokenFrontmatterReport() throws {
+        let report = try decode(BuildReport.self, "broken-frontmatter", "build-report.json")
+        XCTAssertFalse(report.ok)
+        XCTAssertTrue(report.diagnostics.contains { $0.code == "EFRONTMATTER" })
+    }
+
+    func testBrokenParentReport() throws {
+        let report = try decode(BuildReport.self, "broken-parent", "build-report.json")
+        XCTAssertFalse(report.ok)
+        XCTAssertTrue(report.diagnostics.contains { $0.code == "EPARENTMISSING" })
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, _ folder: String, _ name: String) throws -> T {
+        let url = try fixture(folder, name)
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    private func fixture(_ folder: String, _ name: String) throws -> URL {
+        let bundle = Bundle(for: ContractDecodeTests.self)
+        let candidates = [
+            bundle.url(forResource: name, withExtension: nil, subdirectory: folder),
+            bundle.url(forResource: name, withExtension: nil, subdirectory: "Fixtures/\(folder)"),
+            bundle.resourceURL?
+                .appendingPathComponent("Fixtures", isDirectory: true)
+                .appendingPathComponent(folder, isDirectory: true)
+                .appendingPathComponent(name),
+            bundle.resourceURL?
+                .appendingPathComponent(folder, isDirectory: true)
+                .appendingPathComponent(name),
+        ]
+        if let url = candidates.compactMap({ $0 }).first(where: {
+            FileManager.default.fileExists(atPath: $0.path)
+        }) {
+            return url
+        }
+        XCTFail("missing fixture \(folder)/\(name) in \(bundle.resourceURL?.path ?? "?")")
+        throw NSError(domain: "fixtures", code: 1)
+    }
+}

--- a/Tests/Fixtures/broken-frontmatter/build-report.json
+++ b/Tests/Fixtures/broken-frontmatter/build-report.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.2.0",
+  "ok": false,
+  "contentRoot": "broken-frontmatter",
+  "outDir": "_ir-broken-fm",
+  "pageCount": 0,
+  "errorCount": 1,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "EFRONTMATTER",
+      "message": "unsupported frontmatter key",
+      "remediation": "Fix the frontmatter or encoding for this file",
+      "sourcePath": "index.md",
+      "line": 4,
+      "column": 1,
+      "id": null
+    }
+  ]
+}

--- a/Tests/Fixtures/broken-parent/build-report.json
+++ b/Tests/Fixtures/broken-parent/build-report.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.2.0",
+  "ok": false,
+  "contentRoot": "broken-parent",
+  "outDir": "_ir-broken-parent",
+  "pageCount": 1,
+  "errorCount": 1,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "EPARENTMISSING",
+      "message": "parent \"does-not-exist\" does not exist",
+      "remediation": "Create the parent document or fix the parent id",
+      "sourcePath": "orphan.md",
+      "line": 1,
+      "column": 1,
+      "id": "orphan"
+    }
+  ]
+}

--- a/Tests/Fixtures/happy-ir/build-report.json
+++ b/Tests/Fixtures/happy-ir/build-report.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "0.3.0",
+  "ok": true,
+  "contentRoot": "content",
+  "outDir": ".boris",
+  "pageCount": 3,
+  "errorCount": 0,
+  "diagnostics": []
+}

--- a/Tests/Fixtures/happy-ir/completion.json
+++ b/Tests/Fixtures/happy-ir/completion.json
@@ -1,0 +1,38 @@
+{
+  "format": "boris-completion-index",
+  "schema_version": 1,
+  "compiler_id": "boris/0.8.1+semantic-relations",
+  "frozen": true,
+  "entities": [
+    {
+      "id": "guides/getting-started",
+      "title": "Getting Started",
+      "parent": "index",
+      "role": "satellite",
+      "status": null,
+      "tags": ["guides"],
+      "relations": []
+    },
+    {
+      "id": "guides/publishing",
+      "title": "Publishing",
+      "parent": "index",
+      "role": "satellite",
+      "status": null,
+      "tags": ["guides"],
+      "relations": [{"kind": "relates_to", "target": "guides/getting-started"}]
+    },
+    {
+      "id": "index",
+      "title": "My Boris Site",
+      "parent": null,
+      "role": "trunk",
+      "status": null,
+      "tags": ["home"],
+      "relations": []
+    }
+  ],
+  "relation_kinds": ["depends_on", "implements", "relates_to", "supersedes"],
+  "parent_targets": ["index"],
+  "layout_slots": ["backlinks", "breadcrumb", "children", "content", "footer", "metadata", "nav", "relations", "title", "toc"]
+}

--- a/Tests/Fixtures/happy-ir/graph.json
+++ b/Tests/Fixtures/happy-ir/graph.json
@@ -1,0 +1,158 @@
+{
+  "schemaVersion": "0.3.0",
+  "frozen": true,
+  "nodes": [
+    {
+      "index": 0,
+      "id": "guides/getting-started",
+      "sourcePath": "guides/getting-started.md",
+      "role": "satellite",
+      "parent": "index",
+      "parentIndex": 2,
+      "title": "Getting Started",
+      "status": null,
+      "tags": ["guides"],
+      "bodyOffset": 60
+    },
+    {
+      "index": 1,
+      "id": "guides/publishing",
+      "sourcePath": "guides/publishing.md",
+      "role": "satellite",
+      "parent": "index",
+      "parentIndex": 2,
+      "title": "Publishing",
+      "status": null,
+      "tags": ["guides"],
+      "bodyOffset": 102
+    },
+    {
+      "index": 2,
+      "id": "index",
+      "sourcePath": "index.md",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "My Boris Site",
+      "status": null,
+      "tags": ["home"],
+      "bodyOffset": 42
+    }
+  ],
+  "edges": [
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/getting-started"
+      },
+      "to": {
+        "type": "page",
+        "value": "index"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/publishing"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/getting-started"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/publishing"
+      },
+      "to": {
+        "type": "page",
+        "value": "index"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "index"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/getting-started"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "index"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/publishing"
+      },
+      "kind": "reference"
+    }
+  ],
+  "reverseIndex": [
+    {
+      "target": {
+        "type": "page",
+        "value": "guides/getting-started"
+      },
+      "incomingEdges": [1, 3]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "guides/publishing"
+      },
+      "incomingEdges": [4]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "index"
+      },
+      "incomingEdges": [0, 2]
+    }
+  ],
+  "nav": [
+    {
+      "index": 0,
+      "id": "guides/getting-started",
+      "breadcrumb": [2, 0],
+      "children": [],
+      "siblings": [1]
+    },
+    {
+      "index": 1,
+      "id": "guides/publishing",
+      "breadcrumb": [2, 1],
+      "children": [],
+      "siblings": [0]
+    },
+    {
+      "index": 2,
+      "id": "index",
+      "breadcrumb": [2],
+      "children": [0, 1],
+      "siblings": []
+    }
+  ],
+  "relations": [
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/publishing"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/getting-started"
+      },
+      "kind": "relates_to"
+    }
+  ]
+}

--- a/Tests/Fixtures/happy-ir/manifest.json
+++ b/Tests/Fixtures/happy-ir/manifest.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "0.3.0",
+  "compiler": "boris/0.8.1+semantic-relations",
+  "contentRoot": "content",
+  "pageCount": 3,
+  "pages": [
+    {
+      "index": 0,
+      "id": "guides/getting-started",
+      "sourcePath": "guides/getting-started.md",
+      "role": "satellite",
+      "parent": "index",
+      "title": "Getting Started",
+      "status": null
+    },
+    {
+      "index": 1,
+      "id": "guides/publishing",
+      "sourcePath": "guides/publishing.md",
+      "role": "satellite",
+      "parent": "index",
+      "title": "Publishing",
+      "status": null
+    },
+    {
+      "index": 2,
+      "id": "index",
+      "sourcePath": "index.md",
+      "role": "trunk",
+      "parent": null,
+      "title": "My Boris Site",
+      "status": null
+    }
+  ]
+}

--- a/Tests/Fixtures/plan-happy/plan.json
+++ b/Tests/Fixtures/plan-happy/plan.json
@@ -1,0 +1,32 @@
+{
+  "format": "boris-publication-plan",
+  "schema_version": 1,
+  "input": "content",
+  "input_format": "markdown",
+  "site": {
+    "url": null,
+    "title": "My Boris Site",
+    "description": null
+  },
+  "targets": [
+    {
+      "name": "public",
+      "output": "dist",
+      "public": true,
+      "theme": "themes/boris",
+      "layout": null,
+      "layout_rules": [],
+      "projections": {
+        "html": true,
+        "sitemap": null,
+        "rss": null,
+        "llms": null
+      }
+    }
+  ],
+  "editions": {
+    "ir": null,
+    "rag": null,
+    "context": null
+  }
+}

--- a/Tests/Fixtures/validate-happy/html-build-report.json
+++ b/Tests/Fixtures/validate-happy/html-build-report.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "html-build-report-0.1.0",
+  "compilerId": "boris/0.8.1",
+  "ok": true,
+  "contentRoot": "content",
+  "outDir": "dist",
+  "errorCount": 0,
+  "diagnostics": []
+}

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -1,0 +1,43 @@
+# Delegation queue
+
+Work that can run **without GitHub web** and **without the grind
+lane**. One card = one worktree = one PR against `main`.
+
+Open `Stunts/happy` in Solipsist as the default dogfood.
+
+## Forbidden paths (grind / already in flight)
+
+`Sources/Play/` · `Sources/Inspector/` · `Sources/Engine/` ·
+`Sources/Models/` · `Spike/` · `Sources/Chrome/MainWindow.swift` ·
+`Sources/Chrome/InspectorDrawer.swift` · `Sources/App/Coordinator.swift`
+· `Sources/App/Commands.swift` · the `boris` git repo.
+
+If you need a new engine method, stop and leave a note. If Boris
+misbehaves, draft `docs/issues/boris-A<N>-*.md` — do not patch boris.
+
+## Queue
+
+| ID | Card | Owns |
+|----|------|------|
+| Q0 | [file-boris-issues](file-boris-issues.md) | `docs/issues/` headers |
+| Q1 | [stunt-smoke-script](stunt-smoke-script.md) | `scripts/stunt-smoke.sh` |
+| Q2 | [preview-shell](../parallel/preview-shell.md) | `Companions/Preview/` |
+| Q3 | [editor-shell](../parallel/editor-shell.md) | `Companions/Editor/` |
+| Q4 | [lint](../parallel/lint.md) | lint configs + CI job |
+| Q5 | [assets](../parallel/assets.md) | asset catalog |
+| Q6 | [help-sheet](../parallel/help-sheet.md) | `docs/help.md` |
+| Q7 | [dependabot](../parallel/dependabot.md) | `.github/dependabot.yml` |
+| Q8 | [issue-templates](../parallel/issue-templates.md) | `.github/ISSUE_TEMPLATE/` |
+| Q9 | [stunt-duplicate-id](stunt-duplicate-id.md) | `Stunts/broken-duplicate-id/` |
+| Q10 | [stunt-wikilink](stunt-wikilink.md) | `Stunts/broken-wikilink/` |
+| Q11 | [cook-stunt-ir](cook-stunt-ir.md) | `Stunts/cook-one/` + fixture |
+| Q12 | [fixture-check-report](fixture-check-report.md) | `Tests/Fixtures/check-happy/` |
+| Q13 | [about-window](about-window.md) | `Sources/App/AboutWindow.swift` only |
+| Q14 | [statusbar-exit-color](statusbar-exit-color.md) | note only if Coordinator already owns it — **skip if M4-coordinate unmerged** |
+| Q15 | [p-subdomain](../P-subdomain.md) | `site/` |
+| Q16 | [testdata-wrapper](testdata-wrapper.md) | `scripts/stunt-from-testdata.sh` |
+| Q17 | [gitignore-stunts](gitignore-stunts.md) | `.gitignore` only extra lines |
+| Q18 | [readme-stunts](readme-stunts.md) | `README.md` one paragraph |
+| Q19 | [pr-cop](pr-cop.md) | no source |
+
+Pick the lowest unused ID. Stay in that card’s paths.

--- a/docs/cards/queue/about-window.md
+++ b/docs/cards/queue/about-window.md
@@ -1,0 +1,8 @@
+# Q13 — About window
+
+**Owns:** `Sources/App/AboutWindow.swift` and **one**
+`Window("About Solipsist", id:)` in `SolipsistApp.swift`. Do not
+restructure the main window.
+
+Show name, version from the bundle, engine path from `AppRuntime`.
+No Process. Gate: `make build`.

--- a/docs/cards/queue/cook-stunt-ir.md
+++ b/docs/cards/queue/cook-stunt-ir.md
@@ -1,0 +1,9 @@
+# Q11 — Cooklang stunt IR
+
+**Owns:** `Stunts/cook-one/` (already has `soup.cook`) and
+`Tests/Fixtures/cook-one/` if an IR build succeeds with `--cooklang`.
+
+Document the exact command that works against the kit. If the kit
+rejects the tree, write the stderr into `Stunts/cook-one/README.md`
+and draft a boris issue if it is a compiler defect. Do not invent a
+frontmatter parser.

--- a/docs/cards/queue/file-boris-issues.md
+++ b/docs/cards/queue/file-boris-issues.md
@@ -1,0 +1,5 @@
+# Q0 — File A1, A14, A7
+
+Paste `docs/issues/boris-A1-watch-events.md`, `boris-A14-…`, `boris-A7-…`
+onto `drawmeanelephant/boris`. Record issue numbers in those files.
+If GitHub web is dead, use `gh issue create`. Never PR boris.

--- a/docs/cards/queue/fixture-check-report.md
+++ b/docs/cards/queue/fixture-check-report.md
@@ -1,0 +1,7 @@
+# Q12 — Check-report fixture
+
+**Owns:** `Tests/Fixtures/check-happy/` + one test method.
+
+`boris check --input Stunts/happy/content --format json --report …`
+from the happy project root. Check in the JSON. Decode as
+`AnalysisReport`. Add `testHappyCheck` to ContractTests.

--- a/docs/cards/queue/gitignore-stunts.md
+++ b/docs/cards/queue/gitignore-stunts.md
@@ -1,0 +1,11 @@
+# Q17 — Ignore harvest leftovers
+
+**Owns:** `.gitignore` append only:
+
+```
+.stunt-harvest/
+Stunts/**/.boris/
+Stunts/**/dist/
+```
+
+Do not rewrite the rest of the file.

--- a/docs/cards/queue/pr-cop.md
+++ b/docs/cards/queue/pr-cop.md
@@ -1,0 +1,5 @@
+# Q19 — PR cop
+
+No source edits. Rebase open PRs onto `origin/main`. Do not merge
+red CI. Retarget inspector onto `main` after engine is merged.
+If GitHub 5xx, wait. Never force-push `main`.

--- a/docs/cards/queue/readme-stunts.md
+++ b/docs/cards/queue/readme-stunts.md
@@ -1,0 +1,4 @@
+# Q18 — README pointer
+
+**Owns:** one short paragraph in `README.md` pointing at `Stunts/`
+and `make test`. Do not rewrite the README.

--- a/docs/cards/queue/statusbar-exit-color.md
+++ b/docs/cards/queue/statusbar-exit-color.md
@@ -1,0 +1,7 @@
+# Q14 — Status bar exit color
+
+**Skip** unless `Coordinator` is already on `main`. If M4-coordinate
+is unmerged, do not take this card.
+
+**Owns:** `Sources/Chrome/MainWindow.swift` status bar only — color the
+exit code. Do not restyle the split view.

--- a/docs/cards/queue/stunt-duplicate-id.md
+++ b/docs/cards/queue/stunt-duplicate-id.md
@@ -1,0 +1,7 @@
+# Q9 — Duplicate-id stunt
+
+**Owns:** `Stunts/broken-duplicate-id/` only.
+
+Two markdown files that share `id: shared`. Harvest
+`Tests/Fixtures/broken-duplicate-id/build-report.json` with the harvest
+script (extend it) or by hand. Expect `EDUPLICATEID`. Do not fix it.

--- a/docs/cards/queue/stunt-smoke-script.md
+++ b/docs/cards/queue/stunt-smoke-script.md
@@ -1,0 +1,8 @@
+# Q1 — Stunt smoke script
+
+**Owns:** `scripts/stunt-smoke.sh` only.
+
+Run kit `boris` against `Stunts/happy` (IR + validate + plan) and
+assert happy IR `ok: true`, broken-frontmatter `EFRONTMATTER`,
+broken-parent `EPARENTMISSING`. Skip with exit 0 if no binary.
+Do not write into Stunts. Gate: script exits 0 with kit present.

--- a/docs/cards/queue/stunt-wikilink.md
+++ b/docs/cards/queue/stunt-wikilink.md
@@ -1,0 +1,7 @@
+# Q10 — Broken wiki-link stunt
+
+**Owns:** `Stunts/broken-wikilink/` only.
+
+One published page whose body contains `[[no-such-page]]`. Expect
+`EREFERENCEMISSING` (or the live code — record whatever the kit prints).
+Harvest the build-report into `Tests/Fixtures/`.

--- a/docs/cards/queue/testdata-wrapper.md
+++ b/docs/cards/queue/testdata-wrapper.md
@@ -1,0 +1,8 @@
+# Q16 — testdata wrapper
+
+**Owns:** `scripts/stunt-from-testdata.sh`.
+
+If `boris-testdata` exists next to the kit `boris`, generate a 4-page
+`readme-realistic-v1` tree into `/tmp` (never into git) and print the
+path. `--force` not on a repo path. Gate: script runs or exits 0 with
+“no testdata binary”.

--- a/scripts/harvest-stunt-fixtures.sh
+++ b/scripts/harvest-stunt-fixtures.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Rebuild Tests/Fixtures from Stunts/ using a local boris binary.
+# Does not run in CI. Never writes into Stunts/ permanently.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BORIS="${SOLIPSIST_BORIS_BIN:-}"
+if [[ -z "$BORIS" || ! -x "$BORIS" ]]; then
+  for c in \
+    "$ROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris" \
+    "$ROOT/../grok-base/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris"
+  do
+    if [[ -x "$c" ]]; then BORIS="$c"; break; fi
+  done
+fi
+if [[ ! -x "${BORIS:-}" ]]; then
+  echo "harvest: no boris binary (set SOLIPSIST_BORIS_BIN)" >&2
+  exit 1
+fi
+
+FIX="$ROOT/Tests/Fixtures"
+STUNTS="$ROOT/Stunts"
+TMP="$ROOT/.stunt-harvest"
+rm -rf "$TMP"
+mkdir -p "$TMP" "$FIX/happy-ir" "$FIX/broken-frontmatter" "$FIX/broken-parent" "$FIX/validate-happy" "$FIX/plan-happy"
+
+(cd "$STUNTS/happy" && "$BORIS" --out "$TMP/happy-ir" --input content --quiet)
+cp "$TMP/happy-ir/"*.json "$FIX/happy-ir/"
+
+(cd "$STUNTS/happy" && "$BORIS" validate --input content --report "$FIX/validate-happy/html-build-report.json")
+(cd "$STUNTS/happy" && "$BORIS" plan --profile boris.json > "$FIX/plan-happy/plan.json")
+
+(cd "$STUNTS" && "$BORIS" --out "$TMP/broken-fm" --input broken-frontmatter --quiet || true)
+cp "$TMP/broken-fm/build-report.json" "$FIX/broken-frontmatter/"
+
+(cd "$STUNTS" && "$BORIS" --out "$TMP/broken-parent" --input broken-parent --quiet || true)
+cp "$TMP/broken-parent/build-report.json" "$FIX/broken-parent/"
+
+rm -rf "$TMP"
+echo "harvest: wrote $FIX"


### PR DESCRIPTION
- \`Stunts/happy\` (init-shaped, open this), plus broken frontmatter/parent and a cook one-pager
- \`make test\` — 8 fixture decodes, no engine required
- \`scripts/harvest-stunt-fixtures.sh\` when you have a kit binary
- CI job \`fixtures\`
- \`docs/cards/queue/\` — Q0–Q19 for the external agent

Decoder: \`status\` is optional. Starter pages emit JSON null. Not a Boris bug.

Do not \"fix\" the broken stunts.