### PR TITLE
Q24: add Textile stunt corpus and decode fixtures

### DIFF
--- a/Stunts/README.md
+++ b/Stunts/README.md
@@ -10,7 +10,9 @@ have a kit binary.
 | `happy/` | `boris init` shape: 3 pages, theme, `boris.json` | the **folder** (project root) |
 | `broken-frontmatter/` | unknown key `category` → `EFRONTMATTER` | the folder (content root) |
 | `broken-parent/` | `parent: does-not-exist` → `EPARENTMISSING` | the folder |
+| `broken-textile/` | incomplete `"link":` → `ETEXTILE` | the folder |
 | `cook-one/` | one `.cook` recipe | the folder; needs `--cooklang` later |
+| `happy-textile/` | 2 `.textile` pages (`input_format: "textile"`) | the folder (project root) |
 
 Happy is the default dogfood. Broken stunts exist so Validate / Build
 IR have diagnostics to show. Do not “fix” the broken ones.

--- a/Stunts/broken-textile/page.textile
+++ b/Stunts/broken-textile/page.textile
@@ -1,0 +1,5 @@
+---
+id: broken-textile-link
+title: Page with Broken Textile Link
+---
+This page carries an incomplete "Textile link": with no destination, which must fail with ETEXTILE.

--- a/Stunts/happy-textile/boris.json
+++ b/Stunts/happy-textile/boris.json
@@ -1,0 +1,7 @@
+{
+  "format": "boris-publication-profile",
+  "schema_version": 1,
+  "input": "content",
+  "input_format": "textile",
+  "site": { "title": "Textile Tribute" }
+}

--- a/Stunts/happy-textile/content/guides/intro.textile
+++ b/Stunts/happy-textile/content/guides/intro.textile
@@ -1,0 +1,15 @@
+---
+title: Introduction
+parent: index
+status: published
+tags: [guide]
+---
+h2. Introduction
+
+p. This satellite keeps the existing Trunk/Satellite graph. The "home page":./index links back to the trunk.
+
+p. A flat list keeps the adapter happy:
+
+* one
+* two
+* three

--- a/Stunts/happy-textile/content/index.textile
+++ b/Stunts/happy-textile/content/index.textile
@@ -1,0 +1,23 @@
+---
+id: index
+title: Textile Tribute
+status: published
+tags: [textile, home]
+---
+h1. Textile Tribute
+
+A *strong* and _careful_ paragraph with +inserted+ and -deleted- text, @code@, and an "official reference":https://textile-lang.com/.
+
+Literal comparison: 5 < 7 & 8 > 3.
+
+bq. A small language can leave a long shadow.
+
+Start with the "Introduction":./guides/intro.
+
+* Load
+* Roll
+
+p. Then continue in order.
+
+# Ignite
+# Reset

--- a/Tests/ContractTests/ContractDecodeTests.swift
+++ b/Tests/ContractTests/ContractDecodeTests.swift
@@ -66,6 +66,42 @@ final class ContractDecodeTests: XCTestCase {
         XCTAssertTrue(report.diagnostics.contains { $0.code == "EREFERENCEMISSING" })
     }
 
+    func testHappyTextileBuildReport() throws {
+        let report = try decode(BuildReport.self, "happy-textile", "build-report.json")
+        XCTAssertTrue(report.ok)
+        XCTAssertEqual(report.pageCount, 2)
+        XCTAssertEqual(report.errorCount, 0)
+        XCTAssertTrue(report.diagnostics.isEmpty)
+    }
+
+    func testHappyTextileManifest() throws {
+        let manifest = try decode(Manifest.self, "happy-textile", "manifest.json")
+        XCTAssertEqual(manifest.pages.count, 2)
+        XCTAssertEqual(manifest.pages.filter(\.isTrunk).count, 1)
+        XCTAssertTrue(manifest.pages.allSatisfy { $0.sourcePath.hasSuffix(".textile") })
+    }
+
+    func testHappyTextileGraph() throws {
+        let graph = try decode(Graph.self, "happy-textile", "graph.json")
+        XCTAssertTrue(graph.frozen)
+        XCTAssertEqual(graph.nodes.count, 2)
+        XCTAssertTrue(graph.nodes.allSatisfy { $0.sourcePath.hasSuffix(".textile") })
+        XCTAssertEqual(graph.edges.count, 1)
+        XCTAssertEqual(graph.edges.first?.kind, "parent")
+    }
+
+    func testHappyTextileCompletion() throws {
+        let completion = try decode(Completion.self, "happy-textile", "completion.json")
+        XCTAssertEqual(completion.format, "boris-completion-index")
+        XCTAssertEqual(completion.entities.count, 2)
+    }
+
+    func testBrokenTextileReport() throws {
+        let report = try decode(BuildReport.self, "broken-textile", "build-report.json")
+        XCTAssertFalse(report.ok)
+        XCTAssertTrue(report.diagnostics.contains { $0.code == "ETEXTILE" })
+    }
+
     func testHappyCheck() throws {
         let report = try decode(AnalysisReport.self, "check-happy", "analysis-report.json")
         XCTAssertEqual(report.format, "boris-analysis-report")

--- a/Tests/Fixtures/broken-textile/build-report.json
+++ b/Tests/Fixtures/broken-textile/build-report.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.2.0",
+  "ok": false,
+  "contentRoot": "broken-textile",
+  "outDir": "_ir-broken-textile",
+  "pageCount": 0,
+  "errorCount": 1,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "ETEXTILE",
+      "message": "Incomplete link: missing destination after ':'",
+      "remediation": "Give the link a safe destination or remove it",
+      "sourcePath": "page.textile",
+      "line": 4,
+      "column": 30,
+      "id": "broken-textile-link"
+    }
+  ]
+}

