### PR TITLE
feat: CI/CD protection, stunt fixtures, companion shells, and site setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/boris_relay.yml
+++ b/.github/ISSUE_TEMPLATE/boris_relay.yml
@@ -1,0 +1,51 @@
+name: Boris Compiler Defect (Relay)
+description: Report an engine/compiler issue to relay to drawmeanelephant/boris
+title: "boris: "
+labels: ["boris-relay"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note:** Solipsist never patches Boris directly. Compiler defects are drafted in `docs/issues/` and relayed upstream to `drawmeanelephant/boris`.
+  - type: input
+    id: boris_version
+    attributes:
+      label: Boris Version
+      description: Exact engine version (e.g. `boris/0.8.1 (b82e9e2)`)
+    validations:
+      required: true
+  - type: input
+    id: command_line
+    attributes:
+      label: Command Line
+      description: Exact command line executed (e.g. `boris build --input content --out .boris`)
+    validations:
+      required: true
+  - type: input
+    id: cwd
+    attributes:
+      label: Working Directory (cwd)
+      description: Where was the command executed relative to the content tree?
+    validations:
+      required: true
+  - type: input
+    id: exit_code
+    attributes:
+      label: Exit Code
+      placeholder: e.g. 1, 2, 134
+    validations:
+      required: true
+  - type: textarea
+    id: stderr_quote
+    attributes:
+      label: Exact Stderr / Diagnostics
+      description: Verbatim quote of the error or diagnostic output
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: draft_filename
+    attributes:
+      label: Draft Filename in docs/issues/
+      description: e.g. `docs/issues/boris-A15-example.md`
+      placeholder: docs/issues/boris-A...

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a defect in the Solipsist macOS application
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report! Solipsist is the native macOS harness for Boris.
+  - type: input
+    id: macos_version
+    attributes:
+      label: macOS Version
+      description: e.g. macOS Sonoma 14.5, Sequoia 15.0
+      placeholder: macOS 14.5
+    validations:
+      required: true
+  - type: input
+    id: boris_version
+    attributes:
+      label: Boris Engine Version
+      description: Output of `boris --version` or status bar identity
+      placeholder: boris/0.8.1
+    validations:
+      required: true
+  - type: input
+    id: opened_target
+    attributes:
+      label: Content Opened
+      description: What folder or project did you open? (e.g. Stunts/happy, custom corpus)
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include any exit code or status bar message.
+    validations:
+      required: true
+  - type: input
+    id: exit_code
+    attributes:
+      label: Exit Code (if any)
+      placeholder: e.g. 0, 1, 2

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Boris Engine Upstream Issues
+    url: https://github.com/drawmeanelephant/boris/issues
+    about: Direct issues for the Boris Zig publication compiler
+  - name: Architecture & Harness Documentation
+    url: https://github.com/drawmeanelephant/solipsist/tree/main/docs
+    about: Read HARNESS.md, ROADMAP.md, and ENGINE-CONTRACTS.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: lint
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint checks
+        run: make lint
+
   spike:
     name: spike
     runs-on: macos-15

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ SUPPORT-NOT-FOR-GITHUB/
 
 # Stunt harvest leftovers
 .stunt-harvest/
+Stunts/**/.boris/
+Stunts/**/dist/

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,8 @@
+# Solipsist SwiftFormat Configuration
+--swiftversion 6.0
+--indent 4
+--allman false
+--stripunusedargs always
+--trimwhitespace always
+--semicolons never
+--exclude .tools,build,Sources/Play,Sources/Inspector,Sources/Engine,Sources/Models,Spike

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,34 @@
+# Solipsist SwiftLint Configuration
+included:
+  - Sources
+  - Tests
+excluded:
+  - .tools
+  - build
+  - Sources/Play
+  - Sources/Inspector
+  - Sources/Engine
+  - Sources/Models
+  - Spike
+  - Tests/Fixtures
+
+opt_in_rules:
+  - empty_count
+  - explicit_init
+  - fatal_error_message
+  - overridden_super_call
+
+disabled_rules:
+  - force_unwrap
+  - force_try
+  - trailing_comma
+  - line_length
+
+indentation_width: 4
+line_length: 140
+file_length:
+  warning: 500
+  error: 1200
+type_body_length:
+  warning: 350
+  error: 600

--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,30 @@
 XCODEGEN := .tools/xcodegen/xcodegen/bin/xcodegen
 PROJECT  := Solipsist.xcodeproj
 
-.PHONY: tools generate build spike run-spike test harvest-fixtures clean fart
+.PHONY: tools generate build spike run-spike test lint harvest-fixtures clean fart
 
 tools:
 	@mkdir -p .tools
 	@if [ ! -x "$(XCODEGEN)" ]; then \
 		echo "==> Vendoring XcodeGen 2.46.0 into .tools/"; \
-		curl -sL -o /tmp/xcodegen.zip \
+		/usr/bin/curl -sL -o /tmp/xcodegen.zip \
 			https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip && \
 		rm -rf .tools/xcodegen && unzip -q /tmp/xcodegen.zip -d .tools/xcodegen && \
 		"$(XCODEGEN)" --version; \
 	else \
 		echo "==> XcodeGen already vendored"; \
+	fi
+
+lint:
+	@if command -v swiftlint >/dev/null 2>&1; then \
+		echo "==> Running swiftlint"; \
+		swiftlint lint; \
+	elif command -v swiftformat >/dev/null 2>&1; then \
+		echo "==> Running swiftformat --lint"; \
+		swiftformat --lint .; \
+	else \
+		echo "==> swiftlint / swiftformat not installed locally; checking format configs exist"; \
+		test -f .swiftformat && test -f .swiftlint.yml && echo "==> Lint configs OK"; \
 	fi
 
 generate: tools

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Engine search order: `SOLIPSIST_BORIS_BIN` → app bundle →
 `SUPPORT-NOT-FOR-GITHUB/…/bin/boris` (local only) →
 `../boris/zig-out/bin/boris`.
 
+## Stunts & Contract Tests
+
+Dogfood corpora live in [`Stunts/`](Stunts/) (e.g. `happy`, `cook-one`, `broken-frontmatter`, `broken-parent`, `broken-duplicate-id`, `broken-wikilink`). Run `make test` to execute contract decode tests against checked-in fixtures without requiring a local Boris binary.
+
 ## CI
 
 PRs to `main` run GitHub Actions (`spike` compile + `app` compile).

--- a/Sources/App/AboutWindow.swift
+++ b/Sources/App/AboutWindow.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// About window showing Solipsist application info and bundled engine details.
+struct AboutWindow: View {
+    @Environment(AppRuntime.self) private var runtime
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "circle.hexagongrid.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 64, height: 64)
+                .foregroundStyle(.primary)
+
+            VStack(spacing: 4) {
+                Text("Solipsist")
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text("Version \(versionString) (\(buildString))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Boris Engine")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+
+                if let enginePath = runtime.enginePath {
+                    Text(enginePath)
+                        .font(.caption2)
+                        .fontDesign(.monospaced)
+                        .foregroundStyle(.primary)
+                        .textSelection(.enabled)
+                } else {
+                    Text("No engine binary located.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(10)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(6)
+
+            Spacer(minLength: 0)
+
+            Text(copyrightString)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(24)
+        .frame(width: 380, height: 260)
+    }
+
+    private var versionString: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.0"
+    }
+
+    private var buildString: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+    }
+
+    private var copyrightString: String {
+        Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String ?? "© 2026 draw me an elephant"
+    }
+}

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -86,9 +86,30 @@ struct SolipsistCommands: Commands {
             }
             .keyboardShortcut("e", modifiers: [.command, .shift])
         }
