### PR TITLE
feat(publish): Keychain integration, ephemeral secret handling, and zeroing stdin writer (#60)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -21,6 +21,7 @@ settings:
     CODE_SIGN_STYLE: Manual
     CODE_SIGN_IDENTITY: "-"
     ENABLE_HARDENED_RUNTIME: YES
+    ENABLE_USER_SCRIPT_SANDBOXING: NO
 
 targets:
   Solipsist:
@@ -35,6 +36,7 @@ targets:
       - path: Sources/Companions
       - path: Sources/Models
       - path: Sources/Engine
+      - path: Sources/Security
       - path: Solipsist/Assets.xcassets
       - path: docs/help.md
         buildPhase: resources
@@ -62,7 +64,7 @@ targets:
         basedOnDependencyAnalysis: false
         script: |
           set -euo pipefail
-          "${SRCROOT}/scripts/embed-boris.sh" "${SRCROOT}" "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+          /bin/bash "${SRCROOT}/scripts/embed-boris.sh" "${SRCROOT}" "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 
   # M1 engine spike: a headless CLI that runs the bundled boris binary and
   # decodes its JSON contracts. Shares Sources/Models and Sources/Engine
@@ -87,6 +89,7 @@ targets:
       - path: Tests/Fixtures
         type: folder
       - path: Sources/Models
+      - path: Sources/Security
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Sources/Companions/Preview/PreviewURL.swift
     settings:

--- a/Sources/Security/EphemeralSecretStore.swift
+++ b/Sources/Security/EphemeralSecretStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Protocol defining in-memory ephemeral secret storage.
+public protocol EphemeralSecretStoring: Sendable {
+    func storeSecret(_ secret: SecureBuffer, for target: String)
+    func loadSecret(for target: String) -> SecureBuffer?
+    func consumeSecret(for target: String) -> SecureBuffer?
+    func deleteSecret(for target: String)
+    func hasSecret(for target: String) -> Bool
+    func wipeAll()
+}
+
+/// In-memory, thread-safe ephemeral secret store for publish sessions.
+/// Secrets stored here are never written to disk or Keychain, and are wiped when the session ends.
+public final class EphemeralSecretStore: EphemeralSecretStoring, @unchecked Sendable {
+    private var secrets: [String: SecureBuffer] = [:]
+    private let lock = NSLock()
+
+    public init() {}
+
+    deinit {
+        wipeAll()
+    }
+
+    public func storeSecret(_ secret: SecureBuffer, for target: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        // If an existing secret exists for this target, wipe it before replacing
+        secrets[target]?.wipe()
+        secrets[target] = secret
+    }
+
+    public func loadSecret(for target: String) -> SecureBuffer? {
+        lock.lock()
+        defer { lock.unlock() }
+        return secrets[target]
+    }
+
+    public func consumeSecret(for target: String) -> SecureBuffer? {
+        lock.lock()
+        defer { lock.unlock() }
+        return secrets.removeValue(forKey: target)
+    }
+
+    public func deleteSecret(for target: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = secrets.removeValue(forKey: target) {
+            existing.wipe()
+        }
+    }
+
+    public func hasSecret(for target: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let secret = secrets[target] else { return false }
+        return !secret.isEmpty
+    }
+
+    public func wipeAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        for (_, secret) in secrets {
+            secret.wipe()
+        }
+        secrets.removeAll()
+    }
+}

