### PR TITLE
docs(stunts): manual D8 unknown-schemaVersion verification corpus

### DIFF
--- a/Stunts/README.md
+++ b/Stunts/README.md
@@ -18,3 +18,37 @@ have a kit binary.
 
 Happy is the default dogfood. Broken stunts exist so Validate / Build
 IR have diagnostics to show. Do not “fix” the broken ones.
+
+## Manual check: D8 unknown-schemaVersion degrade (#56)
+
+To see the D8 degrade banner in the play pane (unknown/newer
+`schemaVersion` renders “Graph Unavailable” instead of a page list),
+create a synthetic corpus in `/tmp` — it cannot be committed because
+`.boris/` is gitignored (`Stunts/**/.boris/`), so a stunt can’t ship a
+pre-baked graph:
+
+```bash
+mkdir -p /tmp/unknown-schema-corpus/content /tmp/unknown-schema-corpus/.boris
+cp Stunts/happy/boris.json /tmp/unknown-schema-corpus/boris.json
+printf -- '---\ntitle: Unknown Schema\n---\n\n# Unknown Schema\n' \
+  > /tmp/unknown-schema-corpus/content/index.md
+cat > /tmp/unknown-schema-corpus/.boris/graph.json <<'EOF'
+{
+  "schemaVersion": "0.9.9",
+  "frozen": true,
+  "nodes": [{"index": 0, "id": "index", "sourcePath": "index.md",
+    "role": "trunk", "parent": null, "parentIndex": null,
+    "title": "Unknown Schema", "status": "published",
+    "tags": [], "bodyOffset": 60}],
+  "edges": [], "reverseIndex": [], "nav": [], "relations": []
+}
+EOF
+```
+
+Then File → Open… that folder. The play pane must show **Graph
+Unavailable** with `schemaVersion "0.9.9" is not a known IR version
+(supported: 0.2.0, 0.3.0, 0.4.0). Refusing to render an unknown shape.`
+and a Try Again button — never a page list. Covered headlessly by
+`testSchemaPolicyUnknownVersion` in `ContractDecodeTests`; this corpus is
+the manual, end-to-end confirmation. Opening `Stunts/happy` (0.3.0) in the
+same build must still render its 3-page list normally.


### PR DESCRIPTION
Documents the manual end-to-end D8 check that verified #56's fix in the running app: a synthetic corpus whose `.boris/graph.json` claims `schemaVersion: "0.9.9"`.

It can't be committed as a stunt — `.boris/` is gitignored (`Stunts/**/.boris/`), so a checked-in corpus can't ship a pre-baked graph. The README section gives the exact `/tmp` recipe (bash block) and the expected result: **Graph Unavailable** with the refuse-to-render message and a Try Again button, never a page list. Cross-references `testSchemaPolicyUnknownVersion` for the headless coverage.

Docs-only — no build impact.