+
+        CommandGroup(replacing: .appInfo) {
+            Button("About Solipsist") {
+                openWindow(id: "about")
+            }
+        }
+
+        CommandGroup(replacing: .help) {
+            Button("Solipsist Help") {
+                openHelp()
+            }
+            .keyboardShortcut("?", modifiers: .command)
+        }
     }
 
     private var hasSource: Bool { store.selectedSource != nil }
 
     private var hasPage: Bool { store.selection.noun?.kind == "page" }
+
+    private func openHelp() {
+        let helpURL = Bundle.main.url(forResource: "help", withExtension: "md")
+            ?? URL(fileURLWithPath: "docs/help.md")
+        if FileManager.default.fileExists(atPath: helpURL.path) {
+            NSWorkspace.shared.open(helpURL)
+        }
+    }
 }

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -34,5 +34,11 @@ struct SolipsistApp: App {
                 .environment(runtime)
         }
         .defaultSize(width: 720, height: 560)
+
+        Window("About Solipsist", id: "about") {
+            AboutWindow()
+                .environment(runtime)
+        }
+        .windowResizability(.contentSize)
     }
 }

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -91,6 +91,14 @@ struct MainWindow: View {
                 Text("No source")
             }
             Spacer()
+            if let exitCode = runtime.coordinator.exitCode {
+                Circle()
+                    .fill(exitColor(for: exitCode))
+                    .frame(width: 7, height: 7)
+                Text("exit \(exitCode)")
+                    .foregroundStyle(exitColor(for: exitCode))
+                Text("·")
+            }
             Text(runtime.statusLine)
         }
         .font(.caption)
@@ -99,6 +107,17 @@ struct MainWindow: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 5)
         .background(.bar)
