### PR TITLE
fix(contracts): mirror Graph.relations/recipe and AnalysisReport 0.2.0 fields; D8 schemaVersion gate

### DIFF
--- a/Sources/Models/BorisContracts.swift
+++ b/Sources/Models/BorisContracts.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-/// Codable mirrors of the Boris JSON output contracts (IR schemaVersion 0.2.0).
+/// Codable mirrors of the Boris JSON output contracts (IR schemaVersion
+/// 0.2.0–0.4.0; the app's happy fixtures carry 0.3.0).
 ///
 /// These shapes are normative in the Boris repo:
 ///   boris/docs/contracts/ir-schema.md      (manifest / graph / build-report)
@@ -119,6 +120,10 @@ public struct Graph: Codable, Sendable {
     public var edges: [GraphEdge]
     public var reverseIndex: [ReverseIndexEntry]
     public var nav: [NavEntry]
+    /// Author semantic relations (IR 0.3 facet), reshaped as edges. Same
+    /// shape as `edges`; never used for build dependency walks. Present
+    /// only when the corpus carries relations.
+    public var relations: [GraphEdge]?
 }
 
 public struct GraphNode: Codable, Sendable {
@@ -134,6 +139,43 @@ public struct GraphNode: Codable, Sendable {
     public var tags: [String]?
     /// Byte offset of the body start in the source file (IR has no bodies).
     public var bodyOffset: Int?
+    /// Cooklang recipe (IR 0.4 facet). `nil` for a page that carries no
+    /// recipe; present on every node once any page in the corpus does.
+    public var recipe: CookRecipe?
+}
+
+// MARK: - Cooklang recipes (IR 0.4 facet)
+
+/// `recipe` on a graph node (`ir-graph-0.4.0.schema.json`).
+public struct CookRecipe: Codable, Sendable {
+    public var ingredients: [CookIngredient]
+    public var cookware: [CookCookware]
+    public var timers: [CookTimer]
+}
+
+public struct CookIngredient: Codable, Sendable {
+    public var name: String
+    public var quantity: CookQuantity
+    /// Short-hand preparation from `(...)`; empty when absent.
+    public var preparation: String
+    /// Entity id of the referenced recipe when the author wrote `@./path`.
+    public var recipeRef: String?
+}
+
+public struct CookCookware: Codable, Sendable {
+    public var name: String
+    public var quantity: CookQuantity
+}
+
+public struct CookTimer: Codable, Sendable {
+    /// Empty for an anonymous timer.
+    public var name: String
+    public var quantity: CookQuantity
+}
+
+public struct CookQuantity: Codable, Sendable {
+    public var amount: String
+    public var unit: String
 }
 
 public struct GraphEndpoint: Codable, Sendable {
@@ -178,6 +220,31 @@ public struct AnalysisReport: Codable, Sendable {
     public var findings: [AnalysisFinding]
     /// Populated by `impact`; null for `check`.
     public var impact: [AnalysisImpact]?
+    /// Documentation-intelligence 0.2.0 additions. Optional so a 0.1.0
+    /// report still decodes: older shapes degrade (D8), never crash.
+    public var nodes: [AnalysisNode]?
+    public var edges: [GraphEdge]?
+    public var sourceLocations: [AnalysisLocation]?
+    public var diagnostics: [Diagnostic]?
+}
+
+/// 0.2.0: one entry per page node in the validated graph.
+public struct AnalysisNode: Codable, Sendable {
+    /// Const "page" in the schema.
+    public var type: String
+    public var id: String
+    public var sourcePath: String
+    public var parent: String?
+}
+
+/// 0.2.0: a source location the report points at.
+public struct AnalysisLocation: Codable, Sendable {
+    /// "page" or "source".
+    public var type: String
+    public var value: String
+    public var sourcePath: String
+    public var line: Int
+    public var column: Int
 }
 
 public struct AnalysisSummary: Codable, Sendable {
@@ -368,4 +435,28 @@ public struct TimingsCounters: Codable, Sendable {
     public var hash_bytes: Int?
     public var link_resolutions: Int?
     public var fast_path_hits: Int?
+}
+
+// MARK: - Schema version policy (D8)
+
+/// D8: unknown/newer `schemaVersion` degrades visibly, never crashes.
+/// Consumers must classify an IR document before trusting its shape; the
+/// mirrors knowingly decode these versions:
+///   0.2.0 — typed dependency edges (v0.2 IR)
+///   0.3.0 — semantic-relations facet (what the happy fixtures carry)
+///   0.4.0 — Cooklang recipe facet
+public enum ContractSchema {
+    public static let supportedIR: Set<String> = ["0.2.0", "0.3.0", "0.4.0"]
+
+    public enum Status: Equatable, Sendable {
+        case supported
+        case unknown(String)
+    }
+
+    public static func status(ofIR version: String?) -> Status {
+        guard let version, supportedIR.contains(version) else {
+            return .unknown(version ?? "missing")
+        }
+        return .supported
+    }
 }

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -151,6 +151,10 @@ struct LocalPlay: PlaySurface {
             let build = try await engine.buildIR(contentRoot: contentRoot, outDir: outDir)
             guard !Task.isCancelled else { return }
             if let graph = build.graph, build.report.ok {
+                guard ContractSchema.status(ofIR: graph.schemaVersion) == .supported else {
+                    state = .failed(unknownSchemaMessage(graph.schemaVersion))
+                    return
+                }
                 apply(graph)
                 return
             }
@@ -165,8 +169,19 @@ struct LocalPlay: PlaySurface {
     }
 
     private func apply(_ graph: Graph) {
+        // D8: never trust an unknown/newer shape as truth.
+        guard ContractSchema.status(ofIR: graph.schemaVersion) == .supported else {
+            state = .failed(unknownSchemaMessage(graph.schemaVersion))
+            return
+        }
         let pages = LocalPlayGraph.pages(from: graph)
         state = pages.isEmpty ? .empty : .ready(pages)
+    }
+
+    private func unknownSchemaMessage(_ version: String) -> String {
+        "graph.json schemaVersion \"\(version)\" is not a known IR version "
+            + "(supported: \(ContractSchema.supportedIR.sorted().joined(separator: ", "))). "
+            + "Refusing to render an unknown shape."
     }
 
     private func decodeGraph(at url: URL) throws -> Graph {

--- a/Tests/ContractTests/ContractDecodeTests.swift
+++ b/Tests/ContractTests/ContractDecodeTests.swift
@@ -152,10 +152,88 @@ final class ContractDecodeTests: XCTestCase {
     func testHappyCheck() throws {
         let report = try decode(AnalysisReport.self, "check-happy", "analysis-report.json")
         XCTAssertEqual(report.format, "boris-analysis-report")
-        XCTAssertEqual(report.schemaVersion, "0.1.0")
+        XCTAssertEqual(report.schemaVersion, "0.2.0")
         XCTAssertEqual(report.summary.pages, 5)
         XCTAssertEqual(report.summary.unreferencedPages, 1)
         XCTAssertTrue(report.findings.contains { $0.code == "WUNREFERENCED" })
+    }
+
+    func testGraphDecodesRelations() throws {
+        let graph = try decode(Graph.self, "happy-ir", "graph.json")
+        XCTAssertEqual(graph.schemaVersion, "0.3.0")
+        XCTAssertEqual(graph.relations?.count, 1)
+        XCTAssertEqual(graph.relations?.first?.kind, "relates_to")
+        XCTAssertEqual(graph.relations?.first?.to.value, "guides/getting-started")
+    }
+
+    func testGraphNodeDecodesRecipe() throws {
+        // Synthetic IR 0.4.0 node carrying a Cooklang recipe (recipe facet).
+        let json = """
+        {
+          "index": 0,
+          "id": "soup",
+          "sourcePath": "soup.cook",
+          "role": "trunk",
+          "parent": null,
+          "parentIndex": null,
+          "title": "Soup",
+          "status": "published",
+          "tags": ["recipe"],
+          "bodyOffset": 60,
+          "recipe": {
+            "ingredients": [
+              { "name": "water", "quantity": { "amount": "2", "unit": "cups" }, "preparation": "", "recipeRef": null }
+            ],
+            "cookware": [
+              { "name": "skillet", "quantity": { "amount": "1", "unit": "" } }
+            ],
+            "timers": [
+              { "name": "", "quantity": { "amount": "10", "unit": "minutes" } }
+            ]
+          }
+        }
+        """
+        let node = try JSONDecoder().decode(GraphNode.self, from: Data(json.utf8))
+        let recipe = try XCTUnwrap(node.recipe)
+        XCTAssertEqual(recipe.ingredients.first?.name, "water")
+        XCTAssertEqual(recipe.ingredients.first?.quantity.amount, "2")
+        XCTAssertEqual(recipe.cookware.first?.name, "skillet")
+        XCTAssertEqual(recipe.timers.first?.quantity.amount, "10")
+    }
+
+    func testAnalysisReport02FullShape() throws {
+        let report = try decode(AnalysisReport.self, "check-happy", "analysis-report.json")
+        XCTAssertEqual(report.schemaVersion, "0.2.0")
+        XCTAssertEqual(report.summary.pages, 5)
+        XCTAssertEqual(report.nodes?.count, 5)
+        XCTAssertEqual(report.edges?.count, 5)
+        XCTAssertEqual(report.sourceLocations?.first?.value, "orphan")
+        XCTAssertEqual(report.sourceLocations?.first?.sourcePath, "orphan.md")
+        XCTAssertEqual(report.diagnostics?.isEmpty, true)
+    }
+
+    func testSchemaPolicyUnknownVersion() throws {
+        // D8: known IR versions classify as supported; unknown/newer degrade.
+        XCTAssertEqual(ContractSchema.status(ofIR: "0.2.0"), .supported)
+        XCTAssertEqual(ContractSchema.status(ofIR: "0.3.0"), .supported)
+        XCTAssertEqual(ContractSchema.status(ofIR: "0.4.0"), .supported)
+        XCTAssertEqual(ContractSchema.status(ofIR: "0.9.9"), .unknown("0.9.9"))
+        XCTAssertEqual(ContractSchema.status(ofIR: nil), .unknown("missing"))
+
+        // A synthetic unknown-version graph still decodes (fields optional)
+        // but classifies as unknown so consumers refuse to render it.
+        let json = """
+        {
+          "schemaVersion": "0.9.9",
+          "frozen": true,
+          "nodes": [],
+          "edges": [],
+          "reverseIndex": [],
+          "nav": []
+        }
+        """
+        let graph = try JSONDecoder().decode(Graph.self, from: Data(json.utf8))
+        XCTAssertEqual(ContractSchema.status(ofIR: graph.schemaVersion), .unknown("0.9.9"))
     }
 
     private func decode<T: Decodable>(_ type: T.Type, _ folder: String, _ name: String) throws -> T {

--- a/Tests/Fixtures/check-happy/analysis-report.json
+++ b/Tests/Fixtures/check-happy/analysis-report.json
@@ -1,6 +1,6 @@
 {
   "format": "boris-analysis-report",
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.2.0",
   "compiler": "boris/0.8.1",
   "input": "Stunts/happy",
   "summary": {
@@ -11,11 +11,80 @@
     "unreferencedPages": 1,
     "hotspots": 0
   },
-  "pages": [
+  "nodes": [
     {
-      "id": "orphan",
+      "type": "page",
+      "id": "guides/getting-started",
+      "sourcePath": "guides/getting-started.md",
+      "parent": "index"
+    },
+    {
+      "type": "page",
+      "id": "guides/publishing",
+      "sourcePath": "guides/publishing.md",
+      "parent": "index"
+    },
+    {
+      "type": "page",
+      "id": "guides/tips",
+      "sourcePath": "guides/tips.md",
+      "parent": "index"
+    },
+    {
+      "type": "page",
+      "id": "index",
+      "sourcePath": "index.md",
       "parent": null
+    },
+    {
+      "type": "page",
+      "id": "orphan",
+      "sourcePath": "orphan.md",
+      "parent": "index"
     }
+  ],
+  "edges": [
+    {
+      "from": { "type": "page", "value": "guides/getting-started" },
+      "to": { "type": "page", "value": "index" },
+      "kind": "parent"
+    },
+    {
+      "from": { "type": "page", "value": "guides/publishing" },
+      "to": { "type": "page", "value": "index" },
+      "kind": "parent"
+    },
+    {
+      "from": { "type": "page", "value": "guides/tips" },
+      "to": { "type": "page", "value": "index" },
+      "kind": "parent"
+    },
+    {
+      "from": { "type": "page", "value": "orphan" },
+      "to": { "type": "page", "value": "index" },
+      "kind": "parent"
+    },
+    {
+      "from": { "type": "page", "value": "guides/publishing" },
+      "to": { "type": "page", "value": "guides/getting-started" },
+      "kind": "reference"
+    }
+  ],
+  "sourceLocations": [
+    {
+      "type": "page",
+      "value": "orphan",
+      "sourcePath": "orphan.md",
+      "line": 1,
+      "column": 1
+    }
+  ],
+  "pages": [
+    { "id": "guides/getting-started", "parent": "index" },
+    { "id": "guides/publishing", "parent": "index" },
+    { "id": "guides/tips", "parent": "index" },
+    { "id": "index", "parent": null },
+    { "id": "orphan", "parent": "index" }
   ],
   "sources": [],
   "findings": [
@@ -25,5 +94,7 @@
       "value": "orphan",
       "count": 1
     }
-  ]
+  ],
+  "impact": null,
+  "diagnostics": []
 }


### PR DESCRIPTION
Closes #56.

Implements the audit finding's gate — the contract mirrors no longer
silently drop emitted fields, and consumers now branch on `schemaVersion`
per D8.

**Mirrors** (`Sources/Models/BorisContracts.swift`):
- `Graph` gains `relations: [GraphEdge]?` (IR 0.3 semantic-relations
  facet, same shape as edges — was present in the app's own `happy-ir`
  fixture but dropped on decode).
- `GraphNode` gains `recipe: CookRecipe?` (IR 0.4 Cooklang facet) with
  the full `CookRecipe`/`CookIngredient`/`CookCookware`/`CookTimer`/
  `CookQuantity` shapes per `ir-graph-0.4.0.schema.json`.
- `AnalysisReport` gains `nodes`, `edges`, `sourceLocations`,
  `diagnostics` per `documentation-intelligence-0.2.0.schema.json` —
  optional so a 0.1.0 report still decodes (older shapes degrade, D8).
- Header comment updated to 0.2.0–0.4.0 (happy fixtures carry 0.3.0).

**D8 gate** (`Sources/Play/Local/LocalPlay.swift` + new `ContractSchema`
policy): consumers classify an IR document's `schemaVersion` before
trusting its shape. Unknown/newer versions render a visible degrade
message in the play pane ("Refusing to render an unknown shape")
instead of being shown as truth; known versions (0.2.0/0.3.0/0.4.0)
render normally.

**Fixtures & tests**:
- `check-happy/analysis-report.json` upgraded to `0.2.0` with
  nodes/edges/sourceLocations/diagnostics (internally consistent:
  5 pages, 1 root, 4 satellites, orphan unreferenced).
- New tests: `testGraphDecodesRelations`, `testGraphNodeDecodesRecipe`
  (synthetic 0.4.0 node), `testAnalysisReport02FullShape`,
  `testSchemaPolicyUnknownVersion` (synthetic 0.9.9 artifact decodes
  but classifies unknown).
- `testHappyCheck` updated for the 0.2.0 fixture.

Gate: `SKIP_EMBED_BORIS=1 make build` succeeds; `make test` — 31/31
passing (27 existing + 4 new).
