### PR TITLE
docs: record boris#648 as the fix for A1/A14/A7

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -8,13 +8,13 @@ PR against boris from this repo.
 - A3 [boris#638](https://github.com/drawmeanelephant/boris/issues/638) → [#643](https://github.com/drawmeanelephant/boris/pull/643)
 - A4 [boris#639](https://github.com/drawmeanelephant/boris/issues/639) → [#642](https://github.com/drawmeanelephant/boris/pull/642)
 - A13 [boris#640](https://github.com/drawmeanelephant/boris/issues/640) → [#641](https://github.com/drawmeanelephant/boris/pull/641)
+- A1 [boris#644](https://github.com/drawmeanelephant/boris/issues/644) → [#648](https://github.com/drawmeanelephant/boris/pull/648)
+- A14 [boris#645](https://github.com/drawmeanelephant/boris/issues/645) → [#648](https://github.com/drawmeanelephant/boris/pull/648)
+- A7 [boris#646](https://github.com/drawmeanelephant/boris/issues/646) → [#648](https://github.com/drawmeanelephant/boris/pull/648)
 
 **Filed (2026-08-17):**
 
-- A1 [boris#644](https://github.com/drawmeanelephant/boris/issues/644)
-- A14 [boris#645](https://github.com/drawmeanelephant/boris/issues/645)
-- A7 [boris#646](https://github.com/drawmeanelephant/boris/issues/646)
-- A5 [boris#647](https://github.com/drawmeanelephant/boris/issues/647) — RFC, filed as an issue (Discussions disabled on the repo)
+- A5 [boris#647](https://github.com/drawmeanelephant/boris/issues/647) — RFC, filed as an issue (Discussions disabled on the repo). Still open; no fixing PR yet.
 
 **File next:** none.
 

--- a/docs/issues/boris-A1-watch-events.md
+++ b/docs/issues/boris-A1-watch-events.md
@@ -1,6 +1,7 @@
 # A1 — `--watch-json`: structured NDJSON event stream for watch mode
 
 > **Filed:** [boris#644](https://github.com/drawmeanelephant/boris/issues/644).
+> **Fixed by:** [boris#648](https://github.com/drawmeanelephant/boris/pull/648) (merged into `afterparty` 2026-08-17).
 > Priority: P0 (flagship). Size: M. Additive, opt-in — no behavior change without the flag.
 > **Rebaselined against afterparty v0.8.1.** Afterparty added `watch --serve`
 > (an SSE `reload` channel for *browsers*) and `--timings` (one-shot machine

--- a/docs/issues/boris-A14-editor-launch-contract.md
+++ b/docs/issues/boris-A14-editor-launch-contract.md
@@ -1,6 +1,7 @@
 # A14 — Pin the `boris-editor` subprocess launch contract
 
 > **Filed:** [boris#645](https://github.com/drawmeanelephant/boris/issues/645).
+> **Fixed by:** [boris#648](https://github.com/drawmeanelephant/boris/pull/648) (merged into `afterparty` 2026-08-17).
 > Priority: P1. Size: S. Mostly docs + a test pin; one small behavior add
 > (SIGTERM/SIGINT) matching watch.
 > **Fact-checked against afterparty `editor/src/{main,server}.zig`.** The

--- a/docs/issues/boris-A7-workspace-rule.md
+++ b/docs/issues/boris-A7-workspace-rule.md
@@ -1,6 +1,7 @@
 # A7 — Document the workspace-containment rule (uniform now) + the IR absolute-path rule
 
 > **Filed:** [boris#646](https://github.com/drawmeanelephant/boris/issues/646).
+> **Fixed by:** [boris#648](https://github.com/drawmeanelephant/boris/pull/648) (merged into `afterparty` 2026-08-17).
 > Priority: P1. Size: XS. Documentation + one clarifying question.
 > **Rebaselined against afterparty v0.8.1.** The asymmetry that motivated
 > this issue is **resolved**: all output trees are now cwd-contained


### PR DESCRIPTION
Records the closes of boris#644/#645/#646, resolved by boris#648 (merged into `afterparty` 2026-08-17T21:49Z).

**Why manual closes:** the boris repo's default branch is `main` while the dev line is `afterparty`, so the PR's `Closes #644/#645/#646` keywords never auto-closed the issues. Closed them manually with a fix reference, same as the A3/A4/A13 batch (#638/#639/#640 → #641/#642/#643).

**Changes:**
- `docs/issues/README.md`: moved A1/A14/A7 to the "Already merged" list with `→ #648`; A5 stays filed (still open, no fixing PR yet).
- A1/A14/A7 drafts: added `**Fixed by:** boris#648` under the filed line.

Docs-only, no gate.