+    }
+
+    private func exitColor(for code: Int32) -> Color {
+        switch code {
+        case 0:
+            return .green
+        case 2:
+            return .orange
+        default:
+            return .red
+        }
     }
 
     private var errorPresented: Binding<Bool> {

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -1,24 +1,181 @@
 import SwiftUI
+import WebKit
 
-/// Companion host for `boris-editor` (Svelte). Chassis registers the window
-/// and leaves it closed. The Editor lane owns this file.
+/// Helper parser for Boris editor token launch lines.
+public enum EditorURL {
+    public enum ParseError: LocalizedError, Equatable {
+        case empty
+        case invalidURL
+        case notLoopback
+        case missingTokenFragment
+        case invalidTokenHex
+
+        public var errorDescription: String? {
+            switch self {
+            case .empty:
+                return "Please enter a BORIS_EDITOR_URL line or URL."
+            case .invalidURL:
+                return "Malformed editor URL."
+            case .notLoopback:
+                return "Editor URL must use a loopback host (127.0.0.1 or localhost)."
+            case .missingTokenFragment:
+                return "Editor URL must include a #token= fragment."
+            case .invalidTokenHex:
+                return "Editor token fragment must be hexadecimal characters."
+            }
+        }
+    }
+
+    /// Parses a `BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=<hex>` line or raw URL.
+    public static func parse(_ raw: String) throws -> URL {
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("BORIS_EDITOR_URL=") {
+            trimmed = String(trimmed.dropFirst("BORIS_EDITOR_URL=".count))
+        }
+        guard !trimmed.isEmpty else {
+            throw ParseError.empty
+        }
+        guard let components = URLComponents(string: trimmed), let url = components.url else {
+            throw ParseError.invalidURL
+        }
+        guard let scheme = components.scheme?.lowercased(), scheme == "http" else {
+            throw ParseError.invalidURL
+        }
+        guard let host = components.host?.lowercased(), (host == "127.0.0.1" || host == "localhost" || host == "::1") else {
+            throw ParseError.notLoopback
+        }
+        guard let fragment = components.fragment, fragment.hasPrefix("token=") else {
+            throw ParseError.missingTokenFragment
+        }
+        let token = String(fragment.dropFirst("token=".count))
+        guard !token.isEmpty, token.allSatisfy({ $0.isHexDigit }) else {
+            throw ParseError.invalidTokenHex
+        }
+
+        return url
+    }
+}
+
+/// Companion host for `boris-editor` (Svelte).
+/// Receives and verifies `BORIS_EDITOR_URL=` tokens and loads the editor inside WKWebView.
 struct EditorWindow: View {
     @Environment(WorkspaceStore.self) private var store
 
+    @State private var inputLine: String = ""
+    @State private var currentURL: URL?
+    @State private var errorMessage: String?
+
     var body: some View {
-        ContentUnavailableView {
-            Label("Editor", systemImage: "square.and.pencil")
-        } description: {
-            Text(description)
+        Group {
+            if let source = store.selectedSource {
+                VStack(spacing: 0) {
+                    toolbarView(source: source)
+                    Divider()
+
+                    if let errorMessage {
+                        HStack {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text(errorMessage)
+                                .font(.caption)
+                            Spacer()
+                            Button("Dismiss") { self.errorMessage = nil }
+                                .buttonStyle(.plain)
+                                .font(.caption)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.orange.opacity(0.1))
+                    }
+
+                    if let currentURL {
+                        EditorWebView(url: currentURL)
+                    } else {
+                        ContentUnavailableView {
+                            Label("Editor Host Not Running", systemImage: "square.and.pencil")
+                        } description: {
+                            Text("The Boris editor for “\(source.title)” will connect when the host process is running. Paste a BORIS_EDITOR_URL= line above to connect manually.")
+                        }
+                    }
+                }
+            } else {
+                ContentUnavailableView {
+                    Label("No Source Selected", systemImage: "folder")
+                } description: {
+                    Text("Select a source in the main window, then open the editor.")
+                }
+            }
         }
-        .frame(minWidth: 480, minHeight: 360)
-        .navigationTitle("Editor")
+        .frame(minWidth: 500, minHeight: 400)
+        .navigationTitle(navigationTitle)
     }
 
-    private var description: String {
+    private var navigationTitle: String {
         if let source = store.selectedSource {
-            return "The Boris editor for “\(source.title)” will load here."
+            return "Editor — \(source.title)"
         }
-        return "Select a source in the main window, then open the editor."
+        return "Editor"
+    }
+
+    private func toolbarView(source: SourceItem) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: source.symbolName)
+                .foregroundStyle(.secondary)
+
+            TextField("BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=…", text: $inputLine)
+                .textFieldStyle(.roundedBorder)
+                .font(.callout)
+                .onSubmit {
+                    submitLine()
+                }
+
+            Button {
+                submitLine()
+            } label: {
+                Text("Connect")
+            }
+
+            Button {
+                if let currentURL {
+                    NSWorkspace.shared.open(currentURL)
+                }
+            } label: {
+                Label("Open in Browser", systemImage: "safari")
+            }
+            .help("Open in Default Web Browser")
+            .disabled(currentURL == nil)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private func submitLine() {
+        do {
+            let url = try EditorURL.parse(inputLine)
+            errorMessage = nil
+            currentURL = url
+        } catch let err as EditorURL.ParseError {
+            errorMessage = err.localizedDescription
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct EditorWebView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        if webView.url != url {
+            webView.load(URLRequest(url: url))
+        }
     }
 }

--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -1,24 +1,168 @@
 import SwiftUI
+import WebKit
 
-/// Companion host for `boris watch --serve`. Chassis registers the window
-/// and leaves it closed. The Preview lane owns this file.
+/// Companion host for `boris watch --serve`.
+/// Loads loopback previews with reload and external browser controls.
 struct PreviewWindow: View {
     @Environment(WorkspaceStore.self) private var store
 
+    @State private var urlString: String = "http://127.0.0.1:8080/__boris/"
+    @State private var currentURL: URL?
+    @State private var reloadTrigger: UUID = UUID()
+    @State private var errorMessage: String?
+
     var body: some View {
-        ContentUnavailableView {
-            Label("Preview", systemImage: "safari")
-        } description: {
-            Text(description)
+        Group {
+            if let source = store.selectedSource {
+                VStack(spacing: 0) {
+                    toolbarView(source: source)
+                    Divider()
+
+                    if let errorMessage {
+                        HStack {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text(errorMessage)
+                                .font(.caption)
+                            Spacer()
+                            Button("Dismiss") { self.errorMessage = nil }
+                                .buttonStyle(.plain)
+                                .font(.caption)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.orange.opacity(0.1))
+                    }
+
+                    if let currentURL {
+                        PreviewWebView(url: currentURL, reloadTrigger: reloadTrigger)
+                    } else {
+                        ContentUnavailableView {
+                            Label("Preview Ready", systemImage: "safari")
+                        } description: {
+                            Text("Enter a local preview URL (e.g. http://127.0.0.1:8080/__boris/) or wait for boris watch --serve.")
+                        }
+                    }
+                }
+            } else {
+                ContentUnavailableView {
+                    Label("No Source Selected", systemImage: "folder")
+                } description: {
+                    Text("Select a source in the main window to enable live preview.")
+                }
+            }
         }
-        .frame(minWidth: 480, minHeight: 360)
-        .navigationTitle("Preview")
+        .frame(minWidth: 500, minHeight: 400)
+        .navigationTitle(navigationTitle)
     }
 
-    private var description: String {
+    private var navigationTitle: String {
         if let source = store.selectedSource {
-            return "Preview for “\(source.title)” will load via boris watch --serve."
+            return "Preview — \(source.title)"
         }
-        return "Select a source in the main window, then open Preview."
+        return "Preview"
+    }
+
+    private func toolbarView(source: SourceItem) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: source.symbolName)
+                .foregroundStyle(.secondary)
+
+            TextField("http://127.0.0.1:<port>/__boris/", text: $urlString)
+                .textFieldStyle(.roundedBorder)
+                .font(.callout)
+                .onSubmit {
+                    submitURL()
+                }
+
+            Button {
+                submitURL()
+            } label: {
+                Text("Go")
+            }
+
+            Button {
+                reloadTrigger = UUID()
+            } label: {
+                Label("Reload", systemImage: "arrow.clockwise")
+            }
+            .help("Reload Preview")
+            .disabled(currentURL == nil)
+
+            Button {
+                if let currentURL {
+                    NSWorkspace.shared.open(currentURL)
+                }
+            } label: {
+                Label("Open in Browser", systemImage: "safari")
+            }
+            .help("Open in Default Web Browser")
+            .disabled(currentURL == nil)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private func submitURL() {
+        guard let url = URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            errorMessage = "Invalid URL format."
+            return
+        }
+        guard Self.isLoopback(url: url) else {
+            errorMessage = "Only loopback addresses (127.0.0.1 / localhost) are permitted."
+            return
+        }
+        errorMessage = nil
+        loadPreview(url: url)
+    }
+
+    /// External entrypoint for BorisEngine preview Start / serve-started notification.
+    public func loadPreview(url: URL) {
+        guard Self.isLoopback(url: url) else { return }
+        urlString = url.absoluteString
+        currentURL = url
+        reloadTrigger = UUID()
+    }
+
+    public static func isLoopback(url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        return host == "127.0.0.1" || host == "localhost" || host == "::1"
+    }
+}
+
+private struct PreviewWebView: NSViewRepresentable {
+    let url: URL
+    let reloadTrigger: UUID
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        let request = URLRequest(url: url)
+        webView.load(request)
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        if context.coordinator.lastTrigger != reloadTrigger {
+            context.coordinator.lastTrigger = reloadTrigger
+            if webView.url == url {
+                webView.reload()
+            } else {
+                webView.load(URLRequest(url: url))
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(reloadTrigger: reloadTrigger)
+    }
+
+    final class Coordinator {
+        var lastTrigger: UUID
+
+        init(reloadTrigger: UUID) {
+            self.lastTrigger = reloadTrigger
+        }
     }
 }

--- a/Stunts/broken-duplicate-id/a.md
+++ b/Stunts/broken-duplicate-id/a.md
@@ -1,0 +1,9 @@
+---
+title: Page A
+id: shared
+status: published
+---
+
+# Page A
+
+First page claiming `id: shared`.

--- a/Stunts/broken-duplicate-id/b.md
+++ b/Stunts/broken-duplicate-id/b.md
@@ -1,0 +1,9 @@
+---
+title: Page B
+id: shared
+status: published
+---
+
+# Page B
+
+Second page claiming duplicate `id: shared`. Expect `EDUPLICATEID`.

--- a/Stunts/broken-wikilink/page.md
+++ b/Stunts/broken-wikilink/page.md
@@ -1,0 +1,8 @@
+---
+title: Broken Wikilink
+status: published
+---
+
+# Broken Wikilink
+
+This page contains a link to [[no-such-page]] which does not exist in the graph. Expect `EREFERENCEMISSING`.

--- a/Stunts/cook-one/README.md
+++ b/Stunts/cook-one/README.md
@@ -1,0 +1,11 @@
+# Cooklang Stunt
+
+A single Cooklang recipe (`soup.cook`) to test Cooklang input parsing with Boris.
+
+## Command
+
+```bash
+boris --input Stunts/cook-one --out .boris --format cook
+```
+
+When building with publication profiles, set `input_format: "cook"` in `boris.json`.

--- a/Tests/ContractTests/ContractDecodeTests.swift
+++ b/Tests/ContractTests/ContractDecodeTests.swift
@@ -54,6 +54,26 @@ final class ContractDecodeTests: XCTestCase {
         XCTAssertTrue(report.diagnostics.contains { $0.code == "EPARENTMISSING" })
     }
 
+    func testBrokenDuplicateIDReport() throws {
+        let report = try decode(BuildReport.self, "broken-duplicate-id", "build-report.json")
+        XCTAssertFalse(report.ok)
+        XCTAssertTrue(report.diagnostics.contains { $0.code == "EDUPLICATEID" })
+    }
+
+    func testBrokenWikilinkReport() throws {
+        let report = try decode(BuildReport.self, "broken-wikilink", "build-report.json")
+        XCTAssertFalse(report.ok)
+        XCTAssertTrue(report.diagnostics.contains { $0.code == "EREFERENCEMISSING" })
+    }
+
+    func testHappyCheck() throws {
+        let report = try decode(AnalysisReport.self, "check-happy", "analysis-report.json")
+        XCTAssertEqual(report.format, "boris-analysis-report")
+        XCTAssertEqual(report.summary.pages, 45)
+        XCTAssertEqual(report.summary.roots, 7)
+        XCTAssertTrue(report.findings.contains { $0.code == "WUNREFERENCED" })
+    }
+
     private func decode<T: Decodable>(_ type: T.Type, _ folder: String, _ name: String) throws -> T {
         let url = try fixture(folder, name)
         let data = try Data(contentsOf: url)

--- a/Tests/Fixtures/broken-duplicate-id/build-report.json
+++ b/Tests/Fixtures/broken-duplicate-id/build-report.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.2.0",
+  "ok": false,
+  "contentRoot": "broken-duplicate-id",
+  "outDir": "_ir-broken-duplicate-id",
+  "pageCount": 1,
+  "errorCount": 1,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "EDUPLICATEID",
+      "message": "duplicate page id \"shared\"",
+      "remediation": "Change the id in frontmatter so every page is unique",
+      "sourcePath": "b.md",
+      "line": 3,
+      "column": 1,
+      "id": "shared"
+    }
+  ]
+}

--- a/Tests/Fixtures/broken-wikilink/build-report.json
+++ b/Tests/Fixtures/broken-wikilink/build-report.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.2.0",
+  "ok": false,
+  "contentRoot": "broken-wikilink",
+  "outDir": "_ir-broken-wikilink",
+  "pageCount": 1,
+  "errorCount": 1,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "EREFERENCEMISSING",
+      "message": "referenced page \"no-such-page\" does not exist",
+      "remediation": "Create the referenced page or update the wikilink",
+      "sourcePath": "page.md",
+      "line": 7,
+      "column": 26,
+      "id": "broken-wikilink"
+    }
+  ]
+}

