### PR TITLE
build(ci): add dependabot for weekly GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Closes #15.

## Card
docs/cards/parallel/dependabot.md

## What
Add `.github/dependabot.yml` configured for weekly `github-actions` updates with grouped patch/minor updates.

## Gate
- [x] Valid YAML syntax
- [x] Diff is only under `.github/dependabot.yml`