### PR TITLE
docs(queue): mark Q13/Q23/Q24/Q25 done

### DIFF
--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -44,17 +44,17 @@ Status legend: **open** · **in flight** (PR open) · **done** (merged — do no
 | Q18 | [readme-stunts](readme-stunts.md) | `README.md` one paragraph | done (#26) |
 | Q19 | [pr-cop](pr-cop.md) | no source | done (#25, #31) |
 
-### Batch 2 (open — pick the lowest ID)
+### Batch 2
 
 | ID | Card | Owns | Status |
 |----|------|------|--------|
-| Q13 | [about-window](about-window.md) | `Sources/App/AboutWindow.swift` + one `Window` in `SolipsistApp.swift` | **open** |
+| Q13 | [about-window](about-window.md) | `Sources/App/AboutWindow.swift` + one `Window` in `SolipsistApp.swift` | done (#46) |
 | Q20 | [companion-url-tests](companion-url-tests.md) | `Tests/` + read-only extraction in `Companions/` | **open** |
 | Q21 | [contract-null-locations](contract-null-location-fixtures.md) | `Tests/Fixtures/` + `ContractDecodeTests` | **open** |
 | Q22 | [make-lint-fails-loudly](make-lint-fail-loudly.md) | `Makefile` lint target only | **open** |
-| Q23 | [site-content-expansion](site-content-expansion.md) | `site/` only | **open** |
-| Q24 | [stunt-textile-corpus](stunt-textile-corpus.md) | `Stunts/` + `Tests/Fixtures/` | **open** |
-| Q25 | [help-doc-coverage](help-doc-coverage.md) | `docs/help.md` only | **open** |
+| Q23 | [site-content-expansion](site-content-expansion.md) | `site/` only | done (#49) |
+| Q24 | [stunt-textile-corpus](stunt-textile-corpus.md) | `Stunts/` + `Tests/Fixtures/` | done (#50) |
+| Q25 | [help-doc-coverage](help-doc-coverage.md) | `docs/help.md` only | done (#48) |
 
 ### Retired
 
@@ -62,4 +62,4 @@ Status legend: **open** · **in flight** (PR open) · **done** (merged — do no
 |----|------|-----|
 | Q14 | statusbar-exit-color | Owns `Sources/Chrome/MainWindow.swift`, which is on this queue's own forbidden list. Grind lane owns the status bar — do not pick. |
 
-Pick the lowest **open** ID (next: Q13, then Q20). Stay in that card's paths.
+Pick the lowest **open** ID (next: Q20, then Q21). Stay in that card's paths.


### PR DESCRIPTION
Catches the delegation queue statuses up after the last four merges:

- Q13 about-window → done (#46)
- Q23 site-content-expansion → done (#49)
- Q24 stunt-textile-corpus → done (#50)
- Q25 help-doc-coverage → done (#48)

The "pick the lowest open ID" pointer moves from Q13 to **Q20** (then
Q21, Q22).