--- a/Sources/Security/KeychainStore.swift
+++ b/Sources/Security/KeychainStore.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Security
+
+/// Errors encountered during macOS Keychain operations.
+public enum KeychainError: Error, Equatable, Sendable {
+    case duplicateItem
+    case itemNotFound
+    case unhandledError(status: OSStatus)
+    case unexpectedDataFormat
+}
+
+/// Protocol defining macOS Keychain storage operations for publish credentials.
+public protocol KeychainStoring: Sendable {
+    func saveSecret(_ secret: SecureBuffer, account: String, service: String) throws
+    func loadSecret(account: String, service: String) throws -> SecureBuffer?
+    func deleteSecret(account: String, service: String) throws
+    func hasSecret(account: String, service: String) -> Bool
+}
+
+extension KeychainStoring {
+    public func saveSecret(_ secret: SecureBuffer, account: String) throws {
+        try saveSecret(secret, account: account, service: KeychainStore.defaultService)
+    }
+
+    public func loadSecret(account: String) throws -> SecureBuffer? {
+        try loadSecret(account: account, service: KeychainStore.defaultService)
+    }
+
+    public func deleteSecret(account: String) throws {
+        try deleteSecret(account: account, service: KeychainStore.defaultService)
+    }
+
+    public func hasSecret(account: String) -> Bool {
+        hasSecret(account: account, service: KeychainStore.defaultService)
+    }
+}
+
+/// Production Keychain store using `kSecClassGenericPassword`.
+public final class KeychainStore: KeychainStoring {
+    public static let defaultService = "dev.drawmeanelephant.solipsist"
+
+    public let defaultTargetService: String
+
+    public init(defaultTargetService: String = KeychainStore.defaultService) {
+        self.defaultTargetService = defaultTargetService
+    }
+
+    public func saveSecret(_ secret: SecureBuffer, account: String, service: String) throws {
+        let secretData: Data = secret.withUnsafeBytes { raw in
+            Data(raw)
+        } ?? Data()
+
+        // Check if item already exists
+        if hasSecret(account: account, service: service) {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: account,
+            ]
+            let attributesToUpdate: [String: Any] = [
+                kSecValueData as String: secretData,
+            ]
+            let status = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
+            guard status == errSecSuccess else {
+                throw KeychainError.unhandledError(status: status)
+            }
+        } else {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: account,
+                kSecValueData as String: secretData,
+            ]
+            let status = SecItemAdd(query as CFDictionary, nil)
+            guard status == errSecSuccess else {
+                if status == errSecDuplicateItem {
+                    throw KeychainError.duplicateItem
+                }
+                throw KeychainError.unhandledError(status: status)
+            }
+        }
+    }
+
+    public func loadSecret(account: String, service: String) throws -> SecureBuffer? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        guard status != errSecItemNotFound else {
+            return nil
+        }
+        guard status == errSecSuccess else {
+            throw KeychainError.unhandledError(status: status)
+        }
+        guard let data = item as? Data else {
+            throw KeychainError.unexpectedDataFormat
+        }
+
+        return SecureBuffer(data: data)
+    }
+
+    public func deleteSecret(account: String, service: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unhandledError(status: status)
+        }
+    }
+
+    public func hasSecret(account: String, service: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+}

--- a/Sources/Security/KeychainStore.swift
+++ b/Sources/Security/KeychainStore.swift
@@ -17,20 +17,20 @@ public protocol KeychainStoring: Sendable {
     func hasSecret(account: String, service: String) -> Bool
 }
 
