### PR TITLE
test(contracts): fixtures and decode tests for null location diagnostics (#41)

### DIFF
--- a/Tests/ContractTests/ContractDecodeTests.swift
+++ b/Tests/ContractTests/ContractDecodeTests.swift
@@ -102,6 +102,53 @@ final class ContractDecodeTests: XCTestCase {
         XCTAssertTrue(report.diagnostics.contains { $0.code == "ETEXTILE" })
     }
 
+    func testBrokenNullLocationsReport() throws {
+        let report = try decode(BuildReport.self, "broken-null-locations", "build-report.json")
+        XCTAssertFalse(report.ok)
+        XCTAssertEqual(report.errorCount, 4)
+        XCTAssertEqual(report.diagnostics.count, 5)
+
+        // Diagnostic 0: ECONFIG with all null location fields
+        let d0 = report.diagnostics[0]
+        XCTAssertEqual(d0.code, "ECONFIG")
+        XCTAssertNil(d0.sourcePath)
+        XCTAssertNil(d0.line)
+        XCTAssertNil(d0.column)
+        XCTAssertNil(d0.id)
+
+        // Diagnostic 1: EFILEACCESS with sourcePath present, null line and column
+        let d1 = report.diagnostics[1]
+        XCTAssertEqual(d1.code, "EFILEACCESS")
+        XCTAssertEqual(d1.sourcePath, "unreadable.md")
+        XCTAssertNil(d1.line)
+        XCTAssertNil(d1.column)
+        XCTAssertEqual(d1.id, "unreadable")
+
+        // Diagnostic 2: ELINEFORMAT with sourcePath and line present, null column
+        let d2 = report.diagnostics[2]
+        XCTAssertEqual(d2.code, "ELINEFORMAT")
+        XCTAssertEqual(d2.sourcePath, "pages/overview.md")
+        XCTAssertEqual(d2.line, 12)
+        XCTAssertNil(d2.column)
+        XCTAssertEqual(d2.id, "overview")
+
+        // Diagnostic 3: EDUPLICATEID with id present, null sourcePath/line/column
+        let d3 = report.diagnostics[3]
+        XCTAssertEqual(d3.code, "EDUPLICATEID")
+        XCTAssertNil(d3.sourcePath)
+        XCTAssertNil(d3.line)
+        XCTAssertNil(d3.column)
+        XCTAssertEqual(d3.id, "intro")
+
+        // Diagnostic 4: WUNREFERENCED with full location
+        let d4 = report.diagnostics[4]
+        XCTAssertEqual(d4.code, "WUNREFERENCED")
+        XCTAssertEqual(d4.sourcePath, "orphan.md")
+        XCTAssertEqual(d4.line, 1)
+        XCTAssertEqual(d4.column, 1)
+        XCTAssertEqual(d4.id, "orphan")
+    }
+
     func testHappyCheck() throws {
         let report = try decode(AnalysisReport.self, "check-happy", "analysis-report.json")
         XCTAssertEqual(report.format, "boris-analysis-report")

--- a/Tests/ContractTests/ContractDecodeTests.swift
+++ b/Tests/ContractTests/ContractDecodeTests.swift
@@ -109,44 +109,44 @@ final class ContractDecodeTests: XCTestCase {
         XCTAssertEqual(report.diagnostics.count, 5)
 
         // Diagnostic 0: ECONFIG with all null location fields
-        let d0 = report.diagnostics[0]
-        XCTAssertEqual(d0.code, "ECONFIG")
-        XCTAssertNil(d0.sourcePath)
-        XCTAssertNil(d0.line)
-        XCTAssertNil(d0.column)
-        XCTAssertNil(d0.id)
+        let diag0 = report.diagnostics[0]
+        XCTAssertEqual(diag0.code, "ECONFIG")
+        XCTAssertNil(diag0.sourcePath)
+        XCTAssertNil(diag0.line)
+        XCTAssertNil(diag0.column)
+        XCTAssertNil(diag0.id)
 
         // Diagnostic 1: EFILEACCESS with sourcePath present, null line and column
-        let d1 = report.diagnostics[1]
-        XCTAssertEqual(d1.code, "EFILEACCESS")
-        XCTAssertEqual(d1.sourcePath, "unreadable.md")
-        XCTAssertNil(d1.line)
-        XCTAssertNil(d1.column)
-        XCTAssertEqual(d1.id, "unreadable")
+        let diag1 = report.diagnostics[1]
+        XCTAssertEqual(diag1.code, "EFILEACCESS")
+        XCTAssertEqual(diag1.sourcePath, "unreadable.md")
+        XCTAssertNil(diag1.line)
+        XCTAssertNil(diag1.column)
+        XCTAssertEqual(diag1.id, "unreadable")
 
         // Diagnostic 2: ELINEFORMAT with sourcePath and line present, null column
-        let d2 = report.diagnostics[2]
-        XCTAssertEqual(d2.code, "ELINEFORMAT")
-        XCTAssertEqual(d2.sourcePath, "pages/overview.md")
-        XCTAssertEqual(d2.line, 12)
-        XCTAssertNil(d2.column)
-        XCTAssertEqual(d2.id, "overview")
+        let diag2 = report.diagnostics[2]
+        XCTAssertEqual(diag2.code, "ELINEFORMAT")
+        XCTAssertEqual(diag2.sourcePath, "pages/overview.md")
+        XCTAssertEqual(diag2.line, 12)
+        XCTAssertNil(diag2.column)
+        XCTAssertEqual(diag2.id, "overview")
 
         // Diagnostic 3: EDUPLICATEID with id present, null sourcePath/line/column
-        let d3 = report.diagnostics[3]
-        XCTAssertEqual(d3.code, "EDUPLICATEID")
-        XCTAssertNil(d3.sourcePath)
-        XCTAssertNil(d3.line)
-        XCTAssertNil(d3.column)
-        XCTAssertEqual(d3.id, "intro")
+        let diag3 = report.diagnostics[3]
+        XCTAssertEqual(diag3.code, "EDUPLICATEID")
+        XCTAssertNil(diag3.sourcePath)
+        XCTAssertNil(diag3.line)
+        XCTAssertNil(diag3.column)
+        XCTAssertEqual(diag3.id, "intro")
 
         // Diagnostic 4: WUNREFERENCED with full location
-        let d4 = report.diagnostics[4]
-        XCTAssertEqual(d4.code, "WUNREFERENCED")
-        XCTAssertEqual(d4.sourcePath, "orphan.md")
-        XCTAssertEqual(d4.line, 1)
-        XCTAssertEqual(d4.column, 1)
-        XCTAssertEqual(d4.id, "orphan")
+        let diag4 = report.diagnostics[4]
+        XCTAssertEqual(diag4.code, "WUNREFERENCED")
+        XCTAssertEqual(diag4.sourcePath, "orphan.md")
+        XCTAssertEqual(diag4.line, 1)
+        XCTAssertEqual(diag4.column, 1)
+        XCTAssertEqual(diag4.id, "orphan")
     }
 
     func testHappyCheck() throws {

--- a/Tests/Fixtures/broken-null-locations/build-report.json
+++ b/Tests/Fixtures/broken-null-locations/build-report.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "0.2.0",
+  "ok": false,
+  "contentRoot": "broken-null-locations",
+  "outDir": "_ir-broken-null-locations",
+  "pageCount": 3,
+  "errorCount": 4,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "ECONFIG",
+      "message": "global publication config error without file location",
+      "remediation": "Check boris.json configuration",
+      "sourcePath": null,
+      "line": null,
+      "column": null,
+      "id": null
+    },
+    {
+      "severity": "error",
+      "code": "EFILEACCESS",
+      "message": "file level error without line or column",
+      "remediation": "Check file permissions for document",
+      "sourcePath": "unreadable.md",
+      "line": null,
+      "column": null,
+      "id": "unreadable"
+    },
+    {
+      "severity": "error",
+      "code": "ELINEFORMAT",
+      "message": "line level error without column",
+      "remediation": "Check formatting on the indicated line",
+      "sourcePath": "pages/overview.md",
+      "line": 12,
+      "column": null,
+      "id": "overview"
+    },
+    {
+      "severity": "error",
+      "code": "EDUPLICATEID",
+      "message": "duplicate entity id without line or column",
+      "remediation": "Ensure all entity IDs are unique across pages",
+      "sourcePath": null,
+      "line": null,
+      "column": null,
+      "id": "intro"
+    },
+    {
+      "severity": "warning",
+      "code": "WUNREFERENCED",
+      "message": "unreferenced page with full location details",
+      "remediation": "Add an incoming wikilink or nav reference",
+      "sourcePath": "orphan.md",
+      "line": 1,
+      "column": 1,
+      "id": "orphan"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #41 (Card Q21).

- Adds `Tests/Fixtures/broken-null-locations/build-report.json` fixture covering diagnostic location permutations where some or all of `sourcePath`, `line`, `column`, and `id` are null
- Adds `testBrokenNullLocationsReport` to `ContractDecodeTests.swift` verifying that `Diagnostic` optional location fields decode cleanly to `nil` and `BuildReport` decodes with `ok == false` and correct `errorCount`
- Verified with `make generate && make test`