### PR TITLE
Q25: document every menu verb and shortcut in docs/help.md

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -6,20 +6,46 @@ Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeane
 
 Solipsist organizes its workspace into a three-column spatial model:
 
-- **Sources (Left)**: Switch between opened Boris publication folders (`File -> Open...` or `⌘O`) and dogfood test corpora under `Stunts/`.
+- **Sources (Left)**: Switch between opened Boris publication folders (`File → Open…` or `⌘O`) and dogfood test corpora under `Stunts/`.
 - **Play (Center)**: Displays publication pages, node graph relationships, and generated artifacts derived from compiler contracts.
 - **Inspector Drawer (Right)**: Inspect publication configuration (`boris.json`), page frontmatter completion index (`completion.json`), and execution options.
 
-## Coordinator Verbs
+## Menu Reference
 
-Execute compiler tasks directly from the menu:
+Every menu verb and keyboard shortcut:
 
-- **Plan**: Run Boris plan step to preview output targets.
-- **Validate**: Validate publication structure and HTML output.
-- **Build**: Compile documents into deterministic IR graph and HTML distribution.
-- **Check**: Run static documentation intelligence and reference checks.
-- **Impact**: Analyze ripple effects of node changes across the graph.
-- **Stop (`⌘.`)**: Terminate any currently running compiler subprocess.
+### File
+
+| Verb | Shortcut | Description |
+| --- | --- | --- |
+| Open… | `⌘O` | Open a Boris publication folder as a source. |
+| Remove Source | — | Remove the currently selected source from the workspace (enabled when a source is selected). |
+
+### Boris
+
+| Verb | Shortcut | Description |
+| --- | --- | --- |
+| Plan | `⌘⇧L` | Run the Boris plan step to preview output targets. |
+| Validate | `⌘⇧K` | Validate publication structure and HTML output. |
+| Build IR | `⌘B` | Compile documents into the deterministic IR graph. |
+| Build HTML | `⌘⇧B` | Build the HTML distribution from the IR graph. |
+| Check | — | Run static documentation intelligence and reference checks. |
+| Impact | — | Analyze ripple effects of node changes across the graph (enabled when a page is selected). |
+| Stop | `⌘.` | Terminate any currently running compiler subprocess. |
+
+### View
+
+| Verb | Shortcut | Description |
+| --- | --- | --- |
+| Show/Hide Inspector | `⌥⌘0` | Toggle the Inspector drawer on the right. |
+| Preview | `⌘⇧P` | Open the Preview companion window (live preview via `watch --serve` with loopback URL validation). |
+| Editor | `⌘⇧E` | Open the Editor companion window (token-isolated host for `boris-editor`). |
+
+### Help
+
+| Verb | Shortcut | Description |
+| --- | --- | --- |
+| Solipsist Help | `⌘?` | Open this guide in the in-app Help window. |
 
 ## Companion Windows
 


### PR DESCRIPTION
Closes #43.

The bundled guide only covered the companion windows and a few verbs.
It now has a full **Menu Reference** — File / Boris / View / Help
tables — covering all 10 keyboard shortcuts from `Commands.swift`
(`Commands.swift` untouched, read-only per the card).

Gate verified: every `.keyboardShortcut` in `Commands.swift` (⌘O, ⌘⇧L,
⌘⇧K, ⌘B, ⌘⇧B, ⌘., ⌥⌘0, ⌘⇧P, ⌘⇧E, ⌘?) has a matching documented entry
in `docs/help.md`.