--- a/Tests/Fixtures/happy-textile/build-report.json
+++ b/Tests/Fixtures/happy-textile/build-report.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "0.3.0",
+  "compiler": "boris/0.8.1",
+  "ok": true,
+  "contentRoot": "content",
+  "outDir": ".boris",
+  "pageCount": 2,
+  "errorCount": 0,
+  "diagnostics": []
+}

--- a/Tests/Fixtures/happy-textile/completion.json
+++ b/Tests/Fixtures/happy-textile/completion.json
@@ -1,0 +1,29 @@
+{
+  "format": "boris-completion-index",
+  "schema_version": 1,
+  "compiler_id": "boris/0.8.1",
+  "frozen": true,
+  "entities": [
+    {
+      "id": "guides/intro",
+      "title": "Introduction",
+      "parent": "index",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["guide"],
+      "relations": []
+    },
+    {
+      "id": "index",
+      "title": "Textile Tribute",
+      "parent": null,
+      "role": "trunk",
+      "status": "published",
+      "tags": ["textile", "home"],
+      "relations": []
+    }
+  ],
+  "relation_kinds": ["depends_on", "implements", "relates_to", "supersedes"],
+  "parent_targets": ["index"],
+  "layout_slots": ["backlinks", "breadcrumb", "children", "content", "footer", "metadata", "nav", "relations", "title", "toc"]
+}

--- a/Tests/Fixtures/happy-textile/graph.json
+++ b/Tests/Fixtures/happy-textile/graph.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "0.3.0",
+  "frozen": true,
+  "nodes": [
+    {
+      "index": 0,
+      "id": "guides/intro",
+      "sourcePath": "guides/intro.textile",
+      "role": "satellite",
+      "parent": "index",
+      "parentIndex": 1,
+      "title": "Introduction",
+      "status": "published",
+      "tags": ["guide"],
+      "bodyOffset": 90
+    },
+    {
+      "index": 1,
+      "id": "index",
+      "sourcePath": "index.textile",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "Textile Tribute",
+      "status": "published",
+      "tags": ["textile", "home"],
+      "bodyOffset": 79
+    }
+  ],
+  "edges": [
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/intro"
+      },
+      "to": {
+        "type": "page",
+        "value": "index"
+      },
+      "kind": "parent"
+    }
+  ],
+  "reverseIndex": [
+    {
+      "target": {
+        "type": "page",
+        "value": "index"
+      },
+      "incomingEdges": [0]
+    }
+  ],
+  "nav": [
+    {
+      "index": 0,
+      "id": "guides/intro",
+      "breadcrumb": [1, 0],
+      "children": [],
+      "siblings": []
+    },
+    {
+      "index": 1,
+      "id": "index",
+      "breadcrumb": [1],
+      "children": [0],
+      "siblings": []
+    }
+  ],
+  "relations": []
+}

--- a/Tests/Fixtures/happy-textile/manifest.json
+++ b/Tests/Fixtures/happy-textile/manifest.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "0.3.0",
+  "compiler": "boris/0.8.1",
+  "contentRoot": "content",
+  "pageCount": 2,
+  "pages": [
+    {
+      "index": 0,
+      "id": "guides/intro",
+      "sourcePath": "guides/intro.textile",
+      "role": "satellite",
+      "parent": "index",
+      "title": "Introduction",
+      "status": "published"
+    },
+    {
+      "index": 1,
+      "id": "index",
+      "sourcePath": "index.textile",
+      "role": "trunk",
+      "parent": null,
+      "title": "Textile Tribute",
+      "status": "published"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #44.

Adds Textile-format dogfood coverage so the app's input-format surface (M6: drawer shows profile `input_format`) has real corpora:

- `Stunts/happy-textile/` — `boris.json` with `input_format: "textile"`, two `.textile` pages under the bounded Textile compatibility subset (headings, strong/emphasis/inserted/deleted, `@code@`, `bq.`, lists, safe links), with links between the pages.
- `Stunts/broken-textile/` — an incomplete `"link":` with no destination → `ETEXTILE`. Textile links adapt to Markdown, so a link to a missing page is not the format's loud failure; malformed syntax is, per the boris textile-compatibility contract.
- Checked-in IR fixtures for both corpora (checked-in JSON like the existing stunts — CI runs with `SKIP_EMBED_BORIS`).
- Five new decode tests in `ContractDecodeTests` covering the textile manifest/graph/completion/report shapes.

Gate: `make test` — 16/16 passing (11 existing + 5 new); `make build` succeeds. `Stunts/README.md` lists both new corpora.
