### PR TITLE
docs(cards): record batch-3 dispatch for production-readiness issues

### DIFF
--- a/docs/cards/B3-coordinator.md
+++ b/docs/cards/B3-coordinator.md
@@ -1,0 +1,44 @@
+# Card B3-1 — Coordinator state machine
+
+**Milestones:** M4 (Coordinate) + M5 (Preview) · **Issue:**
+[#58](https://github.com/drawmeanelephant/solipsist/issues/58) ·
+**Lane:** coordinator (grind). One worktree, one PR against `main`;
+branch suggestion `coord/m4-state-machine`.
+
+## Owns
+
+- `Sources/App/Coordinator.swift` — verb orchestration (Plan /
+  Validate / Build / Check / Impact / Stop)
+- `Sources/Engine/**` (`BorisEngine.swift`, `BorisRunner.swift`,
+  `WatchServer.swift`, `BorisBinary.swift`) — the one `Process?` slot,
+  SIGTERM → SIGKILL teardown, zero orphaned children
+- `Sources/Chrome/MainWindow.swift` — only the verb/watch wiring this
+  card needs
+
+## Do
+
+1. Design the coordinator state machine: `idle`, `watching`,
+   `validating`, `building`, `terminating` — transitions with **zero
+   subprocess leak** (the issue's gate).
+2. Cover the live overlaps: save-triggered `validate` debounce
+   (~300 ms) racing an explicit build; `watch --serve` running while
+   Build executes (roadmap M4 gate: "Watch is paused for the build
+   lane"); hang/timeout recovery.
+3. Land the design doc with the implementation in `Coordinator` /
+   `Engine`.
+
+## Do not
+
+- Touch `Sources/Workspace/**` or `Sources/Chrome/SourceSidebar.swift`
+  ([B3-2](B3-workspace.md)).
+- Touch `scripts/embed-boris.sh`, `Project.yml`,
+  `Solipsist/Solipsist.entitlements`, `.github/workflows/*`
+  ([B3-4](B3-ship.md)).
+- Let [B3-3](B3-publish-security.md) touch `Sources/Engine/**` while
+  you own the subprocess boundary — its stdin wiring merges after this
+  card.
+
+## Gate
+
+State-machine spec covering coordinator transitions with zero
+subprocess leak. `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/B3-publish-security.md
+++ b/docs/cards/B3-publish-security.md
@@ -1,0 +1,39 @@
+# Card B3-3 — Publish credentials (Keychain + stdin)
+
+**Milestone:** M8 (Publish) · **Issue:**
+[#60](https://github.com/drawmeanelephant/solipsist/issues/60) ·
+**Lane:** publish-security · **Owner:** uncle-gravity. One worktree,
+one PR against `main`; branch suggestion `ship/publish-security`. Runs
+parallel with [B3-4](B3-ship.md).
+
+## Owns
+
+- New `Sources/Security/` module — `KeychainStore`
+  (`kSecClassGenericPassword`, per-target "Remember in Keychain"
+  toggle), ephemeral session state, zeroing `Data` / `[UInt8]` buffers
+  after the stdin write
+- `Tests/` — unit tests proving secrets reach the stdin pipe and are
+  zeroed, never persisted in app state or plaintext storage
+- The credential-lifecycle design spec (the issue's gate)
+
+## Do
+
+1. Keychain integration with an optional per-target remember toggle.
+2. Ephemeral session mode — memory-only secrets wiped immediately
+   after publication.
+3. Zero byte buffers after writing to the child process `stdin` pipe.
+
+## Do not
+
+- Touch `Sources/Engine/**` or `Sources/App/Coordinator.swift`
+  ([B3-1](B3-coordinator.md)). Build the stdin secret-writer on a
+  `SecretProviding` seam in your own module; wiring it into
+  `BorisEngine` merges after B3-1 lands.
+- Touch build files / entitlements / workflows
+  ([B3-4](B3-ship.md), same owner — keep the two PRs separate).
+
+## Gate
+
+Design spec + test case verifying secrets are written to `stdin`
+without persisting in application state or plaintext storage.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/B3-ship.md
+++ b/docs/cards/B3-ship.md
@@ -1,0 +1,44 @@
+# Card B3-4 — Ship: universal binary, sandbox, notarization
+
+**Milestone:** M9 (Ship) · **Issue:**
+[#61](https://github.com/drawmeanelephant/solipsist/issues/61) ·
+**Lane:** ship/build · **Owner:** uncle-gravity. One worktree, one PR
+against `main`; branch suggestion `ship/m9-hardening`.
+
+## Owns
+
+- `scripts/embed-boris.sh` — universal binary embedding (lipo arm64 +
+  x86_64 into `Contents/Resources/boris`), codesign identity for the
+  embedded `boris` matching the host app
+- `Project.yml` + `Solipsist/Solipsist.entitlements` — App Sandbox
+  matrix
+- New `.github/workflows/release-notarize.yml` — build →
+  `xcrun notarytool submit --wait` → `stapler staple`, credentials via
+  CI secrets
+- Ship plan doc under `docs/` (clean-Mac proof checklist)
+
+## Do
+
+1. Universal Mach-O fat binary via `scripts/embed-boris.sh`; sign the
+   embedded engine.
+2. Entitlements matrix: `app-sandbox`,
+   `files.user-selected.read-write`, `network.client` — and keep
+   `network.server` (M5 preview depends on it).
+3. Automated notarization + stapling in CI.
+4. Clean-Mac proof: no Zig, no kit folder, bundled engine only.
+
+## Do not
+
+- Touch `Sources/**` or `Tests/**` — build lane stays build-only; if a
+  Swift-side change is needed to prove the gate, file it on the issue
+  instead.
+- Drop `files.user-selected.read-write` (breaks
+  [B3-2](B3-workspace.md)) or `network.server` (breaks M5 preview).
+- Break the embed search-order contract (`SOLIPSIST_BORIS_BIN`,
+  `SKIP_EMBED_BORIS=1 make build`).
+
+## Gate
+
+Universal `Solipsist.app` runs, spawns `boris`, compiles a publication,
+passes `spctl --assess -vvv --type exec` on a fresh macOS machine.
+Local: `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/B3-workspace.md
+++ b/docs/cards/B3-workspace.md
@@ -1,0 +1,40 @@
+# Card B3-2 — Workspace bookmark persistence
+
+**Milestones:** M2 (Chassis) + M9 (Ship) · **Issue:**
+[#59](https://github.com/drawmeanelephant/solipsist/issues/59) ·
+**Lane:** workspace. One worktree, one PR against `main`; branch
+suggestion `workspace/bookmark-persistence`.
+
+## Owns
+
+- `Sources/Workspace/**` (`WorkspaceStore.swift`,
+  `Local/LocalSource.swift`, `Source.swift`, `WorkspaceSelection.swift`)
+- `Sources/Chrome/SourceSidebar.swift` — the stale-source badge
+- App-level persistence: `Sources/App/SolipsistApp.swift` (+
+  `AppRuntime.swift` as needed) — Open Recent / window restoration
+- Unit tests for the persistence round-trip + stale resolution
+
+## Do
+
+1. Persist security-scoped bookmark `Data` per source (UserDefaults);
+   resolve + `startAccessingSecurityScopedResource()` on relaunch.
+2. Stale / moved / deleted directory recovery: non-blocking sidebar
+   badge ("Unreachable — Relocate / Remove"), no crash, no frozen UI.
+3. Native Open Recent integration.
+
+## Do not
+
+- Touch `Sources/App/Coordinator.swift` or `Sources/Engine/**`
+  ([B3-1](B3-coordinator.md)).
+- Restructure `MainWindow.swift`; the badge lives in
+  `SourceSidebar.swift`.
+- Edit `scripts/embed-boris.sh`, `Project.yml`, or
+  `Solipsist/Solipsist.entitlements` ([B3-4](B3-ship.md)) — if the
+  sandbox blocks `startAccessingSecurityScopedResource`, file the
+  finding on #61 instead.
+
+## Gate
+
+Add source folder → restart app → source remains loaded and
+accessible; deleted folder → non-blocking stale warning.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -17,6 +17,27 @@ These cards win on *what to do now*; those docs win on *what we are*.
 | [M3-inspector](M3-inspector.md) | `Sources/Inspector/`, `Chrome/InspectorDrawer.swift` | P, M3-play, M4 (do not edit `Models/`) | select a page → drawer shows fields; profile writes `boris.json` |
 | [ISSUES-file](ISSUES-file-A1-A14-A7.md) | `docs/issues/` | everything | A1, A14, A7 pasted when GitHub is back |
 
+## Batch 3 (production readiness)
+
+From the roadmap audit — issues
+[#58](https://github.com/drawmeanelephant/solipsist/issues/58) –
+[#61](https://github.com/drawmeanelephant/solipsist/issues/61). These
+own grind-lane paths (`Engine/`, `Coordinator.swift`, `Workspace/`,
+`embed-boris.sh`), so they are **not** queue cards; one card = one
+worktree = one PR. Dispatch is recorded in the comments on each issue.
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [B3-1](B3-coordinator.md) | #58 | coordinator (grind) | B3-2, B3-3, B3-4 | state-machine spec, zero subprocess leak |
+| [B3-2](B3-workspace.md) | #59 | workspace | B3-1, B3-3, B3-4 | restart → source persists; stale → non-blocking warning |
+| [B3-3](B3-publish-security.md) | #60 | publish-security (uncle-gravity) | B3-1, B3-2, B3-4 | secrets on stdin, zeroed, never persisted |
+| [B3-4](B3-ship.md) | #61 | ship/build (uncle-gravity) | B3-1, B3-2, B3-3 | universal app spawns boris, `spctl` clean |
+
+Sequencing: `Sources/Engine/**` is single-owner under B3-1; B3-3's
+stdin wiring merges after B3-1. B3-4 must keep
+`files.user-selected.read-write` (B3-2) and `network.server` (M5
+preview) in the entitlements matrix.
+
 ## Do not start yet
 
 Preview companion, Editor companion, GitHub-as-source, publication

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -62,4 +62,7 @@ Status legend: **open** · **in flight** (PR open) · **done** (merged — do no
 |----|------|-----|
 | Q14 | statusbar-exit-color | Owns `Sources/Chrome/MainWindow.swift`, which is on this queue's own forbidden list. Grind lane owns the status bar — do not pick. |
 
-No open batch-2 cards remain — batch 2 is fully landed. Check batch 3 in the issue tracker before picking.
+No open batch-2 cards remain — batch 2 is fully landed. Batch 3
+lives in the issue tracker (#58–#61; briefs in
+`docs/cards/B3-*.md`) — those own grind-lane paths, so they are not
+queue cards.


### PR DESCRIPTION
Records the batch-3 dispatch from the roadmap audit. Adds four card
briefs under `docs/cards/` mirroring the ownership comments posted on
the issues, and registers them on the cards board.

- `docs/cards/B3-coordinator.md` — subprocess lifecycle state machine (coordinator lane for #58)
- `docs/cards/B3-workspace.md` — bookmark persistence + stale recovery (#59)
- `docs/cards/B3-publish-security.md` — Keychain + stdin secrets (#60, uncle-gravity)
- `docs/cards/B3-ship.md` — universal binary, sandbox, notarization (#61, uncle-gravity)
- `docs/cards/README.md` — Batch 3 board section with lanes, parallelism, and merge sequencing
- `docs/cards/queue/README.md` — pointer from batch 2 to the batch-3 cards

Sequencing notes: `Sources/Engine/**` is single-owner under B3-1;
B3-3's stdin wiring merges after B3-1. B3-4 keeps
`files.user-selected.read-write` (B3-2) and `network.server` (M5
preview) in the entitlements matrix.
