### PR TITLE
Q23: expand site content with roadmap and dogfood pages

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -5,7 +5,7 @@ This directory contains the content and plain publication profile for the public
 ## Profile & Content
 
 - `boris.json`: Plain static-site profile (schema version 1, target `site`, output `dist`, input `content`).
-- `content/`: Closed-frontmatter Markdown pages (`index.md`, `mission.md`, `architecture.md`).
+- `content/`: Closed-frontmatter Markdown pages (`index.md`, `mission.md`, `roadmap.md`, `architecture.md`, `dogfood.md`).
 
 ## Operator Deployment
 

--- a/site/content/dogfood.md
+++ b/site/content/dogfood.md
@@ -1,0 +1,40 @@
+---
+title: Dogfooding
+parent: index
+status: published
+---
+# Dogfooding
+
+Solipsist's test corpora — the **Stunts** — are tiny Boris trees used
+to open, inspect, and diagnose. They live in the repository under
+`Stunts/` and double as the app's default demo content.
+
+## The happy path: `Stunts/happy`
+
+`happy/` is the shape `boris init` creates: a trunk page, two guides
+beneath it, wiki links between them, a starter theme, and a
+`boris.json` publication profile. Open the folder in Solipsist and the
+play place lists the three pages from `graph.json`; select one and the
+drawer shows its completion-backed fields.
+
+## The broken stunts
+
+Broken stunts exist so Validate / Build IR have diagnostics to show —
+do not “fix” them:
+
+| Stunt | What breaks |
+|-------|-------------|
+| `broken-frontmatter/` | unknown key `category` → `EFRONTMATTER` |
+| `broken-parent/` | `parent: does-not-exist` → `EPARENTMISSING` |
+| `broken-wikilink/` | link to a missing page → `EREFERENCEMISSING` |
+| `broken-duplicate-id/` | two pages with the same id → `EDUPLICATEID` |
+| `broken-textile/` | incomplete `"link":` → `ETEXTILE` |
+
+## Other corpora
+
+- `happy-textile/` — two `.textile` pages under the bounded Textile
+  compatibility subset (`input_format: "textile"`)
+- `cook-one/` — one `.cook` recipe for Cooklang handling
+
+See [Stunts/README.md](https://github.com/drawmeanelephant/solipsist/blob/main/Stunts/README.md)
+in the repository for the full table and harvesting instructions.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -18,4 +18,4 @@ It broadcasts local Boris publications while strictly respecting compiler contra
 - **Companion Windows**: Live preview powered by `watch --serve` and editing hosted in `boris-editor`.
 - **First-Class Verbs**: Plan, Validate, Build, Check, Impact, and Stop available directly from the menu.
 
-Read more in our [[mission]] and [[architecture]] documents.
+Read more in our [[mission]], [[roadmap]], [[architecture]], and [[dogfood]] documents.

--- a/site/content/mission.md
+++ b/site/content/mission.md
@@ -3,14 +3,55 @@ title: Mission
 parent: index
 status: published
 ---
-
 # Mission
 
-Solipsist is built to provide an uncompromising, native desktop harness for authoring, inspecting, coordinating, and broadcasting Boris-powered publications.
+**Solipsist is Radio UserLand’s job in Mail’s body**: a native Mac
+harness that turns the graph-native publication compiler into a
+one-window workstation for sources, play, inspection, preview, and
+broadcast — and refuses to invent anything the HIG or a Boris contract
+already named.
 
-## Principles
+## The engine we harness
 
-1. **Never touch the compiler**: Boris remains a separate, deterministic compiler binary written in Zig.
-2. **Decode versioned JSON contracts**: Every visual element derives from typed IR contracts (`manifest.json`, `graph.json`, `completion.json`, `build-report.json`).
-3. **No third settings store**: The publication profile (`boris.json`) is the single source of truth for build configuration.
-4. **Subprocess isolation**: Compiles and validation runs execute as supervised subprocesses with strict cancellation semantics.
+Boris is **not a Markdown-to-HTML converter**. It is a compiler:
+Markdown (or Textile, or Cooklang) in → a validated Trunk/Satellite
+content graph → deterministic contracted projections (HTML, JSON IR,
+RAG packs, context bundles, llms.txt, RSS, sitemap, and live
+publication targets). Solipsist harnesses the `afterparty` integration
+line — `boris/0.8.1` — and never touches the compiler itself.
+
+## Why a Mac app at all
+
+Boris ships its own browser-based editor. Solipsist is the
+complementary **native desktop citizen**:
+
+- **Native file access** — sandboxed, security-scoped bookmarks; real
+  Mac open/save semantics across every project folder.
+- **Mac integration** — windows, menus, keyboard, notifications,
+  pasteboard, drag-and-drop.
+- **A bundled, offline engine** — the `boris` binary ships inside the
+  app (arm64, zero runtime deps); no server, no browser tab, no
+  toolchain at runtime.
+- **A publishing console** — GitHub Pages / Standard.site / Nostr
+  workflows surfaced as native flows, not terminal commands.
+- **No second stack** — the app never reimplements compiler semantics;
+  it renders Boris's JSON contracts (`manifest`, `graph`, `completion`,
+  `build-report`, analysis reports) and drives `watch --serve` for
+  preview.
+
+## The non-negotiables
+
+1. **Never touch the boris repo.** No commits, no edits, no pushes.
+2. **Never reimplement Boris semantics in Swift.** The JSON contracts
+   are the single source of truth; Swift only mirrors and renders them.
+3. **Never silently ignore diagnostics or exit codes.** Surface them.
+4. **The subprocess boundary is a feature.** Crash isolation,
+   cancellation, never in-process Zig.
+5. **Never mutate the user's content tree** except as the direct result
+   of an explicit save.
+
+## Where we are
+
+The engine spike decodes the IR contracts and the Mail-shaped chassis is
+in (sources / play / drawer / companion slots). Next up: play & inspect
+(M3) and the coordinator verbs (M4) — see [[roadmap]].

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -1,0 +1,63 @@
+---
+title: Roadmap
+parent: index
+status: published
+---
+# Roadmap
+
+Solipsist is a **harness**, not a better compiler and not a Markdown
+IDE. Boris stays a better Boris: we vendor the binary, file issues,
+render contracts, and host the surfaces we will not rewrite.
+
+## Where we are
+
+| Milestone | Status |
+|-----------|--------|
+| **M0** Bootstrap | ✅ |
+| **M1** Engine spike | ✅ — decodes the IR contracts |
+| **M2** Chassis | ✅ — sources / play / drawer / companion slots |
+| **P** Project subdomain | next (parallel) |
+| **M3** Play & inspect | next |
+| **M4** Coordinate | — |
+| **M5** Preview | — |
+| **M6** Author | — |
+| **M7** Outputs | — |
+| **M8** Publish | — |
+| **M9** Ship | — |
+
+## v1 must
+
+- One-window Mail-grade chrome: sources, play, inspector drawer, real menus
+- Local source via security-scoped bookmark
+- Graph as a workable list — trunks, satellites, status, relations — from contracts
+- The publication profile (`boris.json`) is the single source of truth
+- Coordinator verbs: Plan, Validate, Build, Check, Impact, Stop — each a menu item
+- Diagnostics as a place: clickable reports, not monospaced dumps
+- Engine-owned preview via `watch --serve` + SSE
+- A hosted editor: `boris-editor` in a companion window
+- Outputs fan-out: every profile target and edition, isolated, reported
+- A publication console: GitHub Pages, Standard.site, Nostr — secrets on stdin
+- Sandboxed, bundled, pinned engine
+
+## v1 must not
+
+- A from-scratch native editor or frontmatter parser
+- An app-side HTTP server or `file://` preview
+- A graph algorithm in Swift
+- Cloudflare / Vercel / Netlify as *in-app* deploy adapters
+- Wasm or `compileBundle` *inside* Solipsist — subprocess isolation stays
+- Theme *authoring* (selection only)
+
+## The north star
+
+Open a folder of Boris content → it appears as a **source** → the play
+place shows the real graph from `graph.json` → the drawer shows the
+profile and the selected page → Plan / Validate / Build surface every
+diagnostic → Preview reloads through `watch --serve` → Edit opens
+`boris-editor` → Publish runs GitHub Pages evidence, Standard.site, or
+Nostr with the Proof Pack attached.
+
+This project's own public face is a Cloudflare subdomain on Boris's
+official Worker + Wasm embed host — stood up early, on the Free tier,
+not as an in-app engine. Full detail lives in the repository
+[ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).


### PR DESCRIPTION
Closes #45.

Expands the public site content so the subdomain has real pages:

- `site/content/roadmap.md` — milestones + status table and v1
  must / must not, drawn from `docs/ROADMAP.md`.
- `site/content/dogfood.md` — points at the `Stunts/happy` corpus and
  the broken stunts for diagnostics.
- `site/content/mission.md` — expanded from the thin skeleton with the
  one-liner, the engine-harness framing, and the non-negotiables from
  `docs/MISSION.md`.
- `site/content/index.md` — now links all four documents.

`boris.json` unchanged: still a plain static-site profile (no
`cloudflare` string, no deploy adapter — that stays with the P-milestone
owners).

Gates: no `cloudflare` in `boris.json` ✓, five pages under
`site/content/` ✓, `make build` succeeds and `site/` is not in the
Xcode project ✓.