### PR TITLE
docs(help): in-app Solipsist Help window and bundled guide

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -36,6 +36,8 @@ targets:
       - path: Sources/Models
       - path: Sources/Engine
       - path: Solipsist/Assets.xcassets
+      - path: docs/help.md
+        buildPhase: resources
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.drawmeanelephant.solipsist

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -86,6 +86,13 @@ struct SolipsistCommands: Commands {
             }
             .keyboardShortcut("e", modifiers: [.command, .shift])
         }
+
+        CommandGroup(replacing: .help) {
+            Button("Solipsist Help") {
+                openWindow(id: "help")
+            }
+            .keyboardShortcut("?", modifiers: .command)
+        }
     }
 
     private var hasSource: Bool { store.selectedSource != nil }

--- a/Sources/App/HelpWindow.swift
+++ b/Sources/App/HelpWindow.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// In-app Help viewer rendering the bundled documentation guide.
+struct HelpWindow: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(.init(helpContent))
+                    .textSelection(.enabled)
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(minWidth: 520, minHeight: 440)
+        .navigationTitle("Solipsist Help")
+    }
+
+    private var helpContent: String {
+        if let url = Bundle.main.url(forResource: "help", withExtension: "md"),
+           let content = try? String(contentsOf: url, encoding: .utf8) {
+            return content
+        }
+        return """
+        # Solipsist Help
+
+        Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeanelephant/boris), the deterministic Zig graph-native publication compiler.
+
+        ## Spatial Layout
+
+        Solipsist organizes its workspace into a three-column spatial model:
+
+        - **Sources (Left)**: Switch between opened Boris publication folders (`File -> Open...` or `⌘O`) and dogfood test corpora under `Stunts/`.
+        - **Play (Center)**: Displays publication pages, node graph relationships, and generated artifacts derived from compiler contracts.
+        - **Inspector Drawer (Right)**: Inspect publication configuration (`boris.json`), page frontmatter completion index (`completion.json`), and execution options.
+
+        ## Coordinator Verbs
+
+        Execute compiler tasks directly from the menu:
+
+        - **Plan**: Run Boris plan step to preview output targets.
+        - **Validate**: Validate publication structure and HTML output.
+        - **Build**: Compile documents into deterministic IR graph and HTML distribution.
+        - **Check**: Run static documentation intelligence and reference checks.
+        - **Impact**: Analyze ripple effects of node changes across the graph.
+        - **Stop (`⌘.`)**: Terminate any currently running compiler subprocess.
+
+        ## Companion Windows
+
+        - **Preview Companion (`⌥⌘P`)**: Live preview powered by `watch --serve` with loopback URL validation.
+        - **Editor Companion (`⌥⌘E`)**: Token-isolated companion host for `boris-editor`.
+
+        For architecture and roadmap details, see [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).
+        """
+    }
+}

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -34,5 +34,11 @@ struct SolipsistApp: App {
                 .environment(runtime)
         }
         .defaultSize(width: 720, height: 560)
+
+        Window("Solipsist Help", id: "help") {
+            HelpWindow()
+        }
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 560, height: 480)
     }
 }

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,0 +1,29 @@
+# Solipsist Help
+
+Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeanelephant/boris), the deterministic Zig graph-native publication compiler.
+
+## Spatial Layout
+
+Solipsist organizes its workspace into a three-column spatial model:
+
+- **Sources (Left)**: Switch between opened Boris publication folders (`File -> Open...` or `⌘O`) and dogfood test corpora under `Stunts/`.
+- **Play (Center)**: Displays publication pages, node graph relationships, and generated artifacts derived from compiler contracts.
+- **Inspector Drawer (Right)**: Inspect publication configuration (`boris.json`), page frontmatter completion index (`completion.json`), and execution options.
+
+## Coordinator Verbs
+
+Execute compiler tasks directly from the menu:
+
+- **Plan**: Run Boris plan step to preview output targets.
+- **Validate**: Validate publication structure and HTML output.
+- **Build**: Compile documents into deterministic IR graph and HTML distribution.
+- **Check**: Run static documentation intelligence and reference checks.
+- **Impact**: Analyze ripple effects of node changes across the graph.
+- **Stop (`⌘.`)**: Terminate any currently running compiler subprocess.
+
+## Companion Windows
+
+- **Preview Companion (`⌥⌘P`)**: Live preview powered by `watch --serve` with loopback URL validation.
+- **Editor Companion (`⌥⌘E`)**: Token-isolated companion host for `boris-editor`.
+
+For architecture and roadmap details, see [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).


### PR DESCRIPTION
Closes #17.

## Card
docs/cards/parallel/help-sheet.md

## What
- Add `docs/help.md` explaining the three-column spatial layout, coordinator verbs, and companion windows.
- Add `Sources/App/HelpWindow.swift` displaying markdown in-window.
- Add `Solipsist Help` (`⌘?`) command under Help menu in `Sources/App/Commands.swift`.
- Register `Window("Solipsist Help", id: "help")` in `Sources/App/SolipsistApp.swift`.
- Bundle `docs/help.md` via resources entry in `Project.yml`.

## Gate
- [x] `SKIP_EMBED_BORIS=1 make build` passes
- [x] No Play / Inspector / Engine diffs