### PR TITLE
docs: record filed boris RFC A5 (boris#647)

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -14,8 +14,9 @@ PR against boris from this repo.
 - A1 [boris#644](https://github.com/drawmeanelephant/boris/issues/644)
 - A14 [boris#645](https://github.com/drawmeanelephant/boris/issues/645)
 - A7 [boris#646](https://github.com/drawmeanelephant/boris/issues/646)
+- A5 [boris#647](https://github.com/drawmeanelephant/boris/issues/647) — RFC, filed as an issue (Discussions disabled on the repo)
 
-**File next:** [A5](boris-A5-check-watch-rfc.md) as a discussion.
+**File next:** none.
 
 Do not ask: unifying `compiler` field names, library mode, relaxing
 editor token/CSP, shipping `boris-editor` in the agent-pack.

--- a/docs/issues/boris-A5-check-watch-rfc.md
+++ b/docs/issues/boris-A5-check-watch-rfc.md
@@ -1,6 +1,6 @@
 # A5 — RFC: `boris validate --watch` — live, artifact-free validation as a daemon
 
-> **Design discussion for the boris repo.** Companion to A1
+> **Filed:** [boris#647](https://github.com/drawmeanelephant/boris/issues/647) — as an issue (Discussions disabled on the repo). Companion to A1
 > ([boris-A1-watch-events.md](boris-A1-watch-events.md)) — this mode consumes
 > A1's event protocol. Not a contract change; an RFC to decide whether boris
 > wants a validate-only watch mode at all.


### PR DESCRIPTION
A5 (boris validate --watch RFC) is filed as boris#647 — as an issue because GitHub Discussions are disabled on drawmeanelephant/boris. This PR records the number and clears the file-next queue.