### PR TITLE
fix(pr-cop): retry transient GitHub API failures

### DIFF
--- a/scripts/pr-cop.sh
+++ b/scripts/pr-cop.sh
@@ -16,6 +16,9 @@
 #
 # Env:
 #   PR_COP_BASE_BRANCH   base branch for the drift comparison (default: main)
+#   PR_COP_RETRIES       attempts for the open-PR list query before giving
+#                        up (default: 5, ~15s apart; transient GitHub API
+#                        503s are retried)
 #   PR_COP_TSV_FILE      read per-PR rows from FILE (same TSV columns the
 #                        script generates from `gh pr list`) instead of the
 #                        live repo. Testing aid only — drift still queries
@@ -31,17 +34,30 @@ trap 'rm -rf "$tmp"' EXIT
 
 # --- Collect one TSV row per open PR -------------------------------------
 # Columns: number, headRefName, title, baseRefName, isDraft, mergeable, checkStates
+# The list query can hit transient GitHub API failures (503s); retry a few
+# times before giving up so the watcher survives blips.
+collect_rows() {
+  local file="$1" attempts="${PR_COP_RETRIES:-5}" attempt=0
+  while (( attempt < attempts )); do
+    if gh pr list --repo "$REPO" --state open --json \
+        number,title,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup \
+        --jq '.[] | [.number, .headRefName, (.title | gsub("[\r\n\t]";" ")), .baseRefName, (.isDraft|tostring), (.mergeable // "UNKNOWN"), ([.statusCheckRollup[]? | (.conclusion // .state)] | join(","))] | @tsv' \
+        > "$file"; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    echo "pr-cop: gh pr list attempt $attempt/$attempts failed — retrying in 15s" >&2
+    sleep 15
+  done
+  echo "pr-cop: gh pr list failed for $REPO after $attempts attempts" >&2
+  return 1
+}
+
 if [[ -n "${PR_COP_TSV_FILE:-}" ]]; then
   rows_file="$PR_COP_TSV_FILE"
 else
   rows_file="$tmp/prs.tsv"
-  if ! gh pr list --repo "$REPO" --state open --json \
-      number,title,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup \
-      --jq '.[] | [.number, .headRefName, (.title | gsub("[\r\n\t]";" ")), .baseRefName, (.isDraft|tostring), (.mergeable // "UNKNOWN"), ([.statusCheckRollup[]? | (.conclusion // .state)] | join(","))] | @tsv' \
-      > "$rows_file"; then
-    echo "pr-cop: gh pr list failed for $REPO" >&2
-    exit 1
-  fi
+  collect_rows "$rows_file" || exit 1
 fi
 
 rows=()


### PR DESCRIPTION
Hardening found while verifying the scheduled watcher end-to-end.

**Retry on transient API failures** — the first `workflow_dispatch` run failed on a single GraphQL 503 (GitHub availability incident, Aug 17 ~13:40–16:59 UTC, error rates elevated) and `gh pr list` hard-failed the whole watcher:

```
HTTP 503: No server is currently available to service your request.
pr-cop: gh pr list failed for drawmeanelephant/solipsist
```

`scripts/pr-cop.sh` now retries the open-PR list query up to `PR_COP_RETRIES` (default 5) times, ~15s apart, before exiting non-zero. Drift checks already degrade to `unknown` on API errors.

**Concurrency guard** — `.github/workflows/pr-cop.yml` now cancels overlapping runs (same pattern as `ci.yml`), so a scheduled run and a manual dispatch can't both post to the radar issue.

Verified: syntax; fixture matrix (failing/pending/passing/none CI, drifted/clean/unknown, draft); fast-fail path with `PR_COP_RETRIES=1`; and a full end-to-end dispatch that posted a live summary to issue #30.
