### PR TITLE
docs(audit): queue batch-2 fully landed; Stunts table complete

### DIFF
--- a/Stunts/README.md
+++ b/Stunts/README.md
@@ -8,9 +8,11 @@ have a kit binary.
 | Stunt | What it is | Open in Solipsist as |
 |-------|------------|----------------------|
 | `happy/` | `boris init` shape: 3 pages, theme, `boris.json` | the **folder** (project root) |
+| `broken-duplicate-id/` | two pages share an `id` → `EDUPLICATEID` | the folder |
 | `broken-frontmatter/` | unknown key `category` → `EFRONTMATTER` | the folder (content root) |
 | `broken-parent/` | `parent: does-not-exist` → `EPARENTMISSING` | the folder |
 | `broken-textile/` | incomplete `"link":` → `ETEXTILE` | the folder |
+| `broken-wikilink/` | `[[missing-page]]` → `EREFERENCEMISSING` | the folder |
 | `cook-one/` | one `.cook` recipe | the folder; needs `--cooklang` later |
 | `happy-textile/` | 2 `.textile` pages (`input_format: "textile"`) | the folder (project root) |
 

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -49,9 +49,9 @@ Status legend: **open** · **in flight** (PR open) · **done** (merged — do no
 | ID | Card | Owns | Status |
 |----|------|------|--------|
 | Q13 | [about-window](about-window.md) | `Sources/App/AboutWindow.swift` + one `Window` in `SolipsistApp.swift` | done (#46) |
-| Q20 | [companion-url-tests](companion-url-tests.md) | `Tests/` + read-only extraction in `Companions/` | **open** |
-| Q21 | [contract-null-locations](contract-null-location-fixtures.md) | `Tests/Fixtures/` + `ContractDecodeTests` | **open** |
-| Q22 | [make-lint-fails-loudly](make-lint-fail-loudly.md) | `Makefile` lint target only | **open** |
+| Q20 | [companion-url-tests](companion-url-tests.md) | `Tests/` + read-only extraction in `Companions/` | done (#47) |
+| Q21 | [contract-null-locations](contract-null-location-fixtures.md) | `Tests/Fixtures/` + `ContractDecodeTests` | done (#51) |
+| Q22 | [make-lint-fails-loudly](make-lint-fail-loudly.md) | `Makefile` lint target only | done (#52) |
 | Q23 | [site-content-expansion](site-content-expansion.md) | `site/` only | done (#49) |
 | Q24 | [stunt-textile-corpus](stunt-textile-corpus.md) | `Stunts/` + `Tests/Fixtures/` | done (#50) |
 | Q25 | [help-doc-coverage](help-doc-coverage.md) | `docs/help.md` only | done (#48) |
@@ -62,4 +62,4 @@ Status legend: **open** · **in flight** (PR open) · **done** (merged — do no
 |----|------|-----|
 | Q14 | statusbar-exit-color | Owns `Sources/Chrome/MainWindow.swift`, which is on this queue's own forbidden list. Grind lane owns the status bar — do not pick. |
 
-Pick the lowest **open** ID (next: Q20, then Q21). Stay in that card's paths.
+No open batch-2 cards remain — batch 2 is fully landed. Check batch 3 in the issue tracker before picking.


### PR DESCRIPTION
Small trivially-safe docs fixes from the audit in #54. One substantive finding (contract mirror gaps + unimplemented D8 schemaVersion branch) is filed separately as #56 — `Sources/Models/` is read-only for the queue lane.

**`docs/cards/queue/README.md`** — Q20 (companion-url-tests), Q21 (contract-null-locations), Q22 (make-lint-fails-loudly) were merged as #47/#51/#52 but still marked **open**; the "next open" pointer aimed at already-merged work (redo hazard). Batch 2 is now fully landed.

**`Stunts/README.md`** — added the missing `broken-duplicate-id/` and `broken-wikilink/` rows (both corpora exist and are fixture-tested; the table just never listed them).

Gate: docs-only, no build impact. Full audit record (ground-truth battery, every checked/clean result) lands as a comment on #54.