-extension KeychainStoring {
-    public func saveSecret(_ secret: SecureBuffer, account: String) throws {
+public extension KeychainStoring {
+    func saveSecret(_ secret: SecureBuffer, account: String) throws {
         try saveSecret(secret, account: account, service: KeychainStore.defaultService)
     }
 
-    public func loadSecret(account: String) throws -> SecureBuffer? {
+    func loadSecret(account: String) throws -> SecureBuffer? {
         try loadSecret(account: account, service: KeychainStore.defaultService)
     }
 
-    public func deleteSecret(account: String) throws {
+    func deleteSecret(account: String) throws {
         try deleteSecret(account: account, service: KeychainStore.defaultService)
     }
 
-    public func hasSecret(account: String) -> Bool {
+    func hasSecret(account: String) -> Bool {
         hasSecret(account: account, service: KeychainStore.defaultService)
     }
 }

--- a/Sources/Security/PublishCredentialManager.swift
+++ b/Sources/Security/PublishCredentialManager.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Unified manager handling the lifecycle of publishing credentials between
+/// macOS Keychain (for persistent storage) and EphemeralSecretStore (for session-only memory).
+public final class PublishCredentialManager: SecretProviding, @unchecked Sendable {
+    public let keychain: KeychainStoring
+    public let ephemeral: EphemeralSecretStoring
+    public let service: String
+
+    public init(
+        keychain: KeychainStoring = KeychainStore(),
+        ephemeral: EphemeralSecretStoring = EphemeralSecretStore(),
+        service: String = KeychainStore.defaultService
+    ) {
+        self.keychain = keychain
+        self.ephemeral = ephemeral
+        self.service = service
+    }
+
+    /// Sets the credential for a publishing target.
+    ///
+    /// - Parameters:
+    ///   - secret: The secret buffer.
+    ///   - target: The publishing target identifier (e.g. `PublishTargets.standardSite` or `PublishTargets.nostr`).
+    ///   - rememberInKeychain: If `true`, saves into macOS Keychain. If `false`, stores in-memory only and deletes any prior Keychain item.
+    public func setCredential(
+        _ secret: SecureBuffer,
+        for target: String,
+        rememberInKeychain: Bool
+    ) throws {
+        if rememberInKeychain {
+            ephemeral.deleteSecret(for: target)
+            try keychain.saveSecret(secret, account: target, service: service)
+        } else {
+            try? keychain.deleteSecret(account: target, service: service)
+            ephemeral.storeSecret(secret, for: target)
+        }
+    }
+
+    /// Retrieves the secret for the target, checking ephemeral memory first, then Keychain.
+    public func provideSecret(for target: String) -> SecureBuffer? {
+        if let ephemeralSecret = ephemeral.loadSecret(for: target) {
+            return ephemeralSecret
+        }
+        if let keychainSecret = try? keychain.loadSecret(account: target, service: service) {
+            return keychainSecret
+        }
+        return nil
+    }
+
+    /// Checks if a credential is saved in the macOS Keychain for the target.
+    public func isRemembered(for target: String) -> Bool {
+        keychain.hasSecret(account: target, service: service)
+    }
+
+    /// Clears any credential stored in both ephemeral memory and Keychain for the target.
+    public func clearCredential(for target: String) throws {
+        ephemeral.deleteSecret(for: target)
+        try keychain.deleteSecret(account: target, service: service)
+    }
+
+    /// Clears all session secrets from memory.
+    public func wipeAllEphemeral() {
+        ephemeral.wipeAll()
+    }
+}

--- a/Sources/Security/SecretProviding.swift
+++ b/Sources/Security/SecretProviding.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Known publishing targets requiring secret resolution.
+public enum PublishTargets {
+    public static let standardSite = "standard.site"
+    public static let nostr = "nostr"
+    public static let githubPages = "github.pages"
+}
+
+/// A seam protocol for vending secrets to publishing commands without exposing store implementations.
+public protocol SecretProviding: Sendable {
+    /// Provides the secret for the given target, if available.
+    func provideSecret(for target: String) -> SecureBuffer?
+}

--- a/Sources/Security/SecureBuffer.swift
+++ b/Sources/Security/SecureBuffer.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// A fixed-capacity byte buffer for holding sensitive secrets in memory.
+///
+/// Ensures memory is zeroed out immediately upon deallocation or when `wipe()` is explicitly called.
+/// Implements `CustomStringConvertible` and `CustomDebugStringConvertible` to prevent accidental
+/// secret exposure through string interpolation or logging.
+public final class SecureBuffer: @unchecked Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+    private var buffer: UnsafeMutableRawBufferPointer?
+    private let lock = NSLock()
+
+    /// The number of valid bytes stored in this buffer.
+    public private(set) var count: Int
+
+    /// Whether this buffer is empty (has 0 bytes or has been wiped).
+    public var isEmpty: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return count == 0 || buffer == nil
+    }
+
+    /// Initializes a `SecureBuffer` by copying the given bytes.
+    public init(bytes: [UInt8]) {
+        self.count = bytes.count
+        if bytes.isEmpty {
+            self.buffer = nil
+        } else {
+            let ptr = UnsafeMutableRawBufferPointer.allocate(byteCount: bytes.count, alignment: 1)
+            bytes.withUnsafeBytes { src in
+                ptr.copyMemory(from: src)
+            }
+            self.buffer = ptr
+        }
+    }
+
+    /// Initializes a `SecureBuffer` from `Data`.
+    public convenience init(data: Data) {
+        let bytes = [UInt8](data)
+        self.init(bytes: bytes)
+    }
+
+    /// Initializes a `SecureBuffer` from a UTF-8 string.
+    public convenience init(utf8String string: String) {
+        let bytes = Array(string.utf8)
+        self.init(bytes: bytes)
+    }
+
+    deinit {
+        wipe()
+    }
+
+    /// Accesses the underlying bytes in a closure.
+    /// Returns `nil` if the buffer is empty or already wiped.
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let buffer, count > 0 else {
+            return nil
+        }
+        return try body(UnsafeRawBufferPointer(buffer))
+    }
+
+    /// Returns a copy of the secret bytes as an array.
+    /// Callers are responsible for wiping their own copy.
+    public func copyBytes() -> [UInt8] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let buffer, count > 0 else { return [] }
+        return Array(buffer)
+    }
+
+    /// Explicitly overwrites memory with zeroes and deallocates the buffer.
+    public func wipe() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let buf = buffer else { return }
+        
+        // Zero the memory buffer using memset_s when available or explicit volatile zeroing
+        #if canImport(Darwin)
+        memset_s(buf.baseAddress, buf.count, 0, buf.count)
+        #else
+        if let base = buf.baseAddress {
+            base.initializeMemory(as: UInt8.self, repeating: 0, count: buf.count)
+        }
+        #endif
+        
+        buf.deallocate()
+        self.buffer = nil
+        self.count = 0
+    }
+
+    // MARK: - Redaction
+
+    public var description: String {
+        "<SecureBuffer count=\(count)>"
+    }
+
+    public var debugDescription: String {
+        "<SecureBuffer count=\(count)>"
+    }
+}

--- a/Sources/Security/SecureBuffer.swift
+++ b/Sources/Security/SecureBuffer.swift
@@ -74,16 +74,16 @@ public final class SecureBuffer: @unchecked Sendable, CustomStringConvertible, C
         lock.lock()
         defer { lock.unlock() }
         guard let buf = buffer else { return }
-        
+
         // Zero the memory buffer using memset_s when available or explicit volatile zeroing
         #if canImport(Darwin)
-        memset_s(buf.baseAddress, buf.count, 0, buf.count)
+            memset_s(buf.baseAddress, buf.count, 0, buf.count)
         #else
