### PR TITLE
ci(site): automated Boris build and Cloudflare Pages deployment to solipsist.pages.dev

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,50 @@
+name: Deploy Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-site.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-site-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy to Cloudflare Pages
+    runs-on: macos-15
+    steps:
+      - name: Checkout Solipsist
+        uses: actions/checkout@v7
+
+      - name: Checkout Boris compiler
+        uses: actions/checkout@v7
+        with:
+          repository: drawmeanelephant/boris
+          path: boris
+          ref: main
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: master
+
+      - name: Build Boris engine
+        run: |
+          cd boris
+          zig build -Doptimize=ReleaseFast
+
+      - name: Compile documentation site
+        run: |
+          cd site
+          ../boris/zig-out/bin/boris build --profile boris.json
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site/dist --project-name=solipsist

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 XCODEGEN := .tools/xcodegen/xcodegen/bin/xcodegen
 PROJECT  := Solipsist.xcodeproj
 
-.PHONY: tools generate build spike run-spike test lint harvest-fixtures clean fart
+.PHONY: tools generate build spike run-spike test lint harvest-fixtures site clean fart
 
 tools:
 	@mkdir -p .tools
@@ -53,6 +53,18 @@ lint:
 
 harvest-fixtures:
 	bash scripts/harvest-stunt-fixtures.sh
+
+site:
+	@if [ -n "$$SOLIPSIST_BORIS_BIN" ] && [ -x "$$SOLIPSIST_BORIS_BIN" ]; then \
+		(cd site && "$$SOLIPSIST_BORIS_BIN" build --profile boris.json); \
+	elif [ -x "../boris/zig-out/bin/boris" ]; then \
+		(cd site && ../boris/zig-out/bin/boris build --profile boris.json); \
+	elif command -v boris >/dev/null 2>&1; then \
+		(cd site && boris build --profile boris.json); \
+	else \
+		echo "error: boris binary not found. Set SOLIPSIST_BORIS_BIN or build ../boris" >&2; \
+		exit 1; \
+	fi
 
 clean:
 	rm -rf build Solipsist.xcodeproj

--- a/site/README.md
+++ b/site/README.md
@@ -1,12 +1,31 @@
 # Solipsist Project Site Content
 
-This directory contains the content and plain publication profile for the public Solipsist documentation and project site.
+This directory contains the content and publication profile for the public Solipsist documentation and project site, hosted at `https://solipsist.pages.dev`.
 
 ## Profile & Content
 
 - `boris.json`: Plain static-site profile (schema version 1, target `site`, output `dist`, input `content`).
 - `content/`: Closed-frontmatter Markdown pages (`index.md`, `mission.md`, `roadmap.md`, `architecture.md`, `dogfood.md`).
 
-## Operator Deployment
+## Deployment to Cloudflare Pages
 
-Solipsist does not build publication targets or embed cloud adapters into the desktop application binary. Publication to the project subdomain (`solipsist.drawmeanelephant.dev`) is operated via the Boris Cloudflare Worker embed host (`hosts/cloudflare-worker/` in the Boris repository) consuming `boris-embed-small.wasm`.
+The site is built with Boris (`boris build --profile site/boris.json`) and published to Cloudflare Pages project `solipsist` (`solipsist.pages.dev`).
+
+### CI / GitHub Actions Deployment
+
+The `.github/workflows/deploy-site.yml` workflow automatically builds and deploys `site/dist/` to Cloudflare Pages on push to `main` when `site/**` changes, using the repository secrets:
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_API_TOKEN`
+
+### Manual Deployment
+
+To compile and deploy locally:
+
+```bash
+# 1. Compile the site with Boris
+cd site
+../boris/zig-out/bin/boris build --profile boris.json
+
+# 2. Deploy dist/ to Cloudflare Pages
+npx wrangler pages deploy dist --project-name solipsist
+```

--- a/site/boris.json
+++ b/site/boris.json
@@ -5,13 +5,13 @@
   "input_format": "markdown",
   "site": {
     "title": "Solipsist",
-    "url": "https://solipsist.drawmeanelephant.dev",
+    "url": "https://solipsist.pages.dev",
     "description": "A native macOS harness for Boris, the deterministic Zig publication compiler."
   },
   "publication": {
     "target": "site",
-    "base_url": "https://solipsist.drawmeanelephant.dev",
-    "origin": "https://solipsist.drawmeanelephant.dev",
+    "base_url": "https://solipsist.pages.dev",
+    "origin": "https://solipsist.pages.dev",
     "base_path": "/"
   },
   "targets": [


### PR DESCRIPTION
Sets up automated deployment of the documentation site to Cloudflare Pages (`solipsist.pages.dev`):

- Adds `.github/workflows/deploy-site.yml` which checks out Boris, compiles the static documentation site with Boris, and deploys `site/dist/` to Cloudflare Pages using `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` secrets
- Updates `site/boris.json` publication endpoints to `https://solipsist.pages.dev`
- Adds `make site` target to `Makefile`
- Updates `site/README.md` with deployment steps