### PR TITLE
docs(site): add site content and plain publication profile

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,12 @@
+# Solipsist Project Site Content
+
+This directory contains the content and plain publication profile for the public Solipsist documentation and project site.
+
+## Profile & Content
+
+- `boris.json`: Plain static-site profile (schema version 1, target `site`, output `dist`, input `content`).
+- `content/`: Closed-frontmatter Markdown pages (`index.md`, `mission.md`, `architecture.md`).
+
+## Operator Deployment
+
+Solipsist does not build publication targets or embed cloud adapters into the desktop application binary. Publication to the project subdomain (`solipsist.drawmeanelephant.dev`) is operated via the Boris Cloudflare Worker embed host (`hosts/cloudflare-worker/` in the Boris repository) consuming `boris-embed-small.wasm`.

--- a/site/boris.json
+++ b/site/boris.json
@@ -1,0 +1,24 @@
+{
+  "format": "boris-publication-profile",
+  "schema_version": 1,
+  "input": "content",
+  "input_format": "markdown",
+  "site": {
+    "title": "Solipsist",
+    "url": "https://solipsist.drawmeanelephant.dev",
+    "description": "A native macOS harness for Boris, the deterministic Zig publication compiler."
+  },
+  "publication": {
+    "target": "site",
+    "base_url": "https://solipsist.drawmeanelephant.dev",
+    "origin": "https://solipsist.drawmeanelephant.dev",
+    "base_path": "/"
+  },
+  "targets": [
+    {
+      "name": "site",
+      "output": "dist",
+      "public": true
+    }
+  ]
+}

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -1,0 +1,26 @@
+---
+title: Architecture
+parent: index
+status: published
+---
+
+# Architecture
+
+Solipsist is built in Swift 6 with SwiftUI for macOS 14+.
+
+## Spatial Model
+
+```
+┌──────────────────┬─────────────────────────────┬──────────────────┐
+│ SOURCES          │ PLAY                        │ DRAWER           │
+│ Local / GitHub   │ Graph, outputs, activity,   │ Profile, page    │
+│                  │ reports                     │ fields, options  │
+└──────────────────┴─────────────────────────────┴──────────────────┘
+Companion windows: Preview (watch --serve) · Editor (boris-editor)
+```
+
+## Engine Integration
+
+- `BorisEngine` actor manages single-process execution and signal handling (`SIGTERM`).
+- Contract models decode normative Boris JSON formats.
+- `Coordinator` maps UI verbs to engine invocations, reporting timings and problems in real-time.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -1,0 +1,21 @@
+---
+title: Solipsist
+status: published
+---
+
+# Solipsist
+
+**Radio UserLand’s job in Mail’s body.**
+
+Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeanelephant/boris), the deterministic Zig graph-native publication compiler.
+
+It broadcasts local Boris publications while strictly respecting compiler contracts and macOS platform conventions.
+
+## Key Features
+
+- **Mail-Grade Chrome**: Sources on the left, Graph play list in the middle, Inspector drawer on the right.
+- **Subprocess Isolation**: Boris runs as an isolated subprocess; compiler semantics are never reimplemented.
+- **Companion Windows**: Live preview powered by `watch --serve` and editing hosted in `boris-editor`.
+- **First-Class Verbs**: Plan, Validate, Build, Check, Impact, and Stop available directly from the menu.
+
+Read more in our [[mission]] and [[architecture]] documents.

--- a/site/content/mission.md
+++ b/site/content/mission.md
@@ -1,0 +1,16 @@
+---
+title: Mission
+parent: index
+status: published
+---
+
+# Mission
+
+Solipsist is built to provide an uncompromising, native desktop harness for authoring, inspecting, coordinating, and broadcasting Boris-powered publications.
+
+## Principles
+
+1. **Never touch the compiler**: Boris remains a separate, deterministic compiler binary written in Zig.
+2. **Decode versioned JSON contracts**: Every visual element derives from typed IR contracts (`manifest.json`, `graph.json`, `completion.json`, `build-report.json`).
+3. **No third settings store**: The publication profile (`boris.json`) is the single source of truth for build configuration.
+4. **Subprocess isolation**: Compiles and validation runs execute as supervised subprocesses with strict cancellation semantics.


### PR DESCRIPTION
Closes #16.

## Card
docs/cards/P-subdomain.md

## What
- Add `site/boris.json` with plain static-site profile (schema v1, target `site`, output `dist`, input `content`).
- Add `site/content/` markdown documents (`index.md`, `mission.md`, `architecture.md`).
- Add `site/README.md` documenting site layout and operator deployment.

## Gate
- [x] Plain static-site profile; no cloudflare publication target or in-app Wasm wiring
- [x] Diff is strictly under `site/`