### PR TITLE
docs(cards): batch 2 queue — retire batch 1, add Q20-Q25

### DIFF
--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -45,15 +45,8 @@ Anything the compiler does wrong or underspecifies is a **draft in
 `docs/issues/`**, then a GitHub issue on `drawmeanelephant/boris`.
 Never a patch to boris.
 
-File these first (bodies are ready):
-
-1. [A1](../../issues/boris-A1-watch-events.md) `--watch-json` + `serve-started`
-2. [A14](../../issues/boris-A14-editor-launch-contract.md) editor URL + SIGTERM
-3. [A7](../../issues/boris-A7-workspace-rule.md) containment docs
-
-Then A5 as a **discussion**, not a patch.
-
-If you hit a new defect (exact stderr, exit code, command line), write
+Filed: A1/A14/A7/A5 → boris#644-#647. If you hit a new defect (exact
+stderr, exit code, command line), write
 `docs/issues/boris-A<N>-<slug>.md` in the same shape and open the
 issue. Record the number at the top of the draft. The owner will get
 it fixed.
@@ -64,20 +57,23 @@ the agent-pack, `plan --out`.
 
 ---
 
-## Board (pick from the top when idle)
+## Board — batch 1 all landed ✅
 
-| # | Card | Owns | Gate |
-|---|------|------|------|
-| 0 | PR cop + file A1/A14/A7 | `docs/issues/` headers only | issues exist on boris; PRs green or restacked |
-| 1 | [contract-fixtures](contract-fixtures.md) | `Tests/`, `Project.yml` test target only | `xcodebuild` test target decodes checked-in JSON |
-| 2 | [preview-shell](preview-shell.md) | `Sources/Companions/Preview/` | Preview window loads a typed URL; no `Process` |
-| 3 | [editor-shell](editor-shell.md) | `Sources/Companions/Editor/` | Parses `BORIS_EDITOR_URL=`; no spawn |
-| 4 | [lint](lint.md) | `.swiftformat` / `.swiftlint.yml`, CI job `lint` | lint job on PRs; no mass reformat of grind paths in the same PR |
-| 5 | [assets](assets.md) | `Sources/Assets.xcassets` or `Solipsist/Assets.xcassets` | app has an icon; `make build` still works |
-| 6 | [P-subdomain](../P-subdomain.md) | `site/` | public URL, no GitHub required |
-| 7 | [help-sheet](help-sheet.md) | `docs/help.md` + Help menu opening it | Help → Solipsist Help shows the sheet |
-| 8 | [dependabot](dependabot.md) | `.github/dependabot.yml` | weekly Actions bumps |
-| 9 | [issue-templates](issue-templates.md) | `.github/ISSUE_TEMPLATE/` | bug + boris-relay templates |
+| # | Card | Status |
+|---|------|--------|
+| 0 | PR cop + file A1/A14/A7/A5 | rolling (boris#644-#647) |
+| 1 | [contract-fixtures](contract-fixtures.md) | done (#8) |
+| 2 | [preview-shell](preview-shell.md) | done (#9) |
+| 3 | [editor-shell](editor-shell.md) | done (#23) |
+| 4 | [lint](lint.md) | done (#24) |
+| 5 | [assets](assets.md) | done (#27) |
+| 6 | [P-subdomain](../P-subdomain.md) | content done (#28); deploy stays with owners |
+| 7 | [help-sheet](help-sheet.md) | done (#29) |
+| 8 | [dependabot](dependabot.md) | done (#21) |
+| 9 | [issue-templates](issue-templates.md) | done (#22) |
+
+New work lives in the [delegation queue](../queue/README.md) — batch 2
+(Q13, Q20-Q25) is open, pick the lowest ID.
 
 Skip: fart app (`make fart` must keep failing). Skip GitHub-as-source.
 Skip publication flows. Skip Wasm in the app.

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -8,9 +8,11 @@ Open `Stunts/happy` in Solipsist as the default dogfood.
 ## Forbidden paths (grind / already in flight)
 
 `Sources/Play/` · `Sources/Inspector/` · `Sources/Engine/` ·
-`Sources/Models/` · `Spike/` · `Sources/Chrome/MainWindow.swift` ·
-`Sources/Chrome/InspectorDrawer.swift` · `Sources/App/Coordinator.swift`
-· `Sources/App/Commands.swift` · the `boris` git repo.
+`Sources/Models/` (read-only — flag, don't edit) · `Spike/` ·
+`Sources/Chrome/MainWindow.swift` · `Sources/Chrome/InspectorDrawer.swift`
+· `Sources/App/Coordinator.swift` · `Sources/App/Commands.swift` ·
+`Sources/Workspace/` · `scripts/embed-boris.sh` (search order) · the
+`boris` git repo.
 
 If you need a new engine method, stop and leave a note. If Boris
 misbehaves, draft `docs/issues/boris-A<N>-*.md` — do not patch boris.
@@ -19,9 +21,11 @@ misbehaves, draft `docs/issues/boris-A<N>-*.md` — do not patch boris.
 
 Status legend: **open** · **in flight** (PR open) · **done** (merged — do not pick).
 
+### Batch 1 (all merged)
+
 | ID | Card | Owns | Status |
 |----|------|------|--------|
-| Q0 | [file-boris-issues](file-boris-issues.md) | `docs/issues/` headers | rolling (A1/A14/A7 filed; A5 via #32) |
+| Q0 | [file-boris-issues](file-boris-issues.md) | `docs/issues/` headers | rolling (A1/A14/A7/A5 filed) |
 | Q1 | [stunt-smoke-script](stunt-smoke-script.md) | `scripts/stunt-smoke.sh` | done (#26) |
 | Q2 | [preview-shell](../parallel/preview-shell.md) | `Companions/Preview/` | done (#9) |
 | Q3 | [editor-shell](../parallel/editor-shell.md) | `Companions/Editor/` | done (#23) |
@@ -34,12 +38,28 @@ Status legend: **open** · **in flight** (PR open) · **done** (merged — do no
 | Q10 | [stunt-wikilink](stunt-wikilink.md) | `Stunts/broken-wikilink/` | done (#26) |
 | Q11 | [cook-stunt-ir](cook-stunt-ir.md) | `Stunts/cook-one/` + fixture | done (#26) |
 | Q12 | [fixture-check-report](fixture-check-report.md) | `Tests/Fixtures/check-happy/` | done (#26) |
-| Q13 | [about-window](about-window.md) | `Sources/App/AboutWindow.swift` only | **open** |
-| Q14 | [statusbar-exit-color](statusbar-exit-color.md) | note only if Coordinator already owns it — **skip if M4-coordinate unmerged** | **open** |
 | Q15 | [p-subdomain](../P-subdomain.md) | `site/` | done (#28) |
 | Q16 | [testdata-wrapper](testdata-wrapper.md) | `scripts/stunt-from-testdata.sh` | done (#26) |
 | Q17 | [gitignore-stunts](gitignore-stunts.md) | `.gitignore` only extra lines | done (#26) |
 | Q18 | [readme-stunts](readme-stunts.md) | `README.md` one paragraph | done (#26) |
 | Q19 | [pr-cop](pr-cop.md) | no source | done (#25, #31) |
 
-Pick the lowest **open** ID (next: Q13, then Q14). Stay in that card’s paths.
+### Batch 2 (open — pick the lowest ID)
+
+| ID | Card | Owns | Status |
+|----|------|------|--------|
+| Q13 | [about-window](about-window.md) | `Sources/App/AboutWindow.swift` + one `Window` in `SolipsistApp.swift` | **open** |
+| Q20 | [companion-url-tests](companion-url-tests.md) | `Tests/` + read-only extraction in `Companions/` | **open** |
+| Q21 | [contract-null-locations](contract-null-location-fixtures.md) | `Tests/Fixtures/` + `ContractDecodeTests` | **open** |
+| Q22 | [make-lint-fails-loudly](make-lint-fail-loudly.md) | `Makefile` lint target only | **open** |
+| Q23 | [site-content-expansion](site-content-expansion.md) | `site/` only | **open** |
+| Q24 | [stunt-textile-corpus](stunt-textile-corpus.md) | `Stunts/` + `Tests/Fixtures/` | **open** |
+| Q25 | [help-doc-coverage](help-doc-coverage.md) | `docs/help.md` only | **open** |
+
+### Retired
+
+| ID | Card | Why |
+|----|------|-----|
+| Q14 | statusbar-exit-color | Owns `Sources/Chrome/MainWindow.swift`, which is on this queue's own forbidden list. Grind lane owns the status bar — do not pick. |
+
+Pick the lowest **open** ID (next: Q13, then Q20). Stay in that card's paths.

--- a/docs/cards/queue/companion-url-tests.md
+++ b/docs/cards/queue/companion-url-tests.md
@@ -1,0 +1,21 @@
+# Q20 — Companion URL parser tests
+
+**Owns:** `Tests/` (new `CompanionTests` target or extend `ContractTests`
+sources), plus read-only extraction if needed.
+
+`EditorURL.parse` in `Sources/Companions/Editor/EditorWindow.swift` and the
+loopback validator in `Sources/Companions/Preview/PreviewWindow.swift` are
+pure logic with zero unit coverage today. Cover them:
+
+- `BORIS_EDITOR_URL=` prefix strip, raw URL, whitespace trim
+- Loopback enforcement: `127.0.0.1` / `localhost` / `::1` accepted;
+  anything else rejected with `.notLoopback`
+- `#token=<hex>` fragment required; non-hex rejected with `.invalidTokenHex`
+- Empty input → `.empty`; garbage URL → `.invalidURL`
+- Preview URL: loopback-only, same host rules, non-loopback rejected inline
+
+If the parsers live inside `View` structs, extract them into a testable
+location first (e.g. `Sources/Companions/Editor/EditorURL.swift`) — that
+file is in-lane. Do not change parser behavior, only expose it.
+
+Gate: `make test` — new tests pass; no behavior change.

--- a/docs/cards/queue/contract-null-location-fixtures.md
+++ b/docs/cards/queue/contract-null-location-fixtures.md
@@ -1,0 +1,20 @@
+# Q21 — Contract fixtures: null-location diagnostics
+
+**Owns:** `Tests/Fixtures/`, `Tests/ContractTests/ContractDecodeTests.swift`,
+and `Sources/Models/` decode types only if a field is missing.
+
+M4's gate says the problems list must stay clickable when
+`sourcePath`/`line`/`column` are **null** — Boris reports them as optional.
+Today the fixtures only cover non-null diagnostics (broken-frontmatter,
+broken-parent, broken-duplicate-id, broken-wikilink).
+
+Add a fixture (e.g. `Tests/Fixtures/broken-null-locations/build-report.json`)
+with a mix of diagnostics where some or all of `sourcePath`, `line`,
+`column` are null, plus decode tests asserting they decode to `nil` and
+the report still decodes `ok == false` with the right `code`.
+
+If the decode model forces non-optional location fields, fix the model
+(optional) — `Models/` is only readable otherwise, so flag it in the PR
+if the change looks like it reaches beyond the fixture.
+
+Gate: `make test` — new fixture decodes, nulls stay null.

--- a/docs/cards/queue/help-doc-coverage.md
+++ b/docs/cards/queue/help-doc-coverage.md
@@ -1,0 +1,21 @@
+# Q25 — Help doc coverage audit
+
+**Owns:** `docs/help.md`, and `Sources/App/Commands.swift` **read-only**
+(flag anything you can't fix).
+
+The shortcuts were corrected in #37 (`⌘⇧P`/`⌘⇧E`), but the bundled guide
+should document **every** menu verb, not just the companion windows.
+Audit `Sources/App/Commands.swift` against `docs/help.md`:
+
+- Every `Button` with a `.keyboardShortcut` appears in the guide with the
+  same key
+- Plan / Validate / Build / Check / Impact / Stop are all listed with
+  their `⌘`-equivalents
+- File → Open… / New Project… are mentioned if present
+- The Help window itself is documented (⌘? per Commands.swift)
+
+Fix only `docs/help.md`. If a menu item is missing from the guide, add a
+line; do not change `Commands.swift`.
+
+Gate: every `.keyboardShortcut` in `Commands.swift` has a matching
+documented entry in `docs/help.md`.

--- a/docs/cards/queue/make-lint-fail-loudly.md
+++ b/docs/cards/queue/make-lint-fail-loudly.md
@@ -1,0 +1,20 @@
+# Q22 — `make lint` fails loudly without tools
+
+**Owns:** `Makefile` lint target only.
+
+The CI lint job now installs swiftformat/swiftlint and runs
+`swiftformat --lint .` + `swiftlint --strict` — but the local `make lint`
+target still has the old fake fallback: when the tools are missing it
+prints "Lint configs OK" and exits 0. That is a fake gate and must die.
+
+Make `make lint`:
+- exit non-zero with a clear "install swiftformat and swiftlint"
+  message when either tool is missing, **or**
+- install them via `brew install swiftformat swiftlint` and run both
+  checks (match CI exactly).
+
+Do not touch `ci.yml`. Do not reformat files — configs already exist and
+pass in CI.
+
+Gate: `make lint` with tools missing exits non-zero; with tools present it
+runs both checks exactly as CI does.

--- a/docs/cards/queue/site-content-expansion.md
+++ b/docs/cards/queue/site-content-expansion.md
@@ -1,0 +1,19 @@
+# Q23 — Site content expansion
+
+**Owns:** `site/` only.
+
+The P-subdomain (card 6 / Q15) landed the site skeleton: `README.md`,
+`boris.json`, and a `content/` tree. Expand the public content so the
+subdomain has real pages when we deploy:
+
+- A mission page (draw from `docs/MISSION.md`)
+- A roadmap page (draw from `docs/ROADMAP.md`, milestones + status table)
+- A dogfood page pointing at `Stunts/happy` content
+- Link the pages from `site/content/` index
+
+**Do not** add a `"cloudflare"` publication target, Wasm wiring, or any
+deploy adapter — `boris.json` stays a plain static-site profile. Deploy
+(Cloudflare/wrangler) is not this card; it stays with the owners.
+
+Gate: `boris.json` still a plain profile (no `cloudflare` string), pages
+exist under `site/content/`, `make build` unaffected.

--- a/docs/cards/queue/stunt-textile-corpus.md
+++ b/docs/cards/queue/stunt-textile-corpus.md
@@ -1,0 +1,21 @@
+# Q24 — Textile stunt corpus
+
+**Owns:** `Stunts/`, `Tests/Fixtures/`, `scripts/stunt-from-testdata.sh`.
+
+The stunt corpus covers Markdown (happy, broken-*) and Cooklang
+(cook-one). Add a **Textile**-format corpus (`input_format: textile`) so
+the app's input-format surface (M6: drawer shows profile `input_format`)
+has dogfood coverage:
+
+- `Stunts/happy-textile/` with `boris.json` (`input_format: "textile"`),
+  a couple of pages, and a link between them
+- A broken-textile case (e.g. a link to a missing page) if the format
+  supports it
+- Harvested fixtures via `scripts/stunt-from-testdata.sh` + decode tests
+  in `ContractDecodeTests`
+
+If Textile fixtures can't be harvested without a boris binary, commit the
+checked-in JSON like the existing stunts (CI runs with `SKIP_EMBED_BORIS`).
+
+Gate: `make test` — new corpus fixtures decode; `Stunts/README.md` lists
+the new corpora.


### PR DESCRIPTION
## What

Batch 1 of the parallel/queue cards is fully landed. This PR redoes the lists:

- **parallel README board** — mark cards 0-9 done with their PR numbers; point new work at the queue.
- **queue README** — move batch 1 to a 'done' table; add **batch 2** (Q20-Q25): companion URL parser tests, null-location contract fixtures, `make lint` failing loudly, site content expansion, textile stunt corpus, help doc coverage.
- **Retire Q14** (statusbar-exit-color) — the card owns `Sources/Chrome/MainWindow.swift`, which is on the queue's own forbidden list. Self-contradictory; grind lane owns the status bar.
- Also tightened the forbidden list: `Sources/Workspace/` and `scripts/embed-boris.sh` search order were missing from the queue README.

## Files

- `docs/cards/parallel/README.md`
- `docs/cards/queue/README.md`
- 6 new card files under `docs/cards/queue/`

Docs-only change; no source touched. Gate: none (docs).