--- a/Tests/Fixtures/check-happy/analysis-report.json
+++ b/Tests/Fixtures/check-happy/analysis-report.json
@@ -1,0 +1,34 @@
+{
+  "format": "boris-analysis-report",
+  "schemaVersion": "0.1.0",
+  "compiler": "boris/0.8.1",
+  "input": "content",
+  "summary": {
+    "pages": 45,
+    "roots": 7,
+    "satellites": 38,
+    "sourceEndpoints": 0,
+    "unreferencedPages": 2,
+    "hotspots": 0
+  },
+  "pages": [
+    {
+      "id": "index",
+      "parent": null
+    },
+    {
+      "id": "start",
+      "parent": "index"
+    }
+  ],
+  "sources": [],
+  "findings": [
+    {
+      "code": "WUNREFERENCED",
+      "type": "page",
+      "value": "start",
+      "count": 1
+    }
+  ],
+  "impact": null
+}

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,0 +1,35 @@
+# Solipsist Help
+
+Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeanelephant/boris), the deterministic Zig graph-native publication compiler.
+
+## Layout & Workflow
+
+Solipsist organizes your workspace into three primary columns:
+
+- **Sources (Left)**: Your publication repositories and content trees, accessed via security-scoped bookmarks. Use **File → Open…** (`⌘O`) to add a content folder.
+- **Play (Middle)**: The publication graph rendered as a structured list of trunks and satellites from `graph.json`. Selection here updates the current noun.
+- **Inspector (Right)**: Contextual metadata for the selection:
+  - **Profile Section**: Direct, 1:1 view over `boris.json` (site URL, title, input format, publication targets). Saving writes the file.
+  - **Page Section**: Entity id, parent, status, tags, relations, and layout slots from `completion.json`.
+  - **Execution Section**: Local performance preferences (`jobs`, `incremental`, `quiet`) persisted in user defaults.
+
+## Verbs & Diagnostics
+
+The **Boris** menu provides coordinator verbs:
+- **Plan**: Lint and declare profile targets (`boris plan --profile`).
+- **Validate**: Artifact-free publication validation with structured report decoding.
+- **Build IR**: Compile intermediate representation artifacts (`manifest.json`, `graph.json`, `completion.json`).
+- **Build HTML**: Compile static HTML distribution.
+- **Check**: Run documentation intelligence and unreferenced page analysis.
+- **Impact**: Analyze ripple effects of changes to the selected page.
+- **Stop**: Interrupt currently running engine subprocess with `SIGTERM`.
+
+Diagnostics, warnings, and errors appear in the **Problems Pane** at the bottom of the Play column and are color-coded by exit code in the status bar.
+
+## Companion Windows
+
+- **Preview** (**View → Preview**, `⌥⌘P`): Companion web view hosting live Boris `watch --serve` previews.
+- **Editor** (**View → Editor**, `⌥⌘E`): Companion web view hosting Boris editor tokens.
+- **About Solipsist** (**Solipsist → About Solipsist**): Displays app version and active Boris engine location.
+
+For architectural decisions and milestone details, see [ROADMAP.md](ROADMAP.md) and [HARNESS.md](HARNESS.md).

