### PR TITLE
pr-cop: PR status + drift watcher script (#19)

### DIFF
--- a/.github/workflows/pr-cop.yml
+++ b/.github/workflows/pr-cop.yml
@@ -1,0 +1,30 @@
+name: pr-cop
+
+on:
+  schedule:
+    # Every 6 hours, offset from the top of the hour.
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run pr-cop
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          out="$RUNNER_TEMP/pr-cop.txt"
+          bash scripts/pr-cop.sh > "$out"
+          cat "$out"
+      - name: Post summary to tracking issue
+        if: vars.PR_COP_ISSUE != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_COP_ISSUE: ${{ vars.PR_COP_ISSUE }}
+        run: |
+          gh issue comment "$PR_COP_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/pr-cop.txt"

--- a/scripts/pr-cop.sh
+++ b/scripts/pr-cop.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# pr-cop.sh — read-only PR status + drift report for a GitHub repo.
+#
+# Prints every open PR against REPO with:
+#   • CI status rollup  (passing / failing / pending / none)
+#   • mergeable state   (MERGEABLE / CONFLICTING / UNKNOWN)
+#   • draft flag
+#   • drift flag        (head branch is behind BASE_BRANCH on the remote)
+#
+# Uses the `gh` CLI only; every call is a read. This script never merges,
+# pushes, force-pushes, or mutates any state.
+#
+# Usage:  scripts/pr-cop.sh [REPO]
+#   REPO                 owner/repo to watch (default: drawmeanelephant/solipsist)
+#
+# Env:
+#   PR_COP_BASE_BRANCH   base branch for the drift comparison (default: main)
+#   PR_COP_TSV_FILE      read per-PR rows from FILE (same TSV columns the
+#                        script generates from `gh pr list`) instead of the
+#                        live repo. Testing aid only — drift still queries
+#                        the live compare API per PR.
+
+set -euo pipefail
+
+REPO="${1:-drawmeanelephant/solipsist}"
+BASE_BRANCH="${PR_COP_BASE_BRANCH:-main}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# --- Collect one TSV row per open PR -------------------------------------
+# Columns: number, headRefName, title, baseRefName, isDraft, mergeable, checkStates
+if [[ -n "${PR_COP_TSV_FILE:-}" ]]; then
+  rows_file="$PR_COP_TSV_FILE"
+else
+  rows_file="$tmp/prs.tsv"
+  if ! gh pr list --repo "$REPO" --state open --json \
+      number,title,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup \
+      --jq '.[] | [.number, .headRefName, (.title | gsub("[\r\n\t]";" ")), .baseRefName, (.isDraft|tostring), (.mergeable // "UNKNOWN"), ([.statusCheckRollup[]? | (.conclusion // .state)] | join(","))] | @tsv' \
+      > "$rows_file"; then
+    echo "pr-cop: gh pr list failed for $REPO" >&2
+    exit 1
+  fi
+fi
+
+rows=()
+while IFS= read -r row; do
+  rows+=("$row")
+done < "$rows_file"
+
+echo "pr-cop: open PRs against $REPO (base: $BASE_BRANCH)"
+if (( ${#rows[@]} == 0 )); then
+  echo "  No open PRs."
+  exit 0
+fi
+
+# Worst-case status of a comma-separated check-state list.
+ci_status() {
+  local cs="$1"
+  [[ -z "$cs" ]] && { echo "none"; return; }
+  if [[ "$cs" =~ FAILURE|ERROR|CANCELLED|TIMED_OUT|ACTION_REQUIRED|STARTUP_FAILURE ]]; then
+    echo "failing"; return
+  fi
+  if [[ "$cs" =~ PENDING|IN_PROGRESS|QUEUED|EXPECTED|WAITING|REQUESTED ]]; then
+    echo "pending"; return
+  fi
+  echo "passing"
+}
+
+printf '%-6s %-7s %-8s %-11s %-11s %s\n' "#PR" "state" "ci" "mergeable" "drift" "title"
+
+failing=0
+drifting=0
+for row in "${rows[@]}"; do
+  IFS=$'\t' read -r num head title base draft mergeable checks <<< "$row" || true
+
+  ci="$(ci_status "${checks:-}")"
+
+  behind="$(gh api "repos/$REPO/compare/$BASE_BRANCH...$head" --jq '.behind_by' 2>/dev/null || echo unknown)"
+  if [[ "$behind" =~ ^[0-9]+$ ]]; then
+    if (( behind > 0 )); then
+      drift="behind $behind"
+      drifting=$((drifting + 1))
+    else
+      drift="clean"
+    fi
+  else
+    drift="unknown"
+  fi
+
+  [[ "$ci" == "failing" ]] && failing=$((failing + 1))
+
+  state="open"
+  [[ "$draft" == "true" ]] && state="draft"
+
+  printf '%-6s %-7s %-8s %-11s %-11s %s\n' \
+    "#$num" "$state" "$ci" "$mergeable" "$drift" "$title"
+done
+
+echo
+echo "Summary: ${#rows[@]} open PR(s) — $failing failing CI, $drifting drifted from $BASE_BRANCH."


### PR DESCRIPTION
Closes #19

Read-only PR babysitter: `scripts/pr-cop.sh` lists every open PR against `drawmeanelephant/solipsist` with its CI status rollup (passing / failing / pending / none), mergeable state, draft flag, and a **drift flag** when the head branch is behind `origin/main` (via the compare API's `behind_by`).

- `gh`-only, zero extra runtime deps; every call is a GET — the script never merges, pushes, or force-pushes.
- Bash 3.2-compatible (stock macOS `/bin/bash`), `set -euo pipefail`.
- Optional `.github/workflows/pr-cop.yml`: scheduled every 6h + manual dispatch; posts the summary as an issue comment when a `PR_COP_ISSUE` repo variable is set (log-only otherwise, needs `issues: write`). `ci.yml` untouched.
- Testing aid: `PR_COP_TSV_FILE` env lets you feed per-PR rows while drift still queries the live compare API.

**Gate (run locally):**

```
$ scripts/pr-cop.sh
pr-cop: open PRs against drawmeanelephant/solipsist (base: main)
#PR    state   ci       mergeable   drift       title
#23    open    passing  MERGEABLE   behind 3    feat(editor): WKWebView shell with BORIS_EDITOR_URL parser

Summary: 1 open PR(s) — 0 failing CI, 1 drifted from main.
```

Also exercised failing / pending / none CI, CONFLICTING / UNKNOWN mergeable, draft state, and clean / behind N / unknown drift against live remote refs. Only new files: `scripts/pr-cop.sh`, `.github/workflows/pr-cop.yml`. No Play/Inspector/Engine/Models/Spike/MainWindow.swift/InspectorDrawer.swift/Workspace or boris touches.
