### PR TITLE
test(companions): unit tests for EditorURL and PreviewURL loopback validator (#40)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -85,6 +85,8 @@ targets:
       - path: Tests/Fixtures
         type: folder
       - path: Sources/Models
+      - path: Sources/Companions/Editor/EditorURL.swift
+      - path: Sources/Companions/Preview/PreviewURL.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.drawmeanelephant.solipsist.contracttests

--- a/Sources/Companions/Editor/EditorURL.swift
+++ b/Sources/Companions/Editor/EditorURL.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Helper parser for Boris editor token launch lines.
+public enum EditorURL {
+    public enum ParseError: LocalizedError, Equatable {
+        case empty
+        case invalidURL
+        case notLoopback
+        case missingTokenFragment
+        case invalidTokenHex
+
+        public var errorDescription: String? {
+            switch self {
+            case .empty:
+                return "Please enter a BORIS_EDITOR_URL line or URL."
+            case .invalidURL:
+                return "That is not a valid URL."
+            case .notLoopback:
+                return "Editor URL must use a loopback host (http://127.0.0.1 or http://localhost)."
+            case .missingTokenFragment:
+                return "Editor URL must include a #token= fragment."
+            case .invalidTokenHex:
+                return "Editor token fragment must be hexadecimal characters."
+            }
+        }
+    }
+
+    /// Parses a `BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=<hex>` line or raw URL.
+    public static func parse(_ raw: String) throws -> URL {
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("BORIS_EDITOR_URL=") {
+            trimmed = String(trimmed.dropFirst("BORIS_EDITOR_URL=".count))
+        }
+        guard !trimmed.isEmpty else {
+            throw ParseError.empty
+        }
+        guard let components = URLComponents(string: trimmed), let url = components.url else {
+            throw ParseError.invalidURL
+        }
+        guard let scheme = components.scheme?.lowercased(), scheme == "http" else {
+            throw ParseError.invalidURL
+        }
+        guard let host = components.host?.lowercased(), host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]" else {
+            throw ParseError.notLoopback
+        }
+        guard let fragment = components.fragment, fragment.hasPrefix("token=") else {
+            throw ParseError.missingTokenFragment
+        }
+        let token = String(fragment.dropFirst("token=".count))
+        guard !token.isEmpty, token.allSatisfy({ $0.isHexDigit }) else {
+            throw ParseError.invalidTokenHex
+        }
+
+        return url
+    }
+}

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -3,61 +3,6 @@ import Observation
 import SwiftUI
 import WebKit
 
-/// Helper parser for Boris editor token launch lines.
-public enum EditorURL {
-    public enum ParseError: LocalizedError, Equatable {
-        case empty
-        case invalidURL
-        case notLoopback
-        case missingTokenFragment
-        case invalidTokenHex
-
-        public var errorDescription: String? {
-            switch self {
-            case .empty:
-                return "Please enter a BORIS_EDITOR_URL line or URL."
-            case .invalidURL:
-                return "That is not a valid URL."
-            case .notLoopback:
-                return "Editor URL must use a loopback host (http://127.0.0.1 or http://localhost)."
-            case .missingTokenFragment:
-                return "Editor URL must include a #token= fragment."
-            case .invalidTokenHex:
-                return "Editor token fragment must be hexadecimal characters."
-            }
-        }
-    }
-
-    /// Parses a `BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=<hex>` line or raw URL.
-    public static func parse(_ raw: String) throws -> URL {
-        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("BORIS_EDITOR_URL=") {
-            trimmed = String(trimmed.dropFirst("BORIS_EDITOR_URL=".count))
-        }
-        guard !trimmed.isEmpty else {
-            throw ParseError.empty
-        }
-        guard let components = URLComponents(string: trimmed), let url = components.url else {
-            throw ParseError.invalidURL
-        }
-        guard let scheme = components.scheme?.lowercased(), scheme == "http" else {
-            throw ParseError.invalidURL
-        }
-        guard let host = components.host?.lowercased(), host == "127.0.0.1" || host == "localhost" || host == "::1" else {
-            throw ParseError.notLoopback
-        }
-        guard let fragment = components.fragment, fragment.hasPrefix("token=") else {
-            throw ParseError.missingTokenFragment
-        }
-        let token = String(fragment.dropFirst("token=".count))
-        guard !token.isEmpty, token.allSatisfy({ $0.isHexDigit }) else {
-            throw ParseError.invalidTokenHex
-        }
-
-        return url
-    }
-}
-
 /// Companion host for `boris-editor` (Svelte). Chassis registers the window
 /// and leaves it closed. The Editor lane owns this file.
 ///