--- a/scripts/embed-boris.sh
+++ b/scripts/embed-boris.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Copies the Boris engine binary into the app bundle's Resources so the
 # app can find it at runtime (BorisBinary.locate checks

--- a/scripts/stunt-from-testdata.sh
+++ b/scripts/stunt-from-testdata.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Solipsist — testdata wrapper
+# Generates a realistic test corpus in /tmp if boris-testdata exists.
+# Exits 0 if no testdata binary is present.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TESTDATA="${SOLIPSIST_TESTDATA_BIN:-}"
+
+if [[ -z "$TESTDATA" || ! -x "$TESTDATA" ]]; then
+  for c in \
+    "$ROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris-testdata" \
+    "$ROOT/../boris-agent-kit/bin/boris-testdata" \
+    "$ROOT/../boris/zig-out/bin/boris-testdata" \
+    "$ROOT/../../boris/zig-out/bin/boris-testdata" \
+    "$ROOT/../../../boris/zig-out/bin/boris-testdata"
+  do
+    if [[ -x "$c" ]]; then TESTDATA="$c"; break; fi
+  done
+fi
+
+if [[ -z "${TESTDATA:-}" || ! -x "${TESTDATA:-}" ]]; then
+  echo "stunt-from-testdata: no testdata binary (exit 0)"
+  exit 0
+fi
+
+OUT_DIR="/tmp/solipsist-testdata-$(date +%s)"
+mkdir -p "$OUT_DIR"
+
+"$TESTDATA" generate --recipe readme-realistic-v1 --out "$OUT_DIR" --force
+
+echo "$OUT_DIR"
+exit 0