-        if let base = buf.baseAddress {
-            base.initializeMemory(as: UInt8.self, repeating: 0, count: buf.count)
-        }
+            if let base = buf.baseAddress {
+                base.initializeMemory(as: UInt8.self, repeating: 0, count: buf.count)
+            }
         #endif
-        
+
         buf.deallocate()
         self.buffer = nil
         self.count = 0

--- a/Sources/Security/StdinSecretWriter.swift
+++ b/Sources/Security/StdinSecretWriter.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Errors that can occur when streaming secrets to stdin.
+public enum StdinSecretWriterError: Error, Equatable, Sendable {
+    case emptySecret
+    case writeFailed(String)
+}
+
+/// Utility for safely streaming secrets to a child process stdin `FileHandle` / pipe.
+///
+/// Ensures secrets are written directly without intermediate logging, string allocation,
+/// or persistence, and immediately flushes and signals EOF if configured.
+public enum StdinSecretWriter {
+
+    /// Writes the contents of `secret` to the given file handle.
+    ///
+    /// - Parameters:
+    ///   - secret: The secret buffer to write.
+    ///   - handle: The write handle (e.g. write end of child process stdin pipe).
+    ///   - appendNewline: Whether to append a newline byte (`0x0A`) after writing the secret. Defaults to `true`.
+    ///   - closeAfterWriting: Whether to close the file handle after writing to signal EOF. Defaults to `true`.
+    public static func writeSecret(
+        _ secret: SecureBuffer,
+        to handle: FileHandle,
+        appendNewline: Bool = true,
+        closeAfterWriting: Bool = true
+    ) throws {
+        guard !secret.isEmpty else {
+            throw StdinSecretWriterError.emptySecret
+        }
+
+        try secret.withUnsafeBytes { rawBytes in
+            guard let baseAddress = rawBytes.baseAddress, rawBytes.count > 0 else {
+                throw StdinSecretWriterError.emptySecret
+            }
+
+            let fd = handle.fileDescriptor
+            var bytesWritten = 0
+            let totalBytes = rawBytes.count
+
+            while bytesWritten < totalBytes {
+                let chunkPtr = baseAddress.advanced(by: bytesWritten)
+                let remaining = totalBytes - bytesWritten
+                let result = write(fd, chunkPtr, remaining)
+                if result < 0 {
+                    let err = errno
+                    throw StdinSecretWriterError.writeFailed("POSIX write failed with errno: \(err)")
+                }
+                bytesWritten += result
+            }
+
+            if appendNewline {
+                var newlineByte: UInt8 = 0x0A
+                _ = withUnsafeBytes(of: &newlineByte) { nlPtr in
+                    write(fd, nlPtr.baseAddress, 1)
+                }
+            }
+        }
+
+        if closeAfterWriting {
+            do {
+                try handle.close()
+            } catch {
+                throw StdinSecretWriterError.writeFailed("Failed to close file handle: \(error)")
+            }
+        }
+    }
+
+    /// Writes the secret to `handle` and immediately calls `wipe()` on the `secret` buffer.
+    public static func writeAndWipe(
+        _ secret: SecureBuffer,
+        to handle: FileHandle,
+        appendNewline: Bool = true,
+        closeAfterWriting: Bool = true
+    ) throws {
+        defer {
+            secret.wipe()
+        }
+        try writeSecret(
+            secret,
+            to: handle,
+            appendNewline: appendNewline,
+            closeAfterWriting: closeAfterWriting
+        )
+    }
+}

