### PR TITLE
docs: record filed boris issues A1/A14/A7 (#644-#646)

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -9,7 +9,13 @@ PR against boris from this repo.
 - A4 [boris#639](https://github.com/drawmeanelephant/boris/issues/639) → [#642](https://github.com/drawmeanelephant/boris/pull/642)
 - A13 [boris#640](https://github.com/drawmeanelephant/boris/issues/640) → [#641](https://github.com/drawmeanelephant/boris/pull/641)
 
-**File next:** [A1](boris-A1-watch-events.md) → [A14](boris-A14-editor-launch-contract.md) → [A7](boris-A7-workspace-rule.md). Then [A5](boris-A5-check-watch-rfc.md) as a discussion.
+**Filed (2026-08-17):**
+
+- A1 [boris#644](https://github.com/drawmeanelephant/boris/issues/644)
+- A14 [boris#645](https://github.com/drawmeanelephant/boris/issues/645)
+- A7 [boris#646](https://github.com/drawmeanelephant/boris/issues/646)
+
+**File next:** [A5](boris-A5-check-watch-rfc.md) as a discussion.
 
 Do not ask: unifying `compiler` field names, library mode, relaxing
 editor token/CSP, shipping `boris-editor` in the agent-pack.

--- a/docs/issues/boris-A1-watch-events.md
+++ b/docs/issues/boris-A1-watch-events.md
@@ -1,6 +1,6 @@
 # A1 — `--watch-json`: structured NDJSON event stream for watch mode
 
-> **Ready-to-paste GitHub issue for the boris repo.**
+> **Filed:** [boris#644](https://github.com/drawmeanelephant/boris/issues/644).
 > Priority: P0 (flagship). Size: M. Additive, opt-in — no behavior change without the flag.
 > **Rebaselined against afterparty v0.8.1.** Afterparty added `watch --serve`
 > (an SSE `reload` channel for *browsers*) and `--timings` (one-shot machine

--- a/docs/issues/boris-A14-editor-launch-contract.md
+++ b/docs/issues/boris-A14-editor-launch-contract.md
@@ -1,6 +1,6 @@
 # A14 — Pin the `boris-editor` subprocess launch contract
 
-> **Ready-to-paste GitHub issue for the boris repo.**
+> **Filed:** [boris#645](https://github.com/drawmeanelephant/boris/issues/645).
 > Priority: P1. Size: S. Mostly docs + a test pin; one small behavior add
 > (SIGTERM/SIGINT) matching watch.
 > **Fact-checked against afterparty `editor/src/{main,server}.zig`.** The

--- a/docs/issues/boris-A7-workspace-rule.md
+++ b/docs/issues/boris-A7-workspace-rule.md
@@ -1,6 +1,6 @@
 # A7 — Document the workspace-containment rule (uniform now) + the IR absolute-path rule
 
-> **Ready-to-paste GitHub issue for the boris repo.**
+> **Filed:** [boris#646](https://github.com/drawmeanelephant/boris/issues/646).
 > Priority: P1. Size: XS. Documentation + one clarifying question.
 > **Rebaselined against afterparty v0.8.1.** The asymmetry that motivated
 > this issue is **resolved**: all output trees are now cwd-contained


### PR DESCRIPTION
Filed the three consumer-access drafts on `drawmeanelephant/boris`:

- A1 watch-json → boris#644
- A14 editor-launch-contract → boris#645
- A7 workspace-rule → boris#646

This PR records those numbers in the drafts and moves A5 to the remaining discussion.