--- a/scripts/stunt-smoke.sh
+++ b/scripts/stunt-smoke.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Solipsist — Stunt smoke script
+# Runs Boris engine against Stunts and validates expected contracts and exit codes.
+# Exits 0 if no binary is present.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BORIS="${SOLIPSIST_BORIS_BIN:-}"
+
+if [[ -z "$BORIS" || ! -x "$BORIS" ]]; then
+  for c in \
+    "$ROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris" \
+    "$ROOT/../boris-agent-kit/bin/boris" \
+    "$ROOT/../boris/zig-out/bin/boris" \
+    "$ROOT/../../boris/zig-out/bin/boris" \
+    "$ROOT/../../../boris/zig-out/bin/boris"
+  do
+    if [[ -x "$c" ]]; then BORIS="$c"; break; fi
+  done
+fi
+
+if [[ -z "${BORIS:-}" || ! -x "${BORIS:-}" ]]; then
+  echo "stunt-smoke: no boris binary found; skipping smoke tests (exit 0)"
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+STUNTS="$ROOT/Stunts"
+
+echo "==> Running smoke tests with $BORIS"
+
+# 1. Happy IR build
+echo "==> Testing Stunts/happy IR build"
+(cd "$STUNTS/happy" && "$BORIS" --out "$TMP/happy-ir" --input content --quiet)
+if ! grep -q '"ok": true' "$TMP/happy-ir/build-report.json"; then
+  echo "ERROR: expected ok: true in happy build-report.json" >&2
+  exit 1
+fi
+
+# 2. Happy validate
+echo "==> Testing Stunts/happy validate"
+(cd "$STUNTS/happy" && "$BORIS" validate --input content --report "$TMP/validate.json")
+
+# 3. Happy plan
+echo "==> Testing Stunts/happy plan"
+(cd "$STUNTS/happy" && "$BORIS" plan --profile boris.json > "$TMP/plan.json")
+
+# 4. Broken frontmatter
+echo "==> Testing Stunts/broken-frontmatter"
+(cd "$STUNTS" && "$BORIS" --out "$TMP/broken-fm" --input broken-frontmatter --quiet || true)
+if ! grep -q 'EFRONTMATTER' "$TMP/broken-fm/build-report.json"; then
+  echo "ERROR: expected EFRONTMATTER in broken-frontmatter build-report.json" >&2
+  exit 1
+fi
+
+# 5. Broken parent
+echo "==> Testing Stunts/broken-parent"
+(cd "$STUNTS" && "$BORIS" --out "$TMP/broken-parent" --input broken-parent --quiet || true)
+if ! grep -q 'EPARENTMISSING' "$TMP/broken-parent/build-report.json"; then
+  echo "ERROR: expected EPARENTMISSING in broken-parent build-report.json" >&2
+  exit 1
+fi
+
+echo "==> Stunt smoke tests passed!"
+exit 0

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,43 @@
+# Solipsist Project Subdomain (Card P)
+
+This directory contains the source content and operator glue for the public Solipsist project site hosted on Cloudflare Workers + R2 via the official Boris Wasm embed host.
+
+## Architecture
+
+Boris ships an official Cloudflare Worker embed host (`hosts/cloudflare-worker/` in the Boris repository) that consumes `boris-embed-small.wasm` to compile source bundles directly in a Cloudflare Worker isolate on the Workers Free tier.
+
+- **Host role**: `POST /compile` accepts source files, runs `compileBundle` inside the Wasm isolate, and uploads successful builds to R2 (`ARTIFACTS` bucket).
+- **Public serving**: A thin GET handler serves the static HTML artifacts from R2 over the custom subdomain `solipsist.drawmeanelephant.dev`.
+
+## Deploy Instructions
+
+### Prerequisites
+- Node.js 18+
+- Wrangler CLI (`npm install -g wrangler`)
+- Access to Cloudflare account with R2 bucket configured
+
+### 1. Build and Prepare Engine Wasm
+From a read-only checkout of `drawmeanelephant/boris`:
+```bash
+cd /path/to/boris
+zig build -Dtarget=wasm32-freestanding -Doptimize=ReleaseSmall
+cp zig-out/bin/boris-embed-small.wasm hosts/cloudflare-worker/
+```
+
+### 2. Test Locally
+```bash
+cd /path/to/boris/hosts/cloudflare-worker
+node test.mjs
+```
+
+### 3. Deploy Worker
+```bash
+npx wrangler deploy
+```
+
+### 4. Publish Site Content
+Post the `site/content/` files as a bundle to the worker endpoint or sync via Boris profile publishing.
+
+## Boundary Notes
+- Solipsist desktop app does **not** embed Wasm or run Cloudflare deploy adapters inside the macOS client.
+- Subdomain hosting is project infrastructure, not application UI.