--- a/Sources/Companions/Preview/PreviewURL.swift
+++ b/Sources/Companions/Preview/PreviewURL.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Loopback validation rules for Boris Preview companion.
+public enum PreviewURL {
+    public static func isAllowed(_ url: URL) -> Bool {
+        if url.absoluteString == "about:blank" { return true }
+        return isLoopback(url)
+    }
+
+    public static func isLoopback(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" else { return false }
+        guard let host = url.host?.lowercased() else { return false }
+        return host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]"
+    }
+}

--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -169,14 +169,11 @@ final class PreviewWebModel {
     }
 
     private static func isAllowed(_ url: URL) -> Bool {
-        if url.absoluteString == "about:blank" { return true }
-        return isLoopback(url)
+        PreviewURL.isAllowed(url)
     }
 
     private static func isLoopback(_ url: URL) -> Bool {
-        guard let scheme = url.scheme?.lowercased(), scheme == "http" else { return false }
-        guard let host = url.host?.lowercased() else { return false }
-        return host == "127.0.0.1" || host == "localhost" || host == "::1"
+        PreviewURL.isLoopback(url)
     }
 }
 

--- a/Tests/ContractTests/CompanionURLTests.swift
+++ b/Tests/ContractTests/CompanionURLTests.swift
@@ -90,16 +90,16 @@ final class CompanionURLTests: XCTestCase {
     // MARK: - PreviewURL Tests
 
     func testPreviewURLLoopbackRules() throws {
-        let v4 = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/__boris/"))
+        let ipv4 = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/__boris/"))
         let localhost = try XCTUnwrap(URL(string: "http://localhost:3000/"))
-        let v6 = try XCTUnwrap(URL(string: "http://[::1]:9000/preview"))
+        let ipv6 = try XCTUnwrap(URL(string: "http://[::1]:9000/preview"))
 
-        XCTAssertTrue(PreviewURL.isLoopback(v4))
+        XCTAssertTrue(PreviewURL.isLoopback(ipv4))
         XCTAssertTrue(PreviewURL.isLoopback(localhost))
-        XCTAssertTrue(PreviewURL.isLoopback(v6))
-        XCTAssertTrue(PreviewURL.isAllowed(v4))
+        XCTAssertTrue(PreviewURL.isLoopback(ipv6))
+        XCTAssertTrue(PreviewURL.isAllowed(ipv4))
         XCTAssertTrue(PreviewURL.isAllowed(localhost))
-        XCTAssertTrue(PreviewURL.isAllowed(v6))
+        XCTAssertTrue(PreviewURL.isAllowed(ipv6))
     }
 
     func testPreviewURLBlankAllowed() throws {

--- a/Tests/ContractTests/CompanionURLTests.swift
+++ b/Tests/ContractTests/CompanionURLTests.swift
@@ -89,10 +89,10 @@ final class CompanionURLTests: XCTestCase {
 
     // MARK: - PreviewURL Tests
 
-    func testPreviewURLLoopbackRules() {
-        let v4 = URL(string: "http://127.0.0.1:8080/__boris/")!
-        let localhost = URL(string: "http://localhost:3000/")!
-        let v6 = URL(string: "http://[::1]:9000/preview")!
+    func testPreviewURLLoopbackRules() throws {
+        let v4 = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/__boris/"))
+        let localhost = try XCTUnwrap(URL(string: "http://localhost:3000/"))
+        let v6 = try XCTUnwrap(URL(string: "http://[::1]:9000/preview"))
 
         XCTAssertTrue(PreviewURL.isLoopback(v4))
         XCTAssertTrue(PreviewURL.isLoopback(localhost))
@@ -102,17 +102,17 @@ final class CompanionURLTests: XCTestCase {
         XCTAssertTrue(PreviewURL.isAllowed(v6))
     }
 
-    func testPreviewURLBlankAllowed() {
-        let blank = URL(string: "about:blank")!
+    func testPreviewURLBlankAllowed() throws {
+        let blank = try XCTUnwrap(URL(string: "about:blank"))
         XCTAssertTrue(PreviewURL.isAllowed(blank))
         XCTAssertFalse(PreviewURL.isLoopback(blank))
     }
 
-    func testPreviewURLNonLoopbackRejected() {
-        let remote = URL(string: "http://example.com:8080/")!
-        let lan = URL(string: "http://192.168.1.1:8080/")!
-        let secure = URL(string: "https://127.0.0.1:8080/")!
-        let file = URL(string: "file:///tmp/test.html")!
+    func testPreviewURLNonLoopbackRejected() throws {
+        let remote = try XCTUnwrap(URL(string: "http://example.com:8080/"))
+        let lan = try XCTUnwrap(URL(string: "http://192.168.1.1:8080/"))
+        let secure = try XCTUnwrap(URL(string: "https://127.0.0.1:8080/"))
+        let file = try XCTUnwrap(URL(string: "file:///tmp/test.html"))
 
         XCTAssertFalse(PreviewURL.isLoopback(remote))
         XCTAssertFalse(PreviewURL.isAllowed(remote))

--- a/Tests/ContractTests/CompanionURLTests.swift
+++ b/Tests/ContractTests/CompanionURLTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+final class CompanionURLTests: XCTestCase {
+    // MARK: - EditorURL Tests
+
+    func testEditorURLValidWithPrefix() throws {
+        let input = "BORIS_EDITOR_URL=http://127.0.0.1:49152/#token=0123456789abcdef"
+        let url = try EditorURL.parse(input)
+        XCTAssertEqual(url.scheme, "http")
+        XCTAssertEqual(url.host, "127.0.0.1")
+        XCTAssertEqual(url.port, 49152)
+        XCTAssertEqual(url.fragment, "token=0123456789abcdef")
+    }
+
+    func testEditorURLValidRawAndWhitespace() throws {
+        let input = "  \n  http://localhost:8080/#token=feedface  \t  "
+        let url = try EditorURL.parse(input)
+        XCTAssertEqual(url.scheme, "http")
+        XCTAssertEqual(url.host, "localhost")
+        XCTAssertEqual(url.port, 8080)
+        XCTAssertEqual(url.fragment, "token=feedface")
+    }
+
+    func testEditorURLIPv6Loopback() throws {
+        let input = "http://[::1]:9000/#token=abcd1234"
+        let url = try EditorURL.parse(input)
+        XCTAssertEqual(url.scheme, "http")
+        XCTAssertEqual(url.host, "::1")
+        XCTAssertEqual(url.port, 9000)
+    }
+
+    func testEditorURLEmptyInputs() {
+        XCTAssertThrowsError(try EditorURL.parse("")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .empty)
+        }
+        XCTAssertThrowsError(try EditorURL.parse("   \n\t  ")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .empty)
+        }
+        XCTAssertThrowsError(try EditorURL.parse("BORIS_EDITOR_URL=")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .empty)
+        }
+    }
+
+    func testEditorURLInvalidURLs() {
+        XCTAssertThrowsError(try EditorURL.parse("not a valid url :// @")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .invalidURL)
+        }
+        XCTAssertThrowsError(try EditorURL.parse("https://127.0.0.1:8080/#token=abcd")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .invalidURL)
+        }
+        XCTAssertThrowsError(try EditorURL.parse("ws://127.0.0.1:8080/#token=abcd")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .invalidURL)
+        }
+    }
+
+    func testEditorURLNonLoopbackHosts() {
+        XCTAssertThrowsError(try EditorURL.parse("http://example.com:8080/#token=abcd")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .notLoopback)
+        }
+        XCTAssertThrowsError(try EditorURL.parse("http://192.168.1.100:8080/#token=abcd")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .notLoopback)
+        }
+        XCTAssertThrowsError(try EditorURL.parse("http://10.0.0.1:8080/#token=abcd")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .notLoopback)
+        }
+    }
+
+    func testEditorURLTokenValidation() {
+        // Missing fragment
+        XCTAssertThrowsError(try EditorURL.parse("http://127.0.0.1:8080/")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .missingTokenFragment)
+        }
+        // Wrong fragment prefix
+        XCTAssertThrowsError(try EditorURL.parse("http://127.0.0.1:8080/#key=abcd")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .missingTokenFragment)
+        }
+        // Empty token
+        XCTAssertThrowsError(try EditorURL.parse("http://127.0.0.1:8080/#token=")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .invalidTokenHex)
+        }
+        // Non-hex token
+        XCTAssertThrowsError(try EditorURL.parse("http://127.0.0.1:8080/#token=ghijklm")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .invalidTokenHex)
+        }
+        XCTAssertThrowsError(try EditorURL.parse("http://127.0.0.1:8080/#token=123-abc")) { error in
+            XCTAssertEqual(error as? EditorURL.ParseError, .invalidTokenHex)
+        }
+    }
+
+    // MARK: - PreviewURL Tests
+
+    func testPreviewURLLoopbackRules() {
+        let v4 = URL(string: "http://127.0.0.1:8080/__boris/")!
+        let localhost = URL(string: "http://localhost:3000/")!
+        let v6 = URL(string: "http://[::1]:9000/preview")!
+
+        XCTAssertTrue(PreviewURL.isLoopback(v4))
+        XCTAssertTrue(PreviewURL.isLoopback(localhost))
+        XCTAssertTrue(PreviewURL.isLoopback(v6))
+        XCTAssertTrue(PreviewURL.isAllowed(v4))
+        XCTAssertTrue(PreviewURL.isAllowed(localhost))
+        XCTAssertTrue(PreviewURL.isAllowed(v6))
+    }
+
+    func testPreviewURLBlankAllowed() {
+        let blank = URL(string: "about:blank")!
+        XCTAssertTrue(PreviewURL.isAllowed(blank))
+        XCTAssertFalse(PreviewURL.isLoopback(blank))
+    }
+
+    func testPreviewURLNonLoopbackRejected() {
+        let remote = URL(string: "http://example.com:8080/")!
+        let lan = URL(string: "http://192.168.1.1:8080/")!
+        let secure = URL(string: "https://127.0.0.1:8080/")!
+        let file = URL(string: "file:///tmp/test.html")!
+
+        XCTAssertFalse(PreviewURL.isLoopback(remote))
+        XCTAssertFalse(PreviewURL.isAllowed(remote))
+        XCTAssertFalse(PreviewURL.isLoopback(lan))
+        XCTAssertFalse(PreviewURL.isAllowed(lan))
+        XCTAssertFalse(PreviewURL.isLoopback(secure))
+        XCTAssertFalse(PreviewURL.isAllowed(secure))
+        XCTAssertFalse(PreviewURL.isLoopback(file))
+        XCTAssertFalse(PreviewURL.isAllowed(file))
+    }
+}


### PR DESCRIPTION
Closes #40 (Card Q20).

- Exposes `EditorURL` and `PreviewURL` loopback validators in `Sources/Companions/`
- Adds unit tests in `Tests/ContractTests/CompanionURLTests.swift` covering:
  - `BORIS_EDITOR_URL=` prefix stripping, raw URL, whitespace trimming
  - Loopback host enforcement (`127.0.0.1`, `localhost`, `::1` / `[::1]`)
  - `#token=<hex>` fragment requirements & rejection of non-hex tokens
  - Empty input and invalid URL handling
  - Preview URL loopback and `about:blank` rules
- Gate verified with `make generate && make test && make build`