--- a/Sources/Security/StdinSecretWriter.swift
+++ b/Sources/Security/StdinSecretWriter.swift
@@ -11,7 +11,6 @@ public enum StdinSecretWriterError: Error, Equatable, Sendable {
 /// Ensures secrets are written directly without intermediate logging, string allocation,
 /// or persistence, and immediately flushes and signals EOF if configured.
 public enum StdinSecretWriter {
-
     /// Writes the contents of `secret` to the given file handle.
     ///
     /// - Parameters:
@@ -34,14 +33,14 @@ public enum StdinSecretWriter {
                 throw StdinSecretWriterError.emptySecret
             }
 
-            let fd = handle.fileDescriptor
+            let descriptor = handle.fileDescriptor
             var bytesWritten = 0
             let totalBytes = rawBytes.count
 
             while bytesWritten < totalBytes {
                 let chunkPtr = baseAddress.advanced(by: bytesWritten)
                 let remaining = totalBytes - bytesWritten
-                let result = write(fd, chunkPtr, remaining)
+                let result = write(descriptor, chunkPtr, remaining)
                 if result < 0 {
                     let err = errno
                     throw StdinSecretWriterError.writeFailed("POSIX write failed with errno: \(err)")
@@ -52,7 +51,7 @@ public enum StdinSecretWriter {
             if appendNewline {
                 var newlineByte: UInt8 = 0x0A
                 _ = withUnsafeBytes(of: &newlineByte) { nlPtr in
-                    write(fd, nlPtr.baseAddress, 1)
+                    write(descriptor, nlPtr.baseAddress, 1)
                 }
             }
         }

--- a/Tests/ContractTests/SecurityTests.swift
+++ b/Tests/ContractTests/SecurityTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import XCTest
+
+final class MockKeychainStore: KeychainStoring, @unchecked Sendable {
+    var storage: [String: [UInt8]] = [:]
+    var throwError: KeychainError?
+
+    func saveSecret(_ secret: SecureBuffer, account: String, service: String) throws {
+        if let err = throwError { throw err }
+        storage["\(service):\(account)"] = secret.copyBytes()
+    }
+
+    func loadSecret(account: String, service: String) throws -> SecureBuffer? {
+        if let err = throwError { throw err }
+        guard let bytes = storage["\(service):\(account)"] else { return nil }
+        return SecureBuffer(bytes: bytes)
+    }
+
+    func deleteSecret(account: String, service: String) throws {
+        if let err = throwError { throw err }
+        storage.removeValue(forKey: "\(service):\(account)")
+    }
+
+    func hasSecret(account: String, service: String) -> Bool {
+        storage["\(service):\(account)"] != nil
+    }
+}
+
+final class SecurityTests: XCTestCase {
+
+    // MARK: - SecureBuffer Tests
+
+    func testSecureBufferLifecycleAndZeroing() {
+        let secretText = "super-secret-password-xyz"
+        let buffer = SecureBuffer(utf8String: secretText)
+
+        XCTAssertFalse(buffer.isEmpty)
+        XCTAssertEqual(buffer.count, secretText.utf8.count)
+
+        // Verify description redaction
+        XCTAssertFalse(buffer.description.contains(secretText))
+        XCTAssertEqual(buffer.description, "<SecureBuffer count=\(secretText.utf8.count)>")
+        XCTAssertEqual(buffer.debugDescription, "<SecureBuffer count=\(secretText.utf8.count)>")
+
+        // Verify byte reading
+        let bytes = buffer.copyBytes()
+        XCTAssertEqual(String(decoding: bytes, as: UTF8.self), secretText)
+
+        // Verify wipe
+        buffer.wipe()
+        XCTAssertTrue(buffer.isEmpty)
+        XCTAssertEqual(buffer.count, 0)
+        XCTAssertEqual(buffer.copyBytes(), [])
+    }
+
+    func testEmptySecureBuffer() {
+        let empty = SecureBuffer(bytes: [])
+        XCTAssertTrue(empty.isEmpty)
+        XCTAssertEqual(empty.count, 0)
+        XCTAssertEqual(empty.copyBytes(), [])
+    }
+
+    // MARK: - EphemeralSecretStore Tests
+
+    func testEphemeralSecretStoreLifecycle() {
+        let store = EphemeralSecretStore()
+        let secret1 = SecureBuffer(utf8String: "nostr-nsec12345")
+        let target = PublishTargets.nostr
+
+        store.storeSecret(secret1, for: target)
+        XCTAssertTrue(store.hasSecret(for: target))
+
+        let retrieved = store.loadSecret(for: target)
+        XCTAssertNotNil(retrieved)
+        XCTAssertEqual(retrieved?.copyBytes(), Array("nostr-nsec12345".utf8))
+
+        // Consume removes from store
+        let consumed = store.consumeSecret(for: target)
+        XCTAssertNotNil(consumed)
+        XCTAssertFalse(store.hasSecret(for: target))
+        XCTAssertNil(store.loadSecret(for: target))
+
+        // Replace wipes old secret
+        let secA = SecureBuffer(utf8String: "token-AAA")
+        let secB = SecureBuffer(utf8String: "token-BBB")
+        store.storeSecret(secA, for: PublishTargets.standardSite)
+        store.storeSecret(secB, for: PublishTargets.standardSite)
+        XCTAssertTrue(secA.isEmpty) // Previous was wiped
+        XCTAssertFalse(secB.isEmpty)
+
+        // WipeAll clears and wipes everything
+        store.wipeAll()
+        XCTAssertFalse(store.hasSecret(for: PublishTargets.standardSite))
+        XCTAssertTrue(secB.isEmpty)
+    }
+
+    // MARK: - StdinSecretWriter Tests
+
+    func testStdinSecretWriterStreamsToPipe() throws {
+        let pipe = Pipe()
+        let secret = SecureBuffer(utf8String: "nsec1secretpayload999")
+
+        try StdinSecretWriter.writeSecret(
+            secret,
+            to: pipe.fileHandleForWriting,
+            appendNewline: true,
+            closeAfterWriting: true
+        )
+
+        let readData = pipe.fileHandleForReading.readDataToEndOfFile()
+        let receivedText = String(decoding: readData, as: UTF8.self)
+        XCTAssertEqual(receivedText, "nsec1secretpayload999\n")
+    }
+
+    func testStdinSecretWriterWriteAndWipe() throws {
+        let pipe = Pipe()
+        let secret = SecureBuffer(utf8String: "app-password-token-abc")
+
+        try StdinSecretWriter.writeAndWipe(
+            secret,
+            to: pipe.fileHandleForWriting,
+            appendNewline: false,
+            closeAfterWriting: true
+        )
+
+        let readData = pipe.fileHandleForReading.readDataToEndOfFile()
+        let receivedText = String(decoding: readData, as: UTF8.self)
+        XCTAssertEqual(receivedText, "app-password-token-abc")
+
+        // Assert that the source secret buffer was wiped
+        XCTAssertTrue(secret.isEmpty)
+        XCTAssertEqual(secret.count, 0)
+    }
+
+    func testStdinSecretWriterEmptyThrows() {
+        let pipe = Pipe()
+        let emptySecret = SecureBuffer(bytes: [])
+
+        XCTAssertThrowsError(
+            try StdinSecretWriter.writeSecret(emptySecret, to: pipe.fileHandleForWriting)
+        ) { error in
+            XCTAssertEqual(error as? StdinSecretWriterError, .emptySecret)
+        }
+    }
+
+    // MARK: - PublishCredentialManager Tests
+
+    func testPublishCredentialManagerRememberToggle() throws {
+        let mockKeychain = MockKeychainStore()
+        let mockEphemeral = EphemeralSecretStore()
+        let manager = PublishCredentialManager(
+            keychain: mockKeychain,
+            ephemeral: mockEphemeral,
+            service: "test.service"
+        )
+
+        let secret = SecureBuffer(utf8String: "nostr-privkey-demo")
+
+        // 1. Remember in Keychain = true
+        try manager.setCredential(secret, for: PublishTargets.nostr, rememberInKeychain: true)
+        XCTAssertTrue(manager.isRemembered(for: PublishTargets.nostr))
+        XCTAssertFalse(mockEphemeral.hasSecret(for: PublishTargets.nostr))
+
+        let resolved = manager.provideSecret(for: PublishTargets.nostr)
+        XCTAssertNotNil(resolved)
+        XCTAssertEqual(resolved?.copyBytes(), Array("nostr-privkey-demo".utf8))
+
+        // 2. Remember in Keychain = false (switch to ephemeral)
+        let sessionSecret = SecureBuffer(utf8String: "session-only-token")
+        try manager.setCredential(sessionSecret, for: PublishTargets.standardSite, rememberInKeychain: false)
+        XCTAssertFalse(manager.isRemembered(for: PublishTargets.standardSite))
+        XCTAssertTrue(mockEphemeral.hasSecret(for: PublishTargets.standardSite))
+
+        let standardResolved = manager.provideSecret(for: PublishTargets.standardSite)
+        XCTAssertNotNil(standardResolved)
+        XCTAssertEqual(standardResolved?.copyBytes(), Array("session-only-token".utf8))
+
+        // 3. Clear credential
+        try manager.clearCredential(for: PublishTargets.nostr)
+        XCTAssertFalse(manager.isRemembered(for: PublishTargets.nostr))
+        XCTAssertNil(manager.provideSecret(for: PublishTargets.nostr))
+
+        // 4. Wipe all ephemeral
+        manager.wipeAllEphemeral()
+        XCTAssertNil(manager.provideSecret(for: PublishTargets.standardSite))
+    }
+}

--- a/Tests/ContractTests/SecurityTests.swift
+++ b/Tests/ContractTests/SecurityTests.swift
@@ -27,7 +27,6 @@ final class MockKeychainStore: KeychainStoring, @unchecked Sendable {
 }
 
 final class SecurityTests: XCTestCase {
-
     // MARK: - SecureBuffer Tests
 
     func testSecureBufferLifecycleAndZeroing() {
@@ -44,7 +43,7 @@ final class SecurityTests: XCTestCase {
 
         // Verify byte reading
         let bytes = buffer.copyBytes()
-        XCTAssertEqual(String(decoding: bytes, as: UTF8.self), secretText)
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), secretText)
 
         // Verify wipe
         buffer.wipe()
@@ -108,7 +107,7 @@ final class SecurityTests: XCTestCase {
         )
 
         let readData = pipe.fileHandleForReading.readDataToEndOfFile()
-        let receivedText = String(decoding: readData, as: UTF8.self)
+        let receivedText = String(data: readData, encoding: .utf8)
         XCTAssertEqual(receivedText, "nsec1secretpayload999\n")
     }
 
@@ -124,7 +123,7 @@ final class SecurityTests: XCTestCase {
         )
 
         let readData = pipe.fileHandleForReading.readDataToEndOfFile()
-        let receivedText = String(decoding: readData, as: UTF8.self)
+        let receivedText = String(data: readData, encoding: .utf8)
         XCTAssertEqual(receivedText, "app-password-token-abc")
 
         // Assert that the source secret buffer was wiped

--- a/docs/CREDENTIAL-LIFECYCLE.md
+++ b/docs/CREDENTIAL-LIFECYCLE.md
@@ -1,0 +1,147 @@
+# Publish Credential Lifecycle & Security Design Specification
+
+**Status:** Approved Design Spec (Issue #60 / Roadmap M8 Publish)  
+**Author:** draw me an elephant / uncle-gravity  
+**Target:** macOS App Sandbox / Boris Publishing Targets  
+
+---
+
+## 1. Executive Summary & Security Posture
+
+Solipsist is a native macOS workstation that coordinates and broadcasts Boris publications. In **M8 (Publish)**, Solipsist invokes publication flows for:
+1. **Standard.site**: OAuth tokens / App passwords.
+2. **Nostr**: Private relay signing keys via `--key-stdin`.
+3. **GitHub Pages**: Boris-owned workflow evidence inspection.
+
+### The Zero-Leak Invariant
+Secrets (API tokens, private keys, passwords) **must never**:
+- Appear in process arguments (`argv` / `Process.arguments`).
+- Appear in process environment variables (`env` / `Process.environment`).
+- Be logged to stdout, stderr, system logs (`os_log`), or crash dumps.
+- Be persisted to insecure application storage (e.g. `UserDefaults`, `Info.plist`, or unencrypted files).
+- Remain in heap memory after use.
+
+All secrets provided to child compiler processes are streamed strictly over **ephemeral stdin pipes** and wiped from memory immediately upon completion of the write.
+
+---
+
+## 2. Threat Model & Boundaries
+
+| Threat Vector | Mitigation |
+|---|---|
+| **Process Inspection (`ps`, `pgrep`, `top`)** | Secrets are never passed in `argv` or command-line flags. Boris CLI reads keys via `--key-stdin`. |
+| **Environment Variable Snooping** | Secrets are never injected into child process `environment` dictionaries. |
+| **Crash Dumps & Core Memory Leaks** | Secrets are held in heap-allocated `SecureBuffer` instances that explicitly zero memory on deallocation using `memset_s`. String interpolation is redacted via `CustomStringConvertible`. |
+| **Disk Forensics / Unencrypted Configs** | No plaintext keys are written to workspace metadata, `.plist` files, or cache directories. Long-term persistence is restricted exclusively to Apple's Secure Enclave / macOS Keychain (`kSecClassGenericPassword`). |
+| **Shoulder Surfing / Unintended Persistence** | "Remember in Keychain" is an explicit user opt-in toggle per target. Default mode is **Ephemeral Session Mode** (memory-only, wiped on quit or publish completion). |
+
+---
+
+## 3. Credential Lifecycle Architecture
+
+```
+                                 ┌───────────────────────────┐
+                                 │     User Input Prompt     │
+                                 │  (Standard.site / Nostr)  │
+                                 └─────────────┬─────────────┘
+                                               │
+                                 ┌─────────────▼─────────────┐
+                                 │       SecureBuffer        │
+                                 │ (Fixed-capacity [UInt8])  │
+                                 └─────────────┬─────────────┘
+                                               │
+                    ┌──────────────────────────┴──────────────────────────┐
+                    │                                                     │
+   [Remember in Keychain = true]                         [Remember in Keychain = false]
+                    │                                                     │
+                    ▼                                                     ▼
+     ┌─────────────────────────────┐                       ┌─────────────────────────────┐
+     │      macOS Keychain         │                       │    EphemeralSecretStore     │
+     │ (kSecClassGenericPassword)  │                       │   (In-Memory Thread-Safe)   │
+     └──────────────┬──────────────┘                       └──────────────┬──────────────┘
+                    │                                                     │
+                    └──────────────────────────┬──────────────────────────┘
+                                               │
+                                               ▼
+                                 ┌───────────────────────────┐
+                                 │     SecretProviding       │
+                                 │      (Seam Contract)      │
+                                 └─────────────┬─────────────┘
+                                               │
+                                               ▼
+                                 ┌───────────────────────────┐
+                                 │    StdinSecretWriter      │
+                                 │  • Streams to stdin pipe  │
+                                 │  • Flushes & closes (EOF) │
+                                 │  • Wipes buffer in memory │
+                                 └─────────────┬─────────────┘
+                                               │
+                                               ▼
+                                 ┌───────────────────────────┐
+                                 │   Boris Child Process     │
+                                 │ (Reads stdin, e.g. Nostr) │
+                                 └───────────────────────────┘
+```
+
+---
+
+## 4. Components & Responsibilities
+
+### 4.1. `SecureBuffer` (`Sources/Security/SecureBuffer.swift`)
+- Holds raw byte sequences (`[UInt8]`) allocated in memory.
+- Implements `CustomStringConvertible` / `CustomDebugStringConvertible` returning `<SecureBuffer count=N>` to prevent accidental logging.
+- Uses `memset_s` on Darwin to guarantee memory is overwritten with zeros upon `deinit` or explicit `wipe()`, preventing compiler dead-store elimination.
+
+### 4.2. `KeychainStore` (`Sources/Security/KeychainStore.swift`)
+- Wraps Apple `Security.framework` generic password APIs (`kSecClassGenericPassword`).
+- Uses service name `dev.drawmeanelephant.solipsist` and account name matching target identifier (e.g. `nostr`, `standard.site`).
+- Protected by macOS App Sandbox entitlements.
+
+### 4.3. `EphemeralSecretStore` (`Sources/Security/EphemeralSecretStore.swift`)
+- In-memory thread-safe dictionary holding `SecureBuffer` items.
+- Supports `consumeSecret(for:)` which retrieves and immediately removes the item from the dictionary.
+- Supports `wipeAll()` which explicitly zeroes every active buffer and clears the dictionary on session end or app termination.
+
+### 4.4. `StdinSecretWriter` (`Sources/Security/StdinSecretWriter.swift`)
+- Writes bytes directly to the child process's `standardInput` file handle via POSIX `write()`.
+- Appends trailing newline (`0x0A`) for line-oriented stdin parsers.
+- Closes the write descriptor to send `EOF` so the child process completes reading immediately.
+- Invokes `wipe()` on the buffer immediately after transmission.
+
+### 4.5. `PublishCredentialManager` (`Sources/Security/PublishCredentialManager.swift`)
+- Orchestrates between `KeychainStore` and `EphemeralSecretStore`.
+- Implements `SecretProviding` protocol seam:
+  ```swift
+  public protocol SecretProviding: Sendable {
+      func provideSecret(for target: String) -> SecureBuffer?
+  }
+  ```
+- When "Remember in Keychain" is toggled on: writes to Keychain and clears ephemeral cache.
+- When "Remember in Keychain" is toggled off: writes to ephemeral store and deletes any existing Keychain entry.
+
+---
+
+## 5. Publishing Target Specification
+
+### Standard.site (`PublishTargets.standardSite`)
+- **Credential:** App password / OAuth bearer token.
+- **Delivery:** Stdin authentication handshake.
+- **Persistence:** Configurable ("Remember in Keychain" default: false).
+
+### Nostr (`PublishTargets.nostr`)
+- **Credential:** `nsec` / 32-byte hex private key.
+- **Delivery:** `boris publish nostr --key-stdin` (reads key bytes from stdin pipe until EOF).
+- **Persistence:** Configurable ("Remember in Keychain" default: false).
+
+### GitHub Pages (`PublishTargets.githubPages`)
+- **Credential:** Solipsist does not require GitHub personal access tokens or credentials for local harness operation. Proof packs and `.nojekyll` workflows are Boris-managed and published through GitHub Actions in the user's repository.
+
+---
+
+## 6. Verification Gate & Test Strategy
+
+Unit tests in `Tests/ContractTests/SecurityTests.swift` verify:
+1. **Memory Redaction & Zeroing:** `SecureBuffer` redacts string interpolation and zeroes out buffer memory after `wipe()`.
+2. **Ephemeral Isolation:** Secrets in `EphemeralSecretStore` are accessible during the session, wiped on consumption/replacement, and cleared on `wipeAll()`.
+3. **Keychain CRUD & Toggle:** Secrets transition cleanly between Keychain and Ephemeral mode based on user preference.
+4. **Stdin Pipe Streaming:** `StdinSecretWriter` streams raw bytes to an active `Pipe` file handle, sends EOF, and zeroes the source buffer without leaking into system logs or state stores.


### PR DESCRIPTION
Closes #60

## Summary
- Introduces `Sources/Security/` module:
  - `SecureBuffer`: heap-allocated secret buffer with guaranteed `memset_s` zeroing on deallocation / explicit wipe, and `<SecureBuffer count=N>` redacted descriptions preventing string interpolation leaks.
  - `KeychainStore`: macOS Keychain wrapper using `kSecClassGenericPassword` for persistent credential storage.
  - `EphemeralSecretStore`: in-memory thread-safe secret store for session-only credentials.
  - `StdinSecretWriter`: streams secrets directly to child process stdin pipe descriptors, sends EOF, and zeroes memory buffer immediately.
  - `PublishCredentialManager`: unified credential manager coordinating Keychain vs Ephemeral storage per target and providing the `SecretProviding` seam.
- Adds comprehensive unit tests in `Tests/ContractTests/SecurityTests.swift` covering the complete credential lifecycle.
- Adds `docs/CREDENTIAL-LIFECYCLE.md` design specification meeting the issue's gate criteria.

## Gate Verification
- `make test` passes with all 38 contract and security tests green.
- `SKIP_EMBED_BORIS=1 make build` compiles cleanly.
- Secrets are never placed in `argv`, `env`, or plaintext logs.