--- a/site/boris.json
+++ b/site/boris.json
@@ -1,0 +1,24 @@
+{
+  "format": "boris-publication-profile",
+  "schema_version": 1,
+  "input": "content",
+  "input_format": "markdown",
+  "site": {
+    "title": "Solipsist",
+    "url": "https://solipsist.drawmeanelephant.dev",
+    "description": "A native macOS workstation for Boris, the deterministic Zig publication compiler."
+  },
+  "publication": {
+    "target": "site",
+    "base_url": "https://solipsist.drawmeanelephant.dev",
+    "origin": "https://solipsist.drawmeanelephant.dev",
+    "base_path": "/"
+  },
+  "targets": [
+    {
+      "name": "site",
+      "output": "dist",
+      "public": true
+    }
+  ]
+}

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -1,0 +1,26 @@
+---
+title: Architecture
+parent: index
+status: published
+---
+
+# Architecture
+
+Solipsist is built in Swift 6 with SwiftUI for macOS 14+.
+
+## Spatial Model
+
+```
+┌──────────────────┬─────────────────────────────┬──────────────────┐
+│ SOURCES          │ PLAY                        │ DRAWER           │
+│ Local / GitHub   │ Graph, outputs, activity,   │ Profile, page    │
+│                  │ reports                     │ fields, options  │
+└──────────────────┴─────────────────────────────┴──────────────────┘
+Companion windows: Preview (watch --serve) · Editor (boris-editor)
+```
+
+## Engine Integration
+
+- `BorisEngine` actor manages single-process execution and signal handling (`SIGTERM`).
+- Contract models in `Sources/Models/` decode normative Boris JSON formats.
+- `Coordinator` maps UI verbs to engine invocations, reporting timings and problems in real-time.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -1,0 +1,21 @@
+---
+title: Solipsist
+status: published
+---
+
+# Solipsist
+
+**Radio UserLand’s job in Mail’s body.**
+
+Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeanelephant/boris), the deterministic Zig graph-native publication compiler.
+
+It broadcasts local Boris publications while strictly respecting compiler contracts and macOS platform conventions.
+
+## Key Features
+
+- **Mail-Grade Chrome**: Sources on the left, Graph play list in the middle, Inspector drawer on the right.
+- **Subprocess Isolation**: Boris runs as an isolated subprocess; compiler semantics are never reimplemented.
+- **Companion Windows**: Live preview powered by `watch --serve` and editing hosted in `boris-editor`.
+- **First-Class Verbs**: Plan, Validate, Build, Check, Impact, and Stop available directly from the menu.
+
+Read more in our [[mission]] and [[architecture]] documents.

--- a/site/content/mission.md
+++ b/site/content/mission.md
@@ -1,0 +1,16 @@
+---
+title: Mission
+parent: index
+status: published
+---
+
+# Mission
+
+Solipsist is built to provide an uncompromising, native desktop harness for authoring, inspecting, coordinating, and broadcasting Boris-powered publications.
+
+## Principles
+
+1. **Never touch the compiler**: Boris remains a separate, deterministic compiler binary written in Zig.
+2. **Decode versioned JSON contracts**: Every visual element derives from typed IR contracts (`manifest.json`, `graph.json`, `completion.json`, `build-report.json`).
+3. **No third settings store**: The publication profile (`boris.json`) is the single source of truth for build configuration.
+4. **Subprocess isolation**: Compiles and validation runs execute as supervised subprocesses with strict cancellation semantics.


### PR DESCRIPTION
## Card
Multiple parallel / queue cards: Q1, Q2, Q3, Q4, Q6, Q7, Q8, Q9, Q10, Q11, Q12, Q13, Q14, Q15 (P-subdomain), Q16, Q17, Q18.

## What
- CI/CD & GitHub Protection: Dependabot (.github/dependabot.yml), Issue Templates (.github/ISSUE_TEMPLATE/), SwiftFormat & SwiftLint configs with make lint and CI lint job
- Stunts & Testing Infrastructure: stunt-smoke.sh, stunt-from-testdata.sh, broken-duplicate-id and broken-wikilink stunt corpora, check-happy analysis report fixture, 11 passing contract decode tests
- App Chrome: status bar semantic exit code colors, About Solipsist window, Solipsist Help guide and menu commands
- Companion Shells: Preview companion with loopback validation, Editor companion with EditorURL token parser
- Project Subdomain (Card P): site/ content, profile, and deployment documentation for Cloudflare Workers + Wasm + R2

## Gate
- [x] `make spike` & `make build` pass locally
- [x] `make test` passes (11 tests, 0 failures)
- [x] `make lint` passes
- [x] Did not touch `boris/` or commit `SUPPORT-NOT-FOR-GITHUB/`