### PR TITLE
fix(site): make the Pages deploy actually build and ship

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -20,18 +20,21 @@ jobs:
       - name: Checkout Solipsist
         uses: actions/checkout@v7
 
+      # D7 pin: the same afterparty engine commit the app bundles. `main` on
+      # boris is the stale v0.8.0 line; moving pins are not reproducible.
       - name: Checkout Boris compiler
         uses: actions/checkout@v7
         with:
           repository: drawmeanelephant/boris
           path: boris
-          ref: main
+          ref: b82e9e2eace74d9ca61df23dffc1329d2a2fe628
 
+      # Same pin boris's own CI uses (github-pages.yml); `master` tarballs
+      # rotate out of the mirrors and 404.
       - name: Install Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2
         with:
-          version: master
-
+          version: 0.16.0
       - name: Build Boris engine
         run: |
           cd boris

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,7 +143,14 @@ window groups. `Source` / `WorkspaceSelection` / `WorkspaceStore`.
 File → Open… bookmarks a local folder.
 Gate: empty chrome is Mail-shaped; Open adds a source; spike unchanged.
 
-### P — Project subdomain (parallel, plenty early)
+### P — Project subdomain (parallel, plenty early) — ⛔ **withdrawn (2026-08-17)**
+
+**Decision:** not building the Worker/Wasm subdomain host. The public site
+ships via Cloudflare Pages (`solipsist.pages.dev` — see `site/` and
+`.github/workflows/deploy-site.yml`); a separate Worker + R2 + Wasm host
+adds infra for no user-facing gain. The boris-side surfaces
+(`hosts/cloudflare-worker`, `compileBundle` Wasm) stay in the operator
+reviews, but this repo does not stand up a project subdomain on them.
 
 **Goal.** Solipsist has a public URL that is itself a Boris publication,
 without depending on GitHub being up or on us having full GitHub access.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -146,7 +146,7 @@ Gate: empty chrome is Mail-shaped; Open adds a source; spike unchanged.
 ### P — Project subdomain (parallel, plenty early) — ⛔ **withdrawn (2026-08-17)**
 
 **Decision:** not building the Worker/Wasm subdomain host. The public site
