### PR TITLE
fix(hygiene): correct Help shortcuts, mark queue cards done, ignore .tools symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ fastlane/test_output
 
 # Generated / local
 *.xcodeproj
-.tools/
+.tools
 build/
 Resources/boris
 .boris/

--- a/Sources/App/HelpWindow.swift
+++ b/Sources/App/HelpWindow.swift
@@ -20,36 +20,13 @@ struct HelpWindow: View {
            let content = try? String(contentsOf: url, encoding: .utf8) {
             return content
         }
+        // Single source of truth is docs/help.md (bundled as a resource).
+        // Keep this fallback to a stub so shortcuts/content never drift here.
         return """
         # Solipsist Help
 
-        Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeanelephant/boris), the deterministic Zig graph-native publication compiler.
-
-        ## Spatial Layout
-
-        Solipsist organizes its workspace into a three-column spatial model:
-
-        - **Sources (Left)**: Switch between opened Boris publication folders (`File -> Open...` or `⌘O`) and dogfood test corpora under `Stunts/`.
-        - **Play (Center)**: Displays publication pages, node graph relationships, and generated artifacts derived from compiler contracts.
-        - **Inspector Drawer (Right)**: Inspect publication configuration (`boris.json`), page frontmatter completion index (`completion.json`), and execution options.
-
-        ## Coordinator Verbs
-
-        Execute compiler tasks directly from the menu:
-
-        - **Plan**: Run Boris plan step to preview output targets.
-        - **Validate**: Validate publication structure and HTML output.
-        - **Build**: Compile documents into deterministic IR graph and HTML distribution.
-        - **Check**: Run static documentation intelligence and reference checks.
-        - **Impact**: Analyze ripple effects of node changes across the graph.
-        - **Stop (`⌘.`)**: Terminate any currently running compiler subprocess.
-
-        ## Companion Windows
-
-        - **Preview Companion (`⌥⌘P`)**: Live preview powered by `watch --serve` with loopback URL validation.
-        - **Editor Companion (`⌥⌘E`)**: Token-isolated companion host for `boris-editor`.
-
-        For architecture and roadmap details, see [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).
+        The bundled help guide is missing from this build.
+        See `docs/help.md` in the repository for the full guide.
         """
     }
 }

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -17,27 +17,29 @@ misbehaves, draft `docs/issues/boris-A<N>-*.md` — do not patch boris.
 
 ## Queue
 
-| ID | Card | Owns |
-|----|------|------|
-| Q0 | [file-boris-issues](file-boris-issues.md) | `docs/issues/` headers |
-| Q1 | [stunt-smoke-script](stunt-smoke-script.md) | `scripts/stunt-smoke.sh` |
-| Q2 | [preview-shell](../parallel/preview-shell.md) | `Companions/Preview/` |
-| Q3 | [editor-shell](../parallel/editor-shell.md) | `Companions/Editor/` |
-| Q4 | [lint](../parallel/lint.md) | lint configs + CI job |
-| Q5 | [assets](../parallel/assets.md) | asset catalog |
-| Q6 | [help-sheet](../parallel/help-sheet.md) | `docs/help.md` |
-| Q7 | [dependabot](../parallel/dependabot.md) | `.github/dependabot.yml` |
-| Q8 | [issue-templates](../parallel/issue-templates.md) | `.github/ISSUE_TEMPLATE/` |
-| Q9 | [stunt-duplicate-id](stunt-duplicate-id.md) | `Stunts/broken-duplicate-id/` |
-| Q10 | [stunt-wikilink](stunt-wikilink.md) | `Stunts/broken-wikilink/` |
-| Q11 | [cook-stunt-ir](cook-stunt-ir.md) | `Stunts/cook-one/` + fixture |
-| Q12 | [fixture-check-report](fixture-check-report.md) | `Tests/Fixtures/check-happy/` |
-| Q13 | [about-window](about-window.md) | `Sources/App/AboutWindow.swift` only |
-| Q14 | [statusbar-exit-color](statusbar-exit-color.md) | note only if Coordinator already owns it — **skip if M4-coordinate unmerged** |
-| Q15 | [p-subdomain](../P-subdomain.md) | `site/` |
-| Q16 | [testdata-wrapper](testdata-wrapper.md) | `scripts/stunt-from-testdata.sh` |
-| Q17 | [gitignore-stunts](gitignore-stunts.md) | `.gitignore` only extra lines |
-| Q18 | [readme-stunts](readme-stunts.md) | `README.md` one paragraph |
-| Q19 | [pr-cop](pr-cop.md) | no source |
+Status legend: **open** · **in flight** (PR open) · **done** (merged — do not pick).
 
-Pick the lowest unused ID. Stay in that card’s paths.
+| ID | Card | Owns | Status |
+|----|------|------|--------|
+| Q0 | [file-boris-issues](file-boris-issues.md) | `docs/issues/` headers | rolling (A1/A14/A7 filed; A5 via #32) |
+| Q1 | [stunt-smoke-script](stunt-smoke-script.md) | `scripts/stunt-smoke.sh` | done (#26) |
+| Q2 | [preview-shell](../parallel/preview-shell.md) | `Companions/Preview/` | done (#9) |
+| Q3 | [editor-shell](../parallel/editor-shell.md) | `Companions/Editor/` | done (#23) |
+| Q4 | [lint](../parallel/lint.md) | lint configs + CI job | in flight — PR #24 |
+| Q5 | [assets](../parallel/assets.md) | asset catalog | done (#27) |
+| Q6 | [help-sheet](../parallel/help-sheet.md) | `docs/help.md` | done (#29) |
+| Q7 | [dependabot](../parallel/dependabot.md) | `.github/dependabot.yml` | done (#21) |
+| Q8 | [issue-templates](../parallel/issue-templates.md) | `.github/ISSUE_TEMPLATE/` | done (#22) |
+| Q9 | [stunt-duplicate-id](stunt-duplicate-id.md) | `Stunts/broken-duplicate-id/` | done (#26) |
+| Q10 | [stunt-wikilink](stunt-wikilink.md) | `Stunts/broken-wikilink/` | done (#26) |
+| Q11 | [cook-stunt-ir](cook-stunt-ir.md) | `Stunts/cook-one/` + fixture | done (#26) |
+| Q12 | [fixture-check-report](fixture-check-report.md) | `Tests/Fixtures/check-happy/` | done (#26) |
+| Q13 | [about-window](about-window.md) | `Sources/App/AboutWindow.swift` only | **open** |
+| Q14 | [statusbar-exit-color](statusbar-exit-color.md) | note only if Coordinator already owns it — **skip if M4-coordinate unmerged** | **open** |
+| Q15 | [p-subdomain](../P-subdomain.md) | `site/` | done (#28) |
+| Q16 | [testdata-wrapper](testdata-wrapper.md) | `scripts/stunt-from-testdata.sh` | done (#26) |
+| Q17 | [gitignore-stunts](gitignore-stunts.md) | `.gitignore` only extra lines | done (#26) |
+| Q18 | [readme-stunts](readme-stunts.md) | `README.md` one paragraph | done (#26) |
+| Q19 | [pr-cop](pr-cop.md) | no source | done (#25, #31) |
+
+Pick the lowest **open** ID (next: Q13, then Q14). Stay in that card’s paths.

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -25,7 +25,7 @@ Status legend: **open** · **in flight** (PR open) · **done** (merged — do no
 | Q1 | [stunt-smoke-script](stunt-smoke-script.md) | `scripts/stunt-smoke.sh` | done (#26) |
 | Q2 | [preview-shell](../parallel/preview-shell.md) | `Companions/Preview/` | done (#9) |
 | Q3 | [editor-shell](../parallel/editor-shell.md) | `Companions/Editor/` | done (#23) |
-| Q4 | [lint](../parallel/lint.md) | lint configs + CI job | in flight — PR #24 |
+| Q4 | [lint](../parallel/lint.md) | lint configs + CI job | done (#24) |
 | Q5 | [assets](../parallel/assets.md) | asset catalog | done (#27) |
 | Q6 | [help-sheet](../parallel/help-sheet.md) | `docs/help.md` | done (#29) |
 | Q7 | [dependabot](../parallel/dependabot.md) | `.github/dependabot.yml` | done (#21) |

--- a/docs/help.md
+++ b/docs/help.md
@@ -23,7 +23,7 @@ Execute compiler tasks directly from the menu:
 
 ## Companion Windows
 
-- **Preview Companion (`⌥⌘P`)**: Live preview powered by `watch --serve` with loopback URL validation.
-- **Editor Companion (`⌥⌘E`)**: Token-isolated companion host for `boris-editor`.
+- **Preview Companion (`⌘⇧P`)**: Live preview powered by `watch --serve` with loopback URL validation.
+- **Editor Companion (`⌘⇧E`)**: Token-isolated companion host for `boris-editor`.
 
 For architecture and roadmap details, see [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).


### PR DESCRIPTION
One branch, three hygiene fixes from the filed review issues:

**Closes #33 — Help shortcuts + dedup.** `docs/help.md` (and the `HelpWindow.swift` fallback) claimed **⌥⌘P / ⌥⌘E** for the Preview/Editor companions, but `Commands.swift` registers **⌘⇧P / ⌘⇧E** (⌥⌘0 is actually the Inspector toggle). Corrected the guide, and replaced the duplicated fallback body in `HelpWindow.swift` with a short stub so the bundled `docs/help.md` is the single source of truth.

**Closes #34 — Queue status.** `docs/cards/queue/README.md` listed ~15 cards as pickable that are already merged. Added a Status column (`done` / `in flight` / `open` / `rolling`) verified against main's history; next agent now picks the lowest open ID (Q13, then Q14). Q4 is marked in-flight since PR #24 is open.

**Closes #35 — .gitignore.** `.tools/` only matched a directory; worktrees that symlink the vendored toolchain showed `?? .tools`. Dropped the trailing slash so `.tools` matches both. Verified with `git check-ignore` against a symlink.

Gate: `SKIP_EMBED_BORIS=1 make build` succeeds, `make test` 11/11 passing.
