### PR TITLE
docs(github): add bug report and boris relay issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/boris_relay.yml
+++ b/.github/ISSUE_TEMPLATE/boris_relay.yml
@@ -1,0 +1,51 @@
+name: Boris Compiler Defect (Relay)
+description: Report an engine/compiler issue to relay to drawmeanelephant/boris
+title: "boris: "
+labels: ["boris-relay"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note:** Solipsist never patches Boris directly. Compiler defects are drafted in `docs/issues/` and relayed upstream to `drawmeanelephant/boris`.
+  - type: input
+    id: boris_version
+    attributes:
+      label: Boris Version
+      description: Exact engine version (e.g. `boris/0.8.1 (b82e9e2)`)
+    validations:
+      required: true
+  - type: input
+    id: command_line
+    attributes:
+      label: Command Line
+      description: Exact command line executed (e.g. `boris build --input content --out .boris`)
+    validations:
+      required: true
+  - type: input
+    id: cwd
+    attributes:
+      label: Working Directory (cwd)
+      description: Where was the command executed relative to the content tree?
+    validations:
+      required: true
+  - type: input
+    id: exit_code
+    attributes:
+      label: Exit Code
+      placeholder: e.g. 1, 2, 134
+    validations:
+      required: true
+  - type: textarea
+    id: stderr_quote
+    attributes:
+      label: Exact Stderr / Diagnostics
+      description: Verbatim quote of the error or diagnostic output
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: draft_filename
+    attributes:
+      label: Draft Filename in docs/issues/
+      description: e.g. `docs/issues/boris-A15-example.md`
+      placeholder: docs/issues/boris-A...

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a defect in the Solipsist macOS application
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report! Solipsist is the native macOS harness for Boris.
+  - type: input
+    id: macos_version
+    attributes:
+      label: macOS Version
+      description: e.g. macOS Sonoma 14.5, Sequoia 15.0
+      placeholder: macOS 14.5
+    validations:
+      required: true
+  - type: input
+    id: boris_version
+    attributes:
+      label: Boris Engine Version
+      description: Output of `boris --version` or status bar identity
+      placeholder: boris/0.8.1
+    validations:
+      required: true
+  - type: input
+    id: opened_target
+    attributes:
+      label: Content Opened
+      description: What folder or project did you open? (e.g. Stunts/happy, custom corpus)
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include any exit code or status bar message.
+    validations:
+      required: true
+  - type: input
+    id: exit_code
+    attributes:
+      label: Exit Code (if any)
+      placeholder: e.g. 0, 1, 2

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Boris Engine Upstream Issues
+    url: https://github.com/drawmeanelephant/boris/issues
+    about: Direct issues for the Boris Zig publication compiler
+  - name: Architecture & Harness Documentation
+    url: https://github.com/drawmeanelephant/solipsist/tree/main/docs
+    about: Read HARNESS.md, ROADMAP.md, and ENGINE-CONTRACTS.md


### PR DESCRIPTION
Closes #14.

## Card
docs/cards/parallel/issue-templates.md

## What
- Add `.github/ISSUE_TEMPLATE/bug_report.yml` for macOS application bugs.
- Add `.github/ISSUE_TEMPLATE/boris_relay.yml` for Boris compiler defect relays.
- Add `.github/ISSUE_TEMPLATE/config.yml` disabling blank issues.

## Gate
- [x] Valid YAML syntax
- [x] Diff only under `.github/ISSUE_TEMPLATE/`