-ships via Cloudflare Pages (`solipsist.pages.dev` — see `site/` and
+ships via Cloudflare Pages (`https://solipsist.filed.fyi` — see `site/` and
 `.github/workflows/deploy-site.yml`); a separate Worker + R2 + Wasm host
 adds infra for no user-facing gain. The boris-side surfaces
 (`hosts/cloudflare-worker`, `compileBundle` Wasm) stay in the operator

--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -67,7 +67,7 @@ the agent-pack, `plan --out`.
 | 3 | [editor-shell](editor-shell.md) | done (#23) |
 | 4 | [lint](lint.md) | done (#24) |
 | 5 | [assets](assets.md) | done (#27) |
-| 6 | [P-subdomain](../P-subdomain.md) | ⛔ withdrawn — published on Cloudflare Pages instead (`solipsist.pages.dev`); no Worker host |
+| 6 | [P-subdomain](../P-subdomain.md) | ⛔ withdrawn — published on Cloudflare Pages instead (`https://solipsist.filed.fyi`); no Worker host |
 | 7 | [help-sheet](help-sheet.md) | done (#29) |
 | 8 | [dependabot](dependabot.md) | done (#21) |
 | 9 | [issue-templates](issue-templates.md) | done (#22) |

--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -67,7 +67,7 @@ the agent-pack, `plan --out`.
 | 3 | [editor-shell](editor-shell.md) | done (#23) |
 | 4 | [lint](lint.md) | done (#24) |
 | 5 | [assets](assets.md) | done (#27) |
-| 6 | [P-subdomain](../P-subdomain.md) | content done (#28); deploy stays with owners |
+| 6 | [P-subdomain](../P-subdomain.md) | ⛔ withdrawn — published on Cloudflare Pages instead (`solipsist.pages.dev`); no Worker host |
 | 7 | [help-sheet](help-sheet.md) | done (#29) |
 | 8 | [dependabot](dependabot.md) | done (#21) |
 | 9 | [issue-templates](issue-templates.md) | done (#22) |

--- a/site/README.md
+++ b/site/README.md
@@ -1,6 +1,6 @@
 # Solipsist Project Site Content
 
-This directory contains the content and publication profile for the public Solipsist documentation and project site, hosted at `https://solipsist.pages.dev`.
+This directory contains the content and publication profile for the public Solipsist documentation and project site, hosted at `https://solipsist.filed.fyi`.
 
 ## Profile & Content
 
@@ -9,7 +9,7 @@ This directory contains the content and publication profile for the public Solip
 
 ## Deployment to Cloudflare Pages
 
-The site is built with Boris (`boris build --profile site/boris.json`) and published to Cloudflare Pages project `solipsist` (`solipsist.pages.dev`).
+The site is built with Boris (`boris build --profile site/boris.json`) and published to Cloudflare Pages project `solipsist`, served at the custom domain **`https://solipsist.filed.fyi`** (Pages alias: `solipsist.pages.dev`).
 
 ### CI / GitHub Actions Deployment
 

--- a/site/boris.json
+++ b/site/boris.json
@@ -5,7 +5,7 @@
   "input_format": "markdown",
   "site": {
     "title": "Solipsist",
-    "url": "https://solipsist.pages.dev",
+    "url": "https://solipsist.filed.fyi",
     "description": "A native macOS harness for Boris, the deterministic Zig publication compiler."
   },
   "targets": [

--- a/site/boris.json
+++ b/site/boris.json
@@ -8,12 +8,6 @@
     "url": "https://solipsist.pages.dev",
     "description": "A native macOS harness for Boris, the deterministic Zig publication compiler."
   },
-  "publication": {
-    "target": "site",
-    "base_url": "https://solipsist.pages.dev",
-    "origin": "https://solipsist.pages.dev",
-    "base_path": "/"
-  },
   "targets": [
     {
       "name": "site",

--- a/site/themes/boris/assets/css/boris.css
+++ b/site/themes/boris/assets/css/boris.css
@@ -1,0 +1,42 @@
+/* Starter theme for a Boris site. Replace or extend freely. */
+:root {
+  --ink: #1f2328;
+  --paper: #ffffff;
+  --muted: #59636e;
+  --accent: #0969da;
+  --rule: #d1d9e0;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0 auto;
+  max-width: 64rem;
+  padding: 1rem 1.5rem 3rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.site-header {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.site-title { font-size: 1.1rem; font-weight: 700; margin: 0 0 0.5rem; }
+
+.site-nav ul, .site-toc ul { list-style: none; padding-left: 1rem; }
+.site-nav a, .site-toc a, .site-breadcrumb a { color: var(--accent); text-decoration: none; }
+.site-nav a:hover, .site-toc a:hover, .site-breadcrumb a:hover { text-decoration: underline; }
+
+.site-breadcrumb { color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem; }
+.site-toc { border: 1px solid var(--rule); border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1.5rem; font-size: 0.95rem; }
+.site-toc:empty { display: none; }
+
+.site-content h1 { font-size: 1.8rem; margin-top: 0; }
+.site-content code { background: #f6f8fa; border-radius: 4px; padding: 0.1em 0.35em; }
+.site-content pre { background: #f6f8fa; border-radius: 6px; padding: 0.75rem 1rem; overflow-x: auto; }
+
+.site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: 0.9rem; }

--- a/site/themes/boris/layouts/main.html
+++ b/site/themes/boris/layouts/main.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{title}} · Solipsist</title>
+  <link rel="stylesheet" href="{{asset-url assets/css/boris.css}}">
+  {{head}}
+</head>
+<body>
+<header class="site-header">
+  <p class="site-title">Solipsist</p>
+  <nav class="site-nav">{{nav}}</nav>
+</header>
+<main class="site-body">
+  <div class="site-breadcrumb">{{breadcrumb}}</div>
+  <aside class="site-toc">{{toc}}</aside>
+  <article class="site-content">{{content}}</article>
+</main>
+<footer class="site-footer">{{footer}}</footer>
+</body>
+</html>


### PR DESCRIPTION
Fixes the never-green deploy pipeline behind the domain work.

THE FAILURE: deploy-site died on Install Zig (setup-zig version 'master' tarball 404/502 from the mirrors), so solipsist.pages.dev has NO production deploy ever (HTTP 522). Two deeper issues would have failed it even with Zig working:
- site/boris.json carries a 'publication' block that the engine's canonical boris-publication-profile schema rejects (InvalidPublication)
- the site has no theme - a build needs themes/boris/ (layout + css)

CHANGES:
- site/boris.json: drop the invalid 'publication' block (verified field-by-field against the pinned engine: input_format, site.url/description, target rename all accepted)
- site/themes/boris/: vendor the 'boris init' default theme, branded Solipsist
- deploy-site.yml: setup-zig@v2 + zig 0.16.0 (the exact pin boris's own CI uses - 'master' tarballs rotate and 404), and pin the boris checkout to the D7 engine commit b82e9e2e (boris 'main' is the stale v0.8.0 line)
- docs/ROADMAP.md + parallel board: P (Worker/Wasm project subdomain) marked WITHDRAWN - publishing through Cloudflare Pages instead; no Worker host (owner decision)

VERIFIED LOCALLY against the pinned engine binary: 'boris build --profile boris.json' writes all six pages (index/architecture/dogfood/mission/roadmap).

ONE THING I CANNOT CHECK FROM HERE: the repo secrets CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN must exist for the wrangler step (every previous run died before reaching it). If they are set this goes green and the domain starts serving.