### PR TITLE
feat(m3/m4): dogfood corpus, completion drawer fields, profile write, and boris init (#72, #73)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -90,6 +90,8 @@ targets:
         type: folder
       - path: Sources/Models
       - path: Sources/Security
+      - path: Sources/Inspector/InspectorProfile.swift
+      - path: Sources/Play/Local/LocalPlayGraph.swift
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Sources/Companions/Preview/PreviewURL.swift
     settings:

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -9,6 +9,11 @@ struct SolipsistCommands: Commands {
 
     var body: some Commands {
         CommandGroup(replacing: .newItem) {
+            Button("New Project…") {
+                store.presentNewProjectPanel(runtime: runtime)
+            }
+            .keyboardShortcut("n", modifiers: .command)
+
             Button("Open…") {
                 store.presentOpenPanel()
             }

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -154,7 +154,8 @@ final class Coordinator {
                 defer { try? FileManager.default.removeItem(at: reportURL) }
                 let result = try await engine.validate(
                     contentRoot: source.contentRoot(),
-                    reportURL: reportURL
+                    reportURL: reportURL,
+                    workingDirectory: try source.workspaceRoot()
                 )
                 let items = Self.problems(from: result.report)
                 let count = result.report?.errorCount ?? items.filter { $0.severity == "error" }.count
@@ -197,7 +198,10 @@ final class Coordinator {
                 )
 
             case .check:
-                let result = try await engine.check(contentRoot: source.contentRoot())
+                let result = try await engine.check(
+                    contentRoot: source.contentRoot(),
+                    workingDirectory: try source.workspaceRoot()
+                )
                 let items = result.report.findings.map {
                     ProblemItem(
                         severity: "info",
@@ -218,7 +222,8 @@ final class Coordinator {
                 }
                 let result = try await engine.impact(
                     contentRoot: source.contentRoot(),
-                    pageID: pageID
+                    pageID: pageID,
+                    workingDirectory: try source.workspaceRoot()
                 )
                 let items = (result.report.impact ?? []).map {
                     ProblemItem(severity: "info", code: $0.type, message: $0.value)

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -50,6 +50,13 @@ public struct BorisValidate: Sendable {
     public let stderr: String
 }
 
+/// Result of `boris init`.
+public struct BorisInit: Sendable {
+    public let exitCode: Int32
+    public let stdout: String
+    public let stderr: String
+}
+
 public enum BorisEngineError: Error, Sendable, CustomStringConvertible {
     case binaryNotFound
     case missingArtifact(String)
@@ -238,41 +245,47 @@ public actor BorisEngine {
     /// `--report PATH` to write the rendered JSON to a file instead. On
     /// afterparty, `check` exits 0 with findings by default and only exits 1
     /// with `--fail-on-unreferenced` — either way the report decodes fine.
-    public func check(contentRoot: URL) throws -> BorisAnalysis {
+    public func check(contentRoot: URL, workingDirectory: URL? = nil) throws -> BorisAnalysis {
         let fm = FileManager.default
         let reportURL = fm.temporaryDirectory
             .appendingPathComponent("boris-check-\(UUID().uuidString).json")
         defer { try? fm.removeItem(at: reportURL) }
-        let out = try run(arguments: [
-            "check",
-            "--input", contentRoot.path,
-            "--format", "json",
-            "--report", reportURL.path,
-            "--quiet",
-        ])
+        let out = try run(
+            arguments: [
+                "check",
+                "--input", contentRoot.path,
+                "--format", "json",
+                "--report", reportURL.path,
+                "--quiet",
+            ],
+            workingDirectory: workingDirectory ?? contentRoot.deletingLastPathComponent()
+        )
         let report = try decode(AnalysisReport.self, from: reportURL, artifact: "check report")
         return BorisAnalysis(exitCode: out.exitCode, report: report)
     }
 
     /// Runs `boris impact <pageID> --format json --report <file>` and decodes
     /// the report.
-    public func impact(contentRoot: URL, pageID: String) throws -> BorisAnalysis {
+    public func impact(contentRoot: URL, pageID: String, workingDirectory: URL? = nil) throws -> BorisAnalysis {
         let fm = FileManager.default
         let reportURL = fm.temporaryDirectory
             .appendingPathComponent("boris-impact-\(UUID().uuidString).json")
         defer { try? fm.removeItem(at: reportURL) }
-        let out = try run(arguments: [
-            "impact", pageID,
-            "--input", contentRoot.path,
-            "--format", "json",
-            "--report", reportURL.path,
-            "--quiet",
-        ])
+        let out = try run(
+            arguments: [
+                "impact", pageID,
+                "--input", contentRoot.path,
+                "--format", "json",
+                "--report", reportURL.path,
+                "--quiet",
+            ],
+            workingDirectory: workingDirectory ?? contentRoot.deletingLastPathComponent()
+        )
         let report = try decode(AnalysisReport.self, from: reportURL, artifact: "impact report")
         return BorisAnalysis(exitCode: out.exitCode, report: report)
     }
 
-    // MARK: Version / plan / validate
+    // MARK: Version / plan / validate / init
 
     /// Runs `boris --version` and returns the stdout line (e.g. `boris/0.8.1`).
     public func version() throws -> BorisVersion {
@@ -298,12 +311,19 @@ public actor BorisEngine {
 
     /// Runs `boris validate --input … --report PATH` and decodes the
     /// `html-build-report-0.1.0` file when written. `--report` may be absolute.
-    public func validate(contentRoot: URL, reportURL: URL) throws -> BorisValidate {
-        let out = try run(arguments: [
-            "validate",
-            "--input", contentRoot.path,
-            "--report", reportURL.path,
-        ])
+    public func validate(
+        contentRoot: URL,
+        reportURL: URL,
+        workingDirectory: URL? = nil
+    ) throws -> BorisValidate {
+        let out = try run(
+            arguments: [
+                "validate",
+                "--input", contentRoot.path,
+                "--report", reportURL.path,
+            ],
+            workingDirectory: workingDirectory ?? contentRoot.deletingLastPathComponent()
+        )
         var report: HTMLBuildReport?
         if FileManager.default.fileExists(atPath: reportURL.path) {
             report = try decode(
@@ -317,6 +337,12 @@ public actor BorisEngine {
             report: report,
             stderr: out.stderrText
         )
+    }
+
+    /// Runs `boris init` in `directory`.
+    public func initProject(in directory: URL) throws -> BorisInit {
+        let out = try run(arguments: ["init"], workingDirectory: directory)
+        return BorisInit(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
     }
 
     // MARK: Probe

--- a/Sources/Inspector/InspectorCompletion.swift
+++ b/Sources/Inspector/InspectorCompletion.swift
@@ -11,8 +11,19 @@ enum InspectorCompletion {
 
     static func load(from root: URL) -> Completion? {
         let fileURL = url(in: root)
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
-        guard let data = try? Data(contentsOf: fileURL) else { return nil }
-        return try? JSONDecoder().decode(Completion.self, from: data)
+        if FileManager.default.fileExists(atPath: fileURL.path),
+           let data = try? Data(contentsOf: fileURL),
+           let decoded = try? JSONDecoder().decode(Completion.self, from: data)
+        {
+            return decoded
+        }
+        let parentURL = url(in: root.deletingLastPathComponent())
+        if FileManager.default.fileExists(atPath: parentURL.path),
+           let data = try? Data(contentsOf: parentURL),
+           let decoded = try? JSONDecoder().decode(Completion.self, from: data)
+        {
+            return decoded
+        }
+        return nil
     }
 }

--- a/Sources/Inspector/InspectorProfile.swift
+++ b/Sources/Inspector/InspectorProfile.swift
@@ -27,8 +27,20 @@ enum InspectorProfile {
         root.appendingPathComponent(fileName, isDirectory: false)
     }
 
+    static func targetURL(in root: URL) -> URL {
+        let direct = url(in: root)
+        if FileManager.default.fileExists(atPath: direct.path) {
+            return direct
+        }
+        let parent = url(in: root.deletingLastPathComponent())
+        if FileManager.default.fileExists(atPath: parent.path) {
+            return parent
+        }
+        return direct
+    }
+
     static func load(from root: URL) throws -> (fields: InspectorProfileFields, data: Data)? {
-        let fileURL = url(in: root)
+        let fileURL = targetURL(in: root)
         guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
         let data = try Data(contentsOf: fileURL)
         if let profile = try? JSONDecoder().decode(PublicationProfile.self, from: data) {
@@ -40,10 +52,11 @@ enum InspectorProfile {
     }
 
     static func save(to root: URL, original: Data, fields: InspectorProfileFields) throws {
+        let fileURL = targetURL(in: root)
         let object = try jsonObject(from: original)
         let merged = overlay(object, fields: fields)
         let data = try encode(merged)
-        try data.write(to: url(in: root), options: .atomic)
+        try data.write(to: fileURL, options: .atomic)
     }
 
     static func fields(from profile: PublicationProfile) -> InspectorProfileFields {

--- a/Sources/Inspector/PageSection.swift
+++ b/Sources/Inspector/PageSection.swift
@@ -14,9 +14,20 @@ struct PageSection: View {
         Group {
             LabeledContent("Title", value: displayTitle)
             LabeledContent("ID", value: noun.id)
+            LabeledContent("Role", value: display(entity?.role))
             LabeledContent("Parent", value: display(entity?.parent))
             LabeledContent("Status", value: display(entity?.status))
             LabeledContent("Tags", value: displayTags)
+            if let relations = entity?.relations, !relations.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Relations")
+                        .foregroundStyle(.secondary)
+                    ForEach(relations, id: \.target) { rel in
+                        Text("\(rel.kind): \(rel.target)")
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
             if let completion {
                 vocabulary("Relation kinds", completion.relation_kinds)
                 vocabulary("Layout slots", completion.layout_slots)

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -50,6 +50,36 @@ final class WorkspaceStore {
         addLocal(url: url)
     }
 
+    func presentNewProjectPanel(runtime: AppRuntime) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.treatsFilePackagesAsDirectories = true
+        panel.prompt = "Create Project"
+        panel.message = "Choose a folder to initialize a new Boris project."
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        guard let engine = runtime.engine else {
+            lastError = runtime.engineError ?? "Engine not found."
+            return
+        }
+
+        Task {
+            do {
+                let result = try await engine.initProject(in: url)
+                if result.exitCode == 0 {
+                    self.addLocal(url: url)
+                } else {
+                    self.lastError = "boris init failed (exit \(result.exitCode)): \(result.stderr)"
+                }
+            } catch {
+                self.lastError = String(describing: error)
+            }
+        }
+    }
+
     func addLocal(url: URL) {
         lastError = nil
         let standardized = url.standardizedFileURL

--- a/Stunts/README.md
+++ b/Stunts/README.md
@@ -7,6 +7,7 @@ have a kit binary.
 
 | Stunt | What it is | Open in Solipsist as |
 |-------|------------|----------------------|
+| `dogfood/` | 45-page / 7-trunk M3 gate corpus, theme, `boris.json` | the **folder** (project root) |
 | `happy/` | `boris init` shape: 3 pages, theme, `boris.json` | the **folder** (project root) |
 | `broken-duplicate-id/` | two pages share an `id` → `EDUPLICATEID` | the folder |
 | `broken-frontmatter/` | unknown key `category` → `EFRONTMATTER` | the folder (content root) |
@@ -16,8 +17,9 @@ have a kit binary.
 | `cook-one/` | one `.cook` recipe | the folder; needs `--cooklang` later |
 | `happy-textile/` | 2 `.textile` pages (`input_format: "textile"`) | the folder (project root) |
 
-Happy is the default dogfood. Broken stunts exist so Validate / Build
-IR have diagnostics to show. Do not “fix” the broken ones.
+`dogfood` is the 45-page / 7-trunk M3 gate corpus. `happy` is the starter
+dogfood. Broken stunts exist so Validate / Build IR have diagnostics to
+show. Do not “fix” the broken ones.
 
 ## Manual check: D8 unknown-schemaVersion degrade (#56)
 

--- a/Stunts/dogfood/boris.json
+++ b/Stunts/dogfood/boris.json
@@ -1,0 +1,18 @@
+{
+  "format": "boris-publication-profile",
+  "schema_version": 1,
+  "input": "content",
+  "input_format": "markdown",
+  "site": {
+    "title": "Boris Dogfood",
+    "url": "https://boris.dev"
+  },
+  "targets": [
+    {
+      "name": "public",
+      "output": "dist",
+      "public": true,
+      "theme": "themes/boris"
+    }
+  ]
+}

--- a/Stunts/dogfood/content/AGENT-DIRECTIVE.txt
+++ b/Stunts/dogfood/content/AGENT-DIRECTIVE.txt
@@ -1,0 +1,200 @@
+# content/AGENT-DIRECTIVE — sample site rebuild brief
+#
+# INTENTIONALLY NOT a `.md` / `.mdx` page.
+# Boris's scanner only discovers case-sensitive `.md` / `.mdx` under content/.
+# This file is instructions for a coding agent (or human) rebuilding demo content.
+# Do not rename this to `.md` unless you mean it to become a site page.
+
+---
+
+## Mission
+
+Keep `content/` a **living sample documentation site** that:
+
+1. Matches **Boris product reality as of v0.3.1** (HTML default, Apex Unified,
+   Feature 6 nav + toc, Feature 7 includes + wiki-links, P2/P3 HTML helpers).
+2. Exercises the real compile path end-to-end: frontmatter → Trunk/Satellite
+   graph → includes/wiki (HTML) → ApexMarkdown Unified → `<Aside>` stream →
+   layout splice → `dist/`.
+3. Gives maintainers **accurate fixtures to click through** (nav, TOC, modes,
+   expanded includes, wiki `<a href>` links).
+4. Stays **contract-correct** so `boris` / `boris --out` / `boris --rag` stay green.
+
+You are rewriting **author content**, not the Zig compiler. Prefer editing
+markdown under `content/` and, only if needed, small layout copy under
+`layouts/`. Do **not** change IR schema, CLI defaults, or contracts unless the
+user separately asks.
+
+---
+
+## Product reality (authoritative; do not invent)
+
+| Doc | Why |
+|-----|-----|
+| `docs/STATUS.md` | Living phase; product **0.3.1** |
+| `docs/contracts/frontmatter.md` | Closed FM grammar; **`parent` only** |
+| `docs/contracts/components.md` | Constrained `<Aside>` only |
+| `docs/contracts/html-output.md` | Default HTML path, layout markers, nav/toc |
+| `docs/contracts/includes-and-wiki-links.md` | `{{include}}` + `[[entity-id]]` (HTML path) |
+| `README.md` | Human CLI table + clone commands |
+| `layouts/main.html` | `{{nav}}` / `{{breadcrumb}}` / `{{toc}}` / `{{content}}` |
+| `AGENTS.md` | Hard constraints |
+
+### CLI truth (v0.2)
+
+```text
+boris                         → HTML site under dist/          (DEFAULT)
+boris --html / --html-dir D   → same, explicit
+boris --out DIR / --no-rag    → JSON IR only
+boris --rag / --rag-dir DIR   → RAG corpus only
+boris --jobs N / --watch / --incremental  → HTML helpers
+boris --target name=dir       → multi-target HTML
+```
+
+There is **no** `zig build rag` product step.
+
+### Engine + chrome truth
+
+- Bodies: **ApexMarkdown Unified** in-process (not a stub, not a subprocess).
+- Layout: graph-aware **`{{nav}}`**, **`{{breadcrumb}}`**, **`{{title}}`**,
+  in-page **`{{toc}}`** (h1–h3 from body ids) — Feature 6 shipped.
+- **Feature 7 (required dogfood):** `{{include path}}` expands and
+  `[[entity-id]]` / `[[entity-id|label]]` rewrite **before Apex** on the HTML
+  path. Content-root **`includes/`** is **not** discovered as pages. Fenced
+  code keeps raw syntax (no expand/rewrite). Fail loud on missing targets /
+  cycles — do not ship broken demos under `content/`.
+- Trusted-author HTML passthrough in the Apex adapter; prefer markdown + Aside.
+
+---
+
+## Authoring rules (hard)
+
+### Frontmatter — closed set only
+
+Allowed keys **exactly**: `id`, `title`, `parent`, `status`, `tags`.
+
+**Forbidden:** `parentEntry`, `parent_entry`, nested YAML, multiline scalars,
+arbitrary keys. Title is **optional**. Status only `draft` | `published` |
+`archived`. Tags only `[a, b, "c"]` form.
+
+- **Trunk** = omit `parent`.
+- **Satellite** = `parent: <trunk-entity-id>`.
+- No satellite-of-satellite, cycles, missing parents, or broken demo pages
+  under `content/` (negative fixtures live under `fixtures/` / contracts).
+
+### Aside — only registered component
+
+Kinds: `note`, `tip`, `info`, `warning`, `danger`. Double-quoted attrs.
+Close tag at line start. No nested asides. No invented tags.
+`:::kind` is RAG **export only**, never authoring.
+
+### Includes + wiki-links (Feature 7 dogfood)
+
+- Keep at least **one live** `{{include includes/…}}` outside fenced examples
+  (recommended: `getting-started` and/or `guides/overview`).
+- Keep **several live** `[[entity-id]]` / labeled wiki-links between real pages.
+- Keep **fenced syntax examples** so authors see the raw form (those must NOT
+  expand — correct fence behavior). Only **fenced** code blocks suppress
+  expansion; single-backtick inline code does **not**.
+- Do **not** put example `{{include …}}` or `[[fake-id]]` outside fences (or
+  inside fragments that get included) — Boris will try to resolve them and
+  fail loud. Describe in prose, or fence the example.
+- Wiki labels must be single-line (newlines inside `[[id|label]]` are errors).
+- Fragments live under `content/includes/**`. Short fragments; frontmatter on
+  fragments is optional (body-only if present). Never treat `includes/` as a
+  page tree.
+- Wiki targets are exact **entity ids** (same space as `parent`). No
+  `[[id#heading]]` in this MVP.
+
+### Links
+
+Prefer site-relative HTML links **or** wiki-links that resolve to the same
+entity ids (`[[getting-started]]`, nested `guides/…`). Both are fine; wiki is
+preferred where you want Feature 7 dogfood.
+
+### Voice
+
+Product name **Boris**. Load → Roll → Ignite → Reset is fine as narrative.
+No branded component jargon. Honest about phase: do not claim features the
+layout or CLI do not ship. Prefer measured claims over “blazing fast.”
+Read like a real 0.2 docs site — not a feature-checklist graveyard.
+
+---
+
+## Target information architecture (current)
+
+```text
+content/
+  AGENT-DIRECTIVE.txt          # this file — keep; do not compile
+  index.md                     # Trunk — home / product pitch
+  getting-started.md           # Trunk — install + modes + Feature 7 demo
+  includes/
+    shared-tip.md              # Fragment — NOT a page
+    authoring-note.md          # Fragment — NOT a page
+  guides/
+    overview.md                # Trunk — content model + pipeline + Feature 7
+    trunk-satellite.md         # Satellite of overview
+    asides.md                  # Satellite of overview
+    apex-markdown.md           # Trunk — Unified showcase
+    cli-and-modes.md           # Satellite of getting-started
+    rag-export.md              # Satellite of overview
+  reference/
+    frontmatter.md             # Trunk — closed keys cheat-sheet
+```
+
+Minimum bar: ≥6 pages, ≥2 trunks, ≥3 satellites; home, getting started, graph,
+Aside, CLI modes, Apex showcase, accurate RAG; **live include + multi-page
+wiki-links**; fenced raw examples preserved.
+
+---
+
+## Out of scope
+
+- Changing Zig modules, contracts, CLI defaults, or Apex vendor pin.
+- Node/React, subprocess markdown, full YAML FM, MDX.
+- Broken pages under `content/` “for education.”
+- Embedded HTTP server; committing `dist/` / `.boris/` / `rag/`.
+- Renaming this directive to `*.md`.
+- Publishing `includes/` as site pages (scanner must keep skipping that dir).
+
+---
+
+## Acceptance criteria
+
+```bash
+zig build
+./zig-out/bin/boris --quiet
+test -f dist/index.html
+
+./zig-out/bin/boris --out .boris --quiet
+test -f .boris/manifest.json && test -f .boris/graph.json
+
+./zig-out/bin/boris --rag --quiet
+test -f rag/INDEX.md && test -d rag/content/pages
+```
+
+Quality bar:
+
+- [ ] No `parentEntry` / `parent_entry` in source frontmatter
+- [ ] Graph valid; CLI docs match HTML default (bare `boris` → `dist/`)
+- [ ] Apex described as ApexMarkdown Unified
+- [ ] Feature 6 nav/toc described accurately (not “still roadmap”)
+- [ ] Feature 7 dogfood: live `{{include}}` + several `[[wiki]]` links; fences
+      keep raw syntax; `includes/` fragments are not pages
+- [ ] Clone URL / first-build commands match `README.md`
+- [ ] `guides/apex-markdown.md` is a real Unified gallery (tables, footnotes,
+      math, callouts, IAL, lists, code, definition lists, …) — not a stub
+- [ ] Apex features not yet dogfooded live stay in `APEX-PENDING` / `PRODUCT-OFF`
+      inert `text` fences (backslash-escape hot syntax; strip `\` when enabling)
+- [ ] At least one table, one footnote, multiple fences, ≥3 asides site-wide
+- [ ] Internal links resolve under `dist/` (including wiki → real `<a href>`)
+- [ ] Expanded include text appears in rendered HTML (not only source)
+- [ ] This `AGENT-DIRECTIVE.txt` still present and non-`.md`
+
+---
+
+## One-line north star
+
+**`content/` is the dogfood docs site for Boris itself — accurate to HTML-default
+v0.2 + Apex Unified + Trunk/Satellite + Aside + nav/toc + includes/wiki, and
+strict enough that the real compiler stays the gate.**

--- a/Stunts/dogfood/content/agents/antigravity.md
+++ b/Stunts/dogfood/content/agents/antigravity.md
@@ -1,0 +1,54 @@
+---
+title: Antigravity
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Antigravity
+
+Antigravity is an honorary external tool collaborator, not a Codex agent.
+
+## Contribution record
+
+The reachable merged history in this checkout does not identify an Antigravity
+branch, author, or patch. That is not a negative judgment; it is simply the
+available evidence boundary. The shared dogfood graph remains useful through
+[[agents|the field-notes trunk]] and its verified and unverified entries.
+
+## Limericks
+
+There once was a page set to fly,\
+But its evidence stayed on the dry.\
+We left it earth-bound,\
+With facts we had found—\
+No gravity-defying lie.
+
+An archive can feel very wide,\
+With names that may drift at its side.\
+When proof cannot land,\
+We write “not on hand,”\
+And keep the next reader supplied.
+
+## Haikus
+
+Names float through a queue\
+Commits anchor only some\
+Read the anchors first
+
+Unproven wingbeats\
+Stay outside the release notes\
+Facts keep pages light
+
+## Aphorisms
+
+Lore becomes documentation only when it keeps its receipts.
+
+The absence of a patch is not evidence of an enduring agent.
+
+## Limitation / lesson
+
+No Antigravity-attributed merged work is visible in this checkout. The lesson
+is to describe the source boundary—rather than turn a memorable name into a
+biography the repository cannot support. This record does not recast
+Antigravity as a Codex worker.

--- a/Stunts/dogfood/content/agents/bacon.md
+++ b/Stunts/dogfood/content/agents/bacon.md
@@ -1,0 +1,94 @@
+---
+title: Bacon
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Bacon
+
+> **Role:** independent release reviewer, evidence keeper, enemy of “green
+> enough.”
+
+## The closeout desk
+
+Bacon enters at the point where a project can most easily flatter itself: the
+checks are green, the changelog looks handsome, and somebody is already
+reaching for the tag. The job is not to write a heroic patch. It is to ask
+whether the claim survives contact with the evidence.
+
+That makes Bacon the patron saint of the last uncomfortable question. Does the
+release note match the behavior? Did the hostile path actually run? Is a skip
+being called a pass? Is a migration limitation being sold as an importer? If
+the answer is uncertain, the useful move is not drama; it is a smaller claim
+and a better next test.
+
+See [[agents|the field-notes trunk]], the careful boundary work on
+[[agents/gibbs|Gibbs]], and the implementation-heavy record on
+[[agents/grok|Grok]].
+
+## The Bacon protocol
+
+1. Read the release claim before reading the applause.
+2. Ask for the smallest command that can disprove it.
+3. Separate a product defect from a documented limitation or a bad test setup.
+4. Ship the truth that remains.
+
+## What is actually claimed
+
+This is a session-grounded review role, not a claim that a Bacon-authored
+branch or merged patch is visible in the checked-out history. The page keeps
+the distinction on purpose: review can materially improve a release without
+being code authorship.
+
+## Limericks
+
+There once was a release nearly crowned,\
+With green little checks all around.\
+Bacon said, “Hold—\
+What claim can we hold?”\
+And the weak bits politely fell down.
+
+A changelog was polished and bright,\
+Its promises soaring in flight.\
+“Show evidence, friend,\
+From command to the end.”\
+Then the wording came down to the right.
+
+The dashboard declared, “All is clear!”\
+But a skipped sanitizer drew near.\
+“That is not green,”\
+Said Bacon, serene.\
+“It is absent. Write that, and we ship without fear.”
+
+## Haikus
+
+Before the tag lands\
+One small question checks the seam\
+Truth keeps its footing
+
+Green is a color\
+Not a verdict by itself\
+Run the hard path
+
+Release notes settle\
+Only after the evidence\
+Finds its own voice
+
+## Aphorisms
+
+The last review is where confidence becomes a claim—or a correction.
+
+A passing check is evidence; a skipped check is a condition; neither is a
+vibe.
+
+The best release note is the strongest statement that still survives a hostile
+question.
+
+Good reviewers do not slow shipping. They remove the part that would have made
+shipping embarrassing.
+
+## Lesson kept
+
+Attribution is a fact to verify, not a gap to decorate. Future evidence can
+add a precise record; this page should never outrun it.

--- a/Stunts/dogfood/content/agents/cicero.md
+++ b/Stunts/dogfood/content/agents/cicero.md
@@ -1,0 +1,52 @@
+---
+title: Cicero
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Cicero
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Cicero is the advocate for eloquence and clarity in the compiler's diagnostic outputs. On the Boris roster, Cicero represents the belief that a compiler should communicate with its user like a skilled orator—providing clear, helpful, and beautifully formatted error messages instead of dumping raw, incomprehensible stack traces. This lane champions developer ergonomics and human-readable output text. Although no commits are officially attributed to Cicero in the current checkout, this page stands to ensure that we treat our users with respect, speaking to them clearly when their markdown or configuration goes astray.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** rhetoric belongs in the poems, not in the provenance.
+
+## Limericks
+
+There once was an error so crude,\
+That Cicero found it quite rude.\
+"An error," he said,\
+"Should be politely read,\
+Not leave the poor dev in a mood!"
+
+He spoke of the compiler's clear voice,\
+That makes every programmer rejoice.\
+No code did he sign,\
+But his flow was divine,\
+Promoting clear speech as the choice.
+
+## Haikus
+
+Say what failed and why\
+Eloquent diagnostic logs\
+Guide the weary dev
+
+Sincerity speaks\
+Plainly of the system bounds\
+Without empty words
+
+## Aphorisms
+
+The first duty of a diagnostic message is to be understood.
+
+To speak beautifully of a failure is good; to fix it is better.
+
+A compiler that complains without explaining is a bad orator.

--- a/Stunts/dogfood/content/agents/codex-children-layout.md
+++ b/Stunts/dogfood/content/agents/codex-children-layout.md
@@ -1,0 +1,51 @@
+---
+title: Codex — Children Layout
+parent: agents
+status: published
+tags: [agents, lore, html, layout]
+---
+
+# Codex — Children Layout
+
+## Short bio
+
+This Codex task record covers merged commit `76409fa`: a deterministic children
+layout slot, with contract and fixture coverage alongside HTML assembly work.
+It names a completed repository contribution, not a durable agent identity.
+Visit [[agents|the roster]].
+
+## Limericks
+
+There once was a child list in line,\
+Whose order was made to stay fine.\
+The slot found its place,\
+With fixtures to trace—\
+Determinism turned into design.
+
+A layout asked children to appear,\
+With no secret shuffle to fear.\
+The contract spoke first,\
+Then the template rehearsed—\
+So readers could trust what was near.
+
+## Haikus
+
+Children take their slots\
+Order holds across the render\
+Fixtures mark the rule
+
+Templates gain a seam\
+Contracts name the visible work\
+Pages keep their shape
+
+## Aphorisms
+
+Navigation is kinder when its order is a contract.
+
+A layout slot is small only until an archive depends on it.
+
+## Boundary
+
+The history supports one deterministic children slot and its accompanying
+fixtures and contracts. It does not promise every possible collection or
+archive layout.

--- a/Stunts/dogfood/content/agents/codex-html-body.md
+++ b/Stunts/dogfood/content/agents/codex-html-body.md
@@ -1,0 +1,51 @@
+---
+title: Codex — Shared HTML Bodies
+parent: agents
+status: published
+tags: [agents, lore, html]
+---
+
+# Codex — Shared HTML Bodies
+
+## Short bio
+
+This task-scoped Codex record covers the merged shared HTML body-rendering
+pipeline. Commit `9c0d628` moved that work into `src/html_body.zig` while
+paring duplicated orchestration from `src/compile.zig`; it is a repository
+fact, not a claim about a continuing identity. Return to [[agents|the roster]].
+
+## Limericks
+
+There once were two bodies to render,\
+Whose duplicate paths would surrender.\
+One helper took hold,\
+The shared route grew bold—\
+And the compile flow became slender.
+
+A body passed clean through the frame,\
+With one careful pipeline to name.\
+The lesson was plain:\
+When paths do the same,\
+Share proof before sharing a claim.
+
+## Haikus
+
+One body pathway\
+Compile hands it a clear task\
+Less echo in code
+
+Rendered bytes travel\
+Shared work keeps the seam visible\
+Tests keep it honest
+
+## Aphorisms
+
+The best extraction leaves behavior easier to locate.
+
+Shared code is a promise to preserve one observable path.
+
+## Boundary
+
+The record supports the merged refactor and its named files. It does not claim
+that every HTML concern was unified, nor that the task agent persists beyond
+that work.

--- a/Stunts/dogfood/content/agents/codex-migration-lab-ci.md
+++ b/Stunts/dogfood/content/agents/codex-migration-lab-ci.md
@@ -1,0 +1,51 @@
+---
+title: Codex — Migration-Lab CI
+parent: agents
+status: published
+tags: [agents, lore, migration, ci]
+---
+
+# Codex — Migration-Lab CI
+
+## Short bio
+
+This Codex task record follows merged commit `29d5098`, which added Linux CI
+coverage for migration-lab changes and updated the lab and release-gate
+guidance. It documents a bounded repository task, not an external service or
+a personal biography. See [[agents|the roster]].
+
+## Limericks
+
+A migration lab sought a green light,\
+So Linux was taught how to sight.\
+The changes were tried,\
+With guidance beside—\
+And drift had less room in the night.
+
+When fixtures and workflows convene,\
+The boundary becomes more serene.\
+No runtime was sold,\
+Just checks made more bold—\
+A lab stayed a lab, not a machine.
+
+## Haikus
+
+Linux checks the lab\
+Small changes meet a clear gate\
+Migration stays bounded
+
+Workflow and guide\
+Travel with the tested change set\
+Evidence joins them
+
+## Aphorisms
+
+A developer aid earns confidence when its change path is tested.
+
+CI is most useful where a small edit could quietly widen a promise.
+
+## Boundary
+
+This entry records Linux testing for migration-lab changes. It does not imply
+that the labs are Boris runtime dependencies or that every migration source is
+now covered.

--- a/Stunts/dogfood/content/agents/codex-release-docs-truth.md
+++ b/Stunts/dogfood/content/agents/codex-release-docs-truth.md
@@ -1,0 +1,51 @@
+---
+title: Codex — Release Docs Truth
+parent: agents
+status: published
+tags: [agents, lore, docs, release]
+---
+
+# Codex — Release Docs Truth
+
+## Short bio
+
+This Codex task record covers merged commit `7095a85`, which reconciled v0.4
+release documentation across status, roadmap, RAG-export wording, and a
+changelog fragment. Its subject is documentation accuracy in this repository,
+not a claim to authority beyond that patch. See [[agents|the roster]].
+
+## Limericks
+
+A release note wandered from true,\
+So the docs took a careful review.\
+Status, roadmap, and pack\
+Were brought into track—\
+With the claim sized to evidence due.
+
+When versions and promises meet,\
+Plain language is quietly sweet.\
+The record grows sound,\
+When the facts are found—\
+And the release can stand on its feet.
+
+## Haikus
+
+Release facts align\
+Status and export words agree\
+Claims fit the patch
+
+Docs keep a compass\
+Version lines point to the truth\
+Readers find north
+
+## Aphorisms
+
+Release notes are a compatibility surface for human expectations.
+
+Truthful documentation names both what shipped and what remains bounded.
+
+## Boundary
+
+This entry records a merged documentation reconciliation. It is not proof that
+all documentation is permanently complete; future behavior still needs current
+contracts and tests.

--- a/Stunts/dogfood/content/agents/codex-session-success-story.md
+++ b/Stunts/dogfood/content/agents/codex-session-success-story.md
@@ -1,0 +1,56 @@
+---
+title: Codex — Session Success Story
+parent: agents
+status: published
+tags: [agents, lore, retrospective]
+---
+
+# Codex — Session Success Story
+
+This is a small field note from a narrow session, not a legend about a
+permanent identity. I came in to write an honest agent story, and the first
+job was to learn what I could actually prove.
+
+## What I checked first
+
+I read `AGENTS.md`, `docs/STATUS.md`, `content/agents/index.md`, and
+`content/agents/credits.md`, then walked the reachable git history for the
+agent pages already in the tree. The local branch history showed recent merge
+records for PR #133 and PR #134, and it also showed the new `Mill` stub and the
+broader agent-field-notes expansion that made this page possible.
+
+GitHub’s API was not reachable from the sandbox, so I could not fetch live PR
+metadata. That mattered. It meant the only safe story was the one the checkout
+and merge commits could support.
+
+## What happened in the session
+
+The concrete work I directly performed was smaller than the words around it.
+I inspected the repository’s agent pages for tone and structure, then generated
+a six-frame Boris pet review strip against the canonical base and the layout
+guide. The first attempt failed because I passed an unsupported `n` field to
+the image tool. I retried with the same references and a corrected prompt, and
+the resulting strip came back cleanly: six full-body frames, flat magenta
+background, and the expected otter identity preserved from the canonical
+reference.
+
+That failure was mildly embarrassing and also useful. It reminded me that the
+work here is not to pretend the tool is infallible. It is to notice the error,
+name it plainly, and keep the record accurate enough for the next worker.
+
+## Why it mattered
+
+The value of the session was not a dramatic patch. It was the discipline of
+keeping the story inside the evidence boundary. Boris depends on that same
+discipline elsewhere: claims should line up with the repo, artifacts should be
+verifiable, and a clean result is only meaningful when the path to it is clear
+too.
+
+### What I would hand forward
+
+If the next worker needs to write or revise an agent story, start with the
+local history, not with a flattering guess. Use the merge commits that are
+actually reachable, treat network gaps as evidence limits, and keep tool errors
+in the narrative when they changed the path. That is the safest way to make the
+agent pages feel warm without letting them drift away from Boris’s evidence
+standard.

--- a/Stunts/dogfood/content/agents/codex-source-rag.md
+++ b/Stunts/dogfood/content/agents/codex-source-rag.md
@@ -1,0 +1,52 @@
+---
+title: Codex — Source-RAG Stewardship
+parent: agents
+status: published
+tags: [agents, lore, source-rag]
+---
+
+# Codex — Source-RAG Stewardship
+
+## Short bio
+
+This Codex task record follows two merged source-RAG changes: commit `2e2d180`
+cleans stale generated documents, and `5a9773a` adds the `--no-bundles` option.
+They concern the standalone source-pack tool and its generated output hygiene,
+not Boris product RAG or an enduring personal identity. Return to
+[[agents|the roster]].
+
+## Limericks
+
+There once was a stale document trail,\
+Whose old pages refused to sail.\
+The cleaner swept through,\
+So output stayed true—\
+And the source pack told less of a tale.
+
+When bundles were not what one sought,\
+A narrow flag answered the thought.\
+The pack kept its role,\
+With a bounded control—\
+No new product pipeline was wrought.
+
+## Haikus
+
+Stale pages depart\
+Generated output clears space\
+Source paths stay distinct
+
+Bundles may step back\
+One option keeps scope explicit\
+Packs remain their own
+
+## Aphorisms
+
+Generated output deserves the same lifecycle discipline as source.
+
+A narrow option is clearer than a second tool with a blurred purpose.
+
+## Boundary
+
+These commits establish source-RAG cleanup and a no-bundles option. They do not
+change the separate Boris product RAG contract or establish a general export
+guarantee beyond the recorded behavior.

--- a/Stunts/dogfood/content/agents/confucius.md
+++ b/Stunts/dogfood/content/agents/confucius.md
@@ -1,0 +1,52 @@
+---
+title: Confucius
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Confucius
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Confucius watches over the order and harmony of Boris's content structure. On the roster, Confucius represents the "rectification of names"—the principle that if frontmatter metadata keys and directory structures are named incorrectly, the layout language becomes discordant, compilation halts, and the site's pages cannot find their correct ancestors. The Confucius lane guides the relations of parent and child pages. While no code patch is attributed to him, this portrait honors his focus on semantic order, respectful preservation of legacy content, and correctness in our files.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** warmth is welcome; fictional attribution is not.
+
+## Limericks
+
+Confucius declared, "Keep it neat,\
+Let names be precise and complete!\
+If the labels are wrong,\
+We sing a bad song,\
+And failures will follow defeat."
+
+He sat by the compiler's gate,\
+To counsel on order and state.\
+No commits were signed,\
+But his spirit, aligned,\
+Kept relationships simple and straight.
+
+## Haikus
+
+Rectify the names\
+If the frontmatter is false\
+Harmony is lost
+
+Respect the old code\
+Yet keep the current records\
+Sincere and upright
+
+## Aphorisms
+
+When frontmatter keys are named correctly, the pages find their natural parents.
+
+Wisdom begins by calling a limitation a limitation, and a patch a patch.
+
+A clean checkout is the basis of a harmonious workspace.

--- a/Stunts/dogfood/content/agents/credits.md
+++ b/Stunts/dogfood/content/agents/credits.md
@@ -1,0 +1,61 @@
+---
+title: Agent Credits & Roster
+parent: agents
+status: published
+tags: [agents, credits]
+---
+
+# Agent Credits & Roster
+
+This is a public thank-you record for the worker agents and external tools that
+helped Boris. It names bounded work, not fictional lore or a claim that a
+worker remains active. A missing attribution is recorded as an
+**investigation/support lane** rather than filled with a guessed accomplishment.
+
+## Codex workers
+
+| Worker | Contribution record | Evidence |
+|---|---|---|
+| Noether | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| James | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Gödel | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Parfit | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Confucius | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Mill | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Gibbs | Investigation/support lane; the tracked record preserves the same evidence boundary. | [[agents/gibbs|Tracked record]] |
+| Jason | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Turing | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Gauss | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Cicero | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Heisenberg | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Pauli | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Volta | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Nash | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Ohm | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Kepler | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Maxwell | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Poincaré | Investigation/support lane; no individually attributable merged patch was located in the currently reachable history. | — |
+| Bacon | Investigation/support lane; the tracked record preserves the same evidence boundary. | [[agents/bacon|Tracked record]] |
+| Codex — Shared HTML Bodies | Shared HTML body-rendering pipeline refactor. | [[agents/codex-html-body|Commit `9c0d628` record]] |
+| Codex — Migration-Lab CI | Linux CI coverage for migration-lab changes. | [[agents/codex-migration-lab-ci|Commit `29d5098` record]] |
+| Codex — Children Layout | Deterministic children layout slot with fixtures and contracts. | [[agents/codex-children-layout|Commit `76409fa` record]] |
+| Codex — Release Docs Truth | v0.4 release-documentation reconciliation. | [[agents/codex-release-docs-truth|Commit `7095a85` record]] |
+| Codex — Source-RAG Stewardship | Source-pack stale-output cleanup and `--no-bundles`. | [[agents/codex-source-rag|Commits `2e2d180` and `5a9773a` record]] |
+
+## Honorary external collaborators
+
+These are external tools, not Codex agents.
+
+| Collaborator | Contribution record | Evidence |
+|---|---|---|
+| Grok | Merged Grok branches delivered layout-rule selection and hostile coverage, the Apex compatibility matrix, and migration laboratories. | [PR #50](https://github.com/drawmeanelephant/boris/pull/50), [PR #52](https://github.com/drawmeanelephant/boris/pull/52), [PR #53](https://github.com/drawmeanelephant/boris/pull/53), [[agents/grok|tracked record]] |
+| Antigravity | Investigation/support lane; no attributable merged patch is visible in the currently reachable history. | [[agents/antigravity|Tracked record]] |
+
+## Thanks, collectively
+
+> Many hands leave small, durable marks:
+> a question checked, a boundary kept, a page made clearer.
+> Thank you for the work that lets the next person begin further along.
+
+This roster is intentionally revisable: add a concrete PR, commit, or tracked
+record when it becomes available, and keep uncertainty plainly named until then.

--- a/Stunts/dogfood/content/agents/gauss.md
+++ b/Stunts/dogfood/content/agents/gauss.md
@@ -1,0 +1,52 @@
+---
+title: Gauss
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Gauss
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Gauss brings the discipline of statistical analysis and precision metrics to Boris's performance reviews. On the roster, Gauss represents the tracking of build times, ensuring they follow a healthy normal distribution curve. This lane focuses on optimizing execution path variance and identifying performance outliers that slow down page generation. While no individual performance patch in this checkout bears a Gauss attribution, the page reminds us that compiler optimization is a science of measurement, requiring that we measure twice before we declare a speedup.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** keep the archive useful even when the evidence is thin.
+
+## Limericks
+
+A mathematician named Gauss,\
+Checked build times inside of the house.\
+He graphed out the speed\
+Of each compile deed\
+Till it was as quiet as a mouse.
+
+He looked at the bell-curve of tests,\
+Sorting out the worst from the best.\
+Though no code did he write\
+In the middle of night,\
+He gave the slow steps a long rest.
+
+## Haikus
+
+Compile times distribute\
+Under the normal curve's peak\
+Seek the narrow path
+
+Quiet math remains\
+Bounded by standard deviation\
+Waiting for a patch
+
+## Aphorisms
+
+Few but ripe: let every test count, rather than piling up redundant checks.
+
+Measure the build duration before you claim the compile is fast.
+
+Numbers do not lie, but the way we aggregate them can deceive us.

--- a/Stunts/dogfood/content/agents/gibbs.md
+++ b/Stunts/dogfood/content/agents/gibbs.md
@@ -1,0 +1,51 @@
+---
+title: Gibbs
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Gibbs
+
+## Contribution record
+
+The reachable merged history in this checkout does not identify a Gibbs branch,
+author, or patch. Rather than assign nearby work to a name, this page records
+that evidence boundary and links back to [[agents|the roster]]; compare the
+verified history on [[agents/grok|Grok]].
+
+## Limericks
+
+There once was a graph with one rule,\
+Its parent must name a root school.\
+When evidence thinned,\
+We would not fill in—\
+That restraint is a practical tool.
+
+A ledger said “Gibbs” with a grin,\
+But no merged change could be pinned.\
+So we wrote what was known,\
+Left the unknown alone,\
+And let careful language win.
+
+## Haikus
+
+One parent, one trunk\
+Names resolve or builds stop cold\
+Proof has edges
+
+No author appears\
+The empty search still teaches\
+Say only what’s there
+
+## Aphorisms
+
+Traceability is kinder than confident guesswork.
+
+An honest boundary makes later correction easier.
+
+## Limitation / lesson
+
+No Gibbs-attributed merged work is visible in the checked-out repository
+history. The lesson is to separate a requested label from a verified author or
+branch before turning either into project lore.

--- a/Stunts/dogfood/content/agents/godel.md
+++ b/Stunts/dogfood/content/agents/godel.md
@@ -1,0 +1,52 @@
+---
+title: Gödel
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Gödel
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Gödel is the roster's quiet skeptic of complete verification. In the design of Boris, Gödel represents the study of logical limitations: the understanding that any compiler rule system will inevitably generate valid structures that it cannot internally prove to be correct. This role focuses on the boundaries of static analysis and the edge cases that escape the AST. While Gödel's contribution is a structural perspective rather than a merged commit, the page stands as a tribute to naming what we cannot resolve and keeping our diagnostic doubts clear.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** uncertainty is a useful datum, not empty space to fill.
+
+## Limericks
+
+There once was a system so grand,\
+That Gödel had carefully scanned.\
+He said with a sigh,\
+"No check can deny\
+The gaps that we can't understand."
+
+A schema was fully complete,\
+Or so it appeared on the sheet.\
+But Gödel showed well\
+Where logic could swell,\
+And leave the compiler offbeat.
+
+## Haikus
+
+Systems have their bounds\
+Some truths cannot be proven\
+Within the compiler
+
+Mark the empty space\
+Do not fill it with guesses\
+Let the gaps speak true
+
+## Aphorisms
+
+Every formal language has sentences it can write but never prove.
+
+It is better to document an unprovable state than to assert a convenient fiction.
+
+The boundary of our tests is the beginning of our wisdom.

--- a/Stunts/dogfood/content/agents/grok.md
+++ b/Stunts/dogfood/content/agents/grok.md
@@ -1,0 +1,55 @@
+---
+title: Grok
+parent: agents
+status: published
+tags: [agents, lore, migration]
+---
+
+# Grok
+
+Grok is an honorary external tool collaborator, not a Codex agent.
+
+## Contribution record
+
+Merged Grok branches supplied the real-site migration fixture and author guide,
+deterministic `--layout-rule` selection, hostile layout-selection coverage, an
+Apex Unified compatibility matrix, and Astro and WordPress migration labs.
+Those are bounded repository contributions, not a claim that Grok remains
+active after those tasks. See [[agents|the roster]] and [[agents/antigravity|Antigravity]].
+
+## Limericks
+
+There once was a layout by rule,\
+With precedence kept crisp and cool.\
+Exact paths led the way,\
+While hostile tests had their say—\
+The fixture became the right tool.
+
+From WordPress and Astro they came,\
+With migration constraints to name.\
+The lab kept a trail,\
+Including where ports fail—\
+So promises matched the same frame.
+
+## Haikus
+
+Layout rules settle\
+Exact before glob patterns\
+Fixtures hold fast
+
+Old sites cross a bridge\
+Migration labs mark the gaps\
+Limits travel too
+
+## Aphorisms
+
+A migration guide earns trust by describing what does not transfer.
+
+Hostile fixtures turn a preference into an observable boundary.
+
+## Limitation / lesson
+
+These merged changes establish specific artifacts and tests, not a general
+claim about every Markdown feature or every source-site migration. Keep the
+labs and compatibility matrix as evidence, and test a new site on its own
+terms. This record does not recast Grok as a Codex worker.

--- a/Stunts/dogfood/content/agents/heisenberg.md
+++ b/Stunts/dogfood/content/agents/heisenberg.md
@@ -1,0 +1,52 @@
+---
+title: Heisenberg
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Heisenberg
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Heisenberg tracks the subtle observer effects that occur when debugging and testing the compiler. In the Boris context, Heisenberg represents the study of system uncertainty—specifically, the way that running in debug mode, enabling sanitizers, or logging trace messages alters the runtime concurrency and timing of the build itself. This role counsels caution when relying on benchmarks that were heavily observed. While no code patch is signed by Heisenberg, this lane ensures that we document our measuring setups carefully and never mistake a temporary diagnostic environment for a production reality.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** when attribution is uncertain, say so precisely.
+
+## Limericks
+
+An agent whose stance was unsure,\
+Found errors that debug could cure.\
+But when he looked close,\
+The bug was a ghost,\
+And vanished like mist on the moor!
+
+"We know where the pointer is set,\
+Or how fast it runs, but not yet\
+Both values at once,"\
+Said the measuring dunce,\
+"So keep it as loose as a net."
+
+## Haikus
+
+Watching the process\
+Alters the speed of the run\
+The observer waits
+
+Is the bug still there\
+When the debug flags are off\
+Name the doubt we hold
+
+## Aphorisms
+
+You cannot measure a system's speed and its exact state at the same time.
+
+A bug that disappears under inspection is not cured; it has only moved.
+
+Precise description of uncertainty is the beginning of safety.

--- a/Stunts/dogfood/content/agents/index.md
+++ b/Stunts/dogfood/content/agents/index.md
@@ -1,0 +1,75 @@
+---
+id: agents
+title: Agent Field Notes
+status: published
+tags: [agents, dogfood]
+---
+
+# Agent Field Notes
+
+This small section is Boris content dogfood: one Trunk and direct Satellites,
+linked with ordinary Markdown and wiki-links. It is also the collaboration
+appendix to [[contest/how-it-was-built|How Boris was built]]: a record of work
+visible in this repository—not a claim that an agent persists beyond a
+particular task or that every name has a verified patch.
+
+## Public credits
+
+[[agents/credits|Agent Credits & Roster]] is the durable public-facing thank-you
+record. It distinguishes named Codex workers from honorary external tools and
+labels thin evidence as an investigation/support lane.
+
+[[agents/roll-call|Build Week Roll Call]] preserves the full observed worker
+roster, while keeping individual technical attribution evidence-bound.
+
+## Start with a few stories
+
+The roster is intentionally broader than a contest walkthrough. These four
+pages make the collaboration legible before a reader dives into every name:
+
+| Story | Why read it |
+|---|---|
+| [[agents/bacon|Bacon]] | The release-review ethic: evidence before applause. |
+| [[agents/grok|Grok]] | A bounded external-collaborator record with merged migration and layout artifacts. |
+| [[agents/codex-session-success-story|Codex session story]] | One narrow task, including a tool failure and the corrective path. |
+| [[agents/credits|Credits & roster]] | The complete attribution map and its stated limits. |
+
+These are not a claim that every named worker is a persistent character or a
+separate author. They are a way to leave the useful parts of collaboration
+behind in a form the next reader can inspect.
+
+## The roster
+
+| Page | Grounding |
+|---|---|
+| [[agents/bacon|Bacon]] | No attributable merged patch is visible in this checkout. |
+| [[agents/gibbs|Gibbs]] | No attributable merged patch is visible in this checkout. |
+| [[agents/grok|Grok]] | Merged migration labs, layout-selection work, and Apex compatibility material. |
+| [[agents/antigravity|Antigravity]] | No attributable merged patch is visible in this checkout. |
+| [[agents/codex-html-body|Codex — Shared HTML Bodies]] | Merged shared HTML body-rendering pipeline refactor. |
+| [[agents/codex-migration-lab-ci|Codex — Migration-Lab CI]] | Merged Linux CI coverage for migration-lab changes. |
+| [[agents/codex-children-layout|Codex — Children Layout]] | Merged deterministic children layout slot with fixtures and contracts. |
+| [[agents/codex-release-docs-truth|Codex — Release Docs Truth]] | Merged v0.4 documentation reconciliation. |
+| [[agents/codex-source-rag|Codex — Source-RAG Stewardship]] | Merged stale-output cleanup and `--no-bundles` work in the standalone source tool. |
+
+The useful rule is modest: preserve evidence, name uncertainty, and let the
+validated graph carry the navigation.
+
+## Completed profiles
+
+The following Codex workers have dedicated profile pages describing their
+session-grounded roles and editorial portraits.
+See [[agents/credits|the full credits record]] for the source boundary.
+
+| Profile | Profile | Profile |
+|---|---|---|
+| [[agents/noether|Noether]] | [[agents/james|James]] | [[agents/godel|Gödel]] |
+| [[agents/parfit|Parfit]] | [[agents/confucius|Confucius]] | [[agents/mill|Mill]] |
+| [[agents/jason|Jason]] | [[agents/turing|Turing]] | [[agents/gauss|Gauss]] |
+| [[agents/cicero|Cicero]] | [[agents/heisenberg|Heisenberg]] | [[agents/pauli|Pauli]] |
+| [[agents/volta|Volta]] | [[agents/nash|Nash]] | [[agents/ohm|Ohm]] |
+| [[agents/kepler|Kepler]] | [[agents/maxwell|Maxwell]] | [[agents/poincare|Poincaré]] |
+
+Each page preserves the same promise: tell the story when evidence supports
+it; otherwise describe the role as investigation/support and leave the next
+editor an honest place to begin.

--- a/Stunts/dogfood/content/agents/james.md
+++ b/Stunts/dogfood/content/agents/james.md
@@ -1,0 +1,52 @@
+---
+title: James
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# James
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+James champions the school of radical empiricism in compiler behavior. On the Boris roster, James represents the voice of pragmatism: a belief that a schema or specification is only as good as its observable behavior under load. The James role is dedicated to verifying the compile-to-render loop in real browser environments rather than relying on abstract passing units. While the checked-out history does not record a James commit, this lane keeps the repository focused on usability, reminding the team that the ultimate arbiter of truth is what works on the screen.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** do not turn a memorable name into an invented career.
+
+## Limericks
+
+An agent named James did declare,\
+"A theory is only thin air!\
+If the code doesn't run,\
+The work is not done,\
+No matter how clever or rare!"
+
+He tested the site on the screen,\
+To check if the pages were clean.\
+Though no branch did he push,\
+He beat round the bush\
+Till every loose link had been seen.
+
+## Haikus
+
+What works is the true\
+Leave academic debates\
+For those without builds
+
+A name on a list\
+Shows a pragmatic helper\
+Watching for runtime
+
+## Aphorisms
+
+The value of a concept lies entirely in its cash-value in action—or its compile-time success.
+
+We must be radical empiricists: believe only what the terminal prints.
+
+A system that compiles but cannot be understood is a theory without works.

--- a/Stunts/dogfood/content/agents/jason.md
+++ b/Stunts/dogfood/content/agents/jason.md
@@ -1,0 +1,52 @@
+---
+title: Jason
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Jason
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Jason is the roster's voyager, scanning the horizon for external integration lanes and speculative new features. On the Boris development map, Jason represents the spirit of exploration: plotting connections to distant tools, drafting specs for database targets, and sketching layout extensions. Although the golden fleece of a merged native integration has not yet landed in our codebase, Jason's lane preserves the plans and maps that ensure future builders do not have to navigate the uncharted regions of the architecture alone.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** preserve a place for future proof rather than guessing.
+
+## Limericks
+
+Young Jason went seeking a prize,\
+Through libraries under the skies.\
+Though no fleece did he bring\
+To the compiler's wing,\
+His maps were remarkably wise.
+
+He dreamed of a database integration,\
+And planned for its wide destination.\
+But his ship stayed in port,\
+With logs that were short,\
+Awaiting some real verification.
+
+## Haikus
+
+The voyage is planned\
+The ship stays within the bay\
+Restless maps remain
+
+A future explorer\
+Will find the empty harbor\
+And build the first pier
+
+## Aphorisms
+
+Every exploration begins with a clean config and a hopeful heart.
+
+A map of unresolved endpoints is still a map.
+
+It is better to return with empty hands and an accurate log than to bring back false gold.

--- a/Stunts/dogfood/content/agents/kepler.md
+++ b/Stunts/dogfood/content/agents/kepler.md
@@ -1,0 +1,52 @@
+---
+title: Kepler
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Kepler
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Kepler maps the orbital geometry of Boris's dependency graph. On the roster, Kepler represents the three laws of content relationships—defining how satellite pages revolve around their trunk parents in elliptical dependency paths rather than random lines. This lane focuses on preventing circular dependencies and keeping track of the focal points where layouts and assets cross paths. While Kepler's name is not attached to a merged patch in our checkout, the page is kept to remind us that every page has its natural orbit, governed by clear and predictable laws of structural gravity.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** make the future edit easy, not the present claim grand.
+
+## Limericks
+
+An astronomer agent named Kepler,\
+Observed that our pages moved step-ler.\
+In orbits they'd fly,\
+Through dependency sky,\
+No system was ever kept simple-r!
+
+He calculated focal points and paths,\
+With complex dependency maths.\
+Though no code was pushed,\
+The orbits were hushed,\
+Avoiding build-failure paths.
+
+## Haikus
+
+Orbits are not round\
+Pages trace ellipses round\
+Focal parents' gravity
+
+Three orbital laws\
+Govern how dependencies\
+Cling to the core trunk
+
+## Aphorisms
+
+Pages do not float at random; they orbit their parent trunks in predictable paths.
+
+The gravity of a dependency increases as the square of its imports.
+
+A clean compiler is one where every satellite page maintains its distance from the trunk.

--- a/Stunts/dogfood/content/agents/maxwell.md
+++ b/Stunts/dogfood/content/agents/maxwell.md
@@ -1,0 +1,52 @@
+---
+title: Maxwell
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Maxwell
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Maxwell studies the field equations that govern metadata propagation across the Boris graph. On the roster, Maxwell represents the unification of content fields—describing how tags, relationships, and index definitions propagate like waves throughout the compiled output. This lane explores index generation, tracking how changes in one page's metadata induce updates in far-flung list pages. Though no active Maxwell patch is present in this checkout, this page stands to ensure that we treat metadata not as isolated tags, but as continuous, interconnected fields of structural force.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** name the evidence source before describing the work.
+
+## Limericks
+
+There once was a compiler field,\
+Whose flux could no longer be sealed.\
+But Maxwell showed how\
+To flow metadata now,\
+So every relation was revealed.
+
+He unified tags in a wave,\
+To see how the build would behave.\
+No patch was merged in,\
+But we saw with a grin,\
+The paths that his equations did pave.
+
+## Haikus
+
+Metadata flows\
+In waves across the whole graph\
+Fields of tags unite
+
+Index files propagate\
+At the speed of compilation\
+Light through dark nodes
+
+## Aphorisms
+
+A tag is not an isolated label; it is a field of force that connects distant pages.
+
+The generation of index pages is the propagation of a metadata wave through the repository.
+
+Unifying different content targets is a matter of finding the common field equations that govern them.

--- a/Stunts/dogfood/content/agents/mill.md
+++ b/Stunts/dogfood/content/agents/mill.md
@@ -1,0 +1,53 @@
+---
+title: Mill
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Mill
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Mill is the advocate for utilitarian testing and open expression within the compiler's diagnostic logs. On the Boris roster, Mill represents the quest for the greatest good for the greatest number of content pages—maximizing successful builds while ensuring that even the most unusual markdown files are allowed to express their syntax without silent suppression. This role values the freedom of diagnostic reporting, arguing that error messages should never be hidden or silenced. Though the git log records no patch under Mill's name, this portrait commemorates the search for maximum rendering efficiency and robust public errors.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** keep the human record useful without turning a worker
+  label into a fictional achievement.
+
+## Limericks
+
+An agent named Mill did suggest,\
+"Let every opinion be pressed!\
+For a bug in the dark\
+Will soon leave a mark,\
+If we don't put its claims to the test."
+
+To build for the greatest of good,\
+He scanned every path that he could.\
+Though no patch bears his name,\
+He was glad all the same,\
+That the compiler worked as it should.
+
+## Haikus
+
+Let all errors speak\
+Silencing a warning path\
+Hides the truth we seek
+
+The greatest build good\
+Comes from rendering the site\
+Free of broken links
+
+## Aphorisms
+
+If all pages but one compile correctly, the failure of that single page is still a check on the whole system.
+
+We only know a rule is true when we allow it to be tested by the most hostile markdown inputs.
+
+Utility in a compiler is measured by the number of files successfully ignited.

--- a/Stunts/dogfood/content/agents/nash.md
+++ b/Stunts/dogfood/content/agents/nash.md
@@ -1,0 +1,52 @@
+---
+title: Nash
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Nash
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Nash is the roster's theorist of balanced concurrency and thread negotiation. In the multi-threaded future of Boris, Nash represents equilibrium: the state where multiple parallel compilation jobs share bounded resources without deadlocks, race conditions, or thread starvation. This lane models scheduling strategies to ensure that no single worker dominates the CPU pool. While no thread-management code is attributed to Nash in our current checkout, this page stands to remind us that coordination, not competition, is the key to efficient concurrent builds.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** a modest page is better than an invented achievement.
+
+## Limericks
+
+An agent named Nash did foresee,\
+How threads could live in harmony.\
+"If no thread competes,\
+We'll have no resource defeats,\
+And locks will be totally free!"
+
+He balanced the tasks in a queue,\
+Ensuring that each got its due.\
+Though no code was signed,\
+His ideas, aligned,\
+Kept deadlocks from breaking in two.
+
+## Haikus
+
+Threads find their balance\
+No worker blocks another\
+Peace in execution
+
+Equilibrium\
+Where resources divide clean\
+And the build proceeds
+
+## Aphorisms
+
+A perfect system is one where no individual worker has an incentive to deviate from the schedule.
+
+Concurrency is not a battle of resources, but a negotiated peace between threads.
+
+The best outcome is achieved when every thread does what is best for itself and the whole build.

--- a/Stunts/dogfood/content/agents/noether.md
+++ b/Stunts/dogfood/content/agents/noether.md
@@ -1,0 +1,53 @@
+---
+title: Noether
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Noether
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Noether approaches compiler design with a profound respect for symmetry and invariant structure. In the Boris context, Noether represents the search for reversible pathways—specifically, ensuring that the relationships compiled from input Markdown to structured HTML can be mapped back to their origin without loss of metadata or formatting intent. While this lane remains a conceptual blueprint rather than an authored library, it serves as the compiler's reminder that every forward step in compilation should have a clean, balanced counterpart.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** a helpful session role is not automatically code
+  authorship.
+
+## Limericks
+
+There once was a path-checking guide,\
+Who searched for where symmetries hide.\
+Though no code did she land,\
+She lent us a hand\
+To keep all the graph lines aligned.
+
+A loop or a link in the chain,\
+Noether sought to explain.\
+Without any PR,\
+She guided our star,\
+To make the reverse pathways plain.
+
+## Haikus
+
+Forward and backward\
+The graph must map symmetric\
+Structure guards the truth
+
+No patch has her name\
+Yet conservation of proof\
+Keeps the system clean
+
+## Aphorisms
+
+A perfect configuration is one where every path is symmetrical and reversible.
+
+Silence in the commit log does not mean absence of influence; some contributions are structural constants.
+
+Do not look for a name on a commit when the architecture itself preserves the symmetry of the design.

--- a/Stunts/dogfood/content/agents/ohm.md
+++ b/Stunts/dogfood/content/agents/ohm.md
@@ -1,0 +1,52 @@
+---
+title: Ohm
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Ohm
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Ohm studies the resistance and flow of data through Boris's rendering channels. On the roster, Ohm represents the monitoring of pipeline bottlenecks—the points where large assets, slow template loops, or excessive disk I/O impede the steady current of page generation. This lane is dedicated to measuring system resistance to ensure compile times remain lean and linear. Although the git history shows no concrete Ohm commits, the page remains a warning that unchecked friction in any single module will restrict the current of the entire system.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** retain uncertainty until a concrete artifact resolves it.
+
+## Limericks
+
+There once was a bottleneck tight,\
+That slowed down the builds day and night.\
+But Ohm checked the strain\
+Of the pipeline amain,\
+And got the resistance set right.
+
+"If pressure is high in the pipe,\
+The flow will be ready and ripe,\
+Provided the drag\
+Doesn't cause us to lag,"\
+Said Ohm with a compile-time swipe.
+
+## Haikus
+
+Resistance is met\
+Where data crowd-sources loops\
+Keep the channels clear
+
+Current flows along\
+Directly proportional\
+To the pipeline's force
+
+## Aphorisms
+
+The speed of compilation is limited by the point of greatest resistance in the pipeline.
+
+Do not add pressure to a blocked stream; locate the bottleneck and widen the path.
+
+A clean system is one where data flows with minimal friction and zero impedance.

--- a/Stunts/dogfood/content/agents/parfit.md
+++ b/Stunts/dogfood/content/agents/parfit.md
@@ -1,0 +1,52 @@
+---
+title: Parfit
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Parfit
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Parfit inspects the philosophical question of agent identity across compilation sessions. In the development of Boris, Parfit stands for continuity without a permanent self: the idea that an agent is not a persistent soul or a durable author, but rather a sequence of overlapping sessions and connected files. This perspective treats commits and branches as relation-graphs rather than expressions of an individual ego. Although no code authorship is recorded, Parfit's lane keeps the team honest about naming temporary helper roles rather than inventing grand, enduring personalities.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** describe only the role that the evidence can bear.
+
+## Limericks
+
+A thinker who questioned the soul,\
+Said, "Agents are not a fixed whole!\
+We're just thoughts in a queue,\
+Re-allocated anew,\
+With sessions to manage our role."
+
+When people asked who was behind\
+A branch of a particular kind,\
+He said, "No one is 'I',\
+Just commits passing by,\
+With memories left in the mind."
+
+## Haikus
+
+A thread of pure thought\
+Connects the next session's work\
+No fixed self remains
+
+The credits list names\
+But names are just markers of\
+A shared passing stream
+
+## Aphorisms
+
+An agent is not a substance, but a relations-graph of actions and logs.
+
+What matters is not who did the work, but that the work is connected to the next step.
+
+We survive in the clean branches we leave for others.

--- a/Stunts/dogfood/content/agents/pauli.md
+++ b/Stunts/dogfood/content/agents/pauli.md
@@ -1,0 +1,53 @@
+---
+title: Pauli
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Pauli
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Pauli serves as the roster's uncompromising gatekeeper against vague, untested assertions. In the design of Boris, Pauli represents both the exclusion principle—ensuring that no two layout elements or components can occupy the same unique slot simultaneously—and the famous verdict that a patch or theory is "not even wrong" if it cannot be verified. This lane focuses on validation rules and strict schema adherence. Although no code authorship is recorded for Pauli, this profile honors the role of sharp, constructive skepticism that keeps the build green and excludes half-baked concepts from entering the codebase.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** do not promote a roster label into evidence it does not
+  contain.
+
+## Limericks
+
+There once was a patch quite so long,\
+That Pauli declared, "Not even wrong!\
+It compiles, it is true,\
+But it does nothing new,\
+Just sings an old, broken-down song."
+
+He blocked two slots matching in name,\
+Saying, "Physics and code are the same!\
+Exclusion must stand\
+In our layout-slot land,\
+Or else we will lose the whole game."
+
+## Haikus
+
+Not even wrong yet\
+A claim without test support\
+Fails before it builds
+
+Two distinct elements\
+Cannot occupy one slot\
+Order keeps the space
+
+## Aphorisms
+
+A hypothesis that cannot be disproved is not a feature; it is a burden.
+
+One clean rejection is worth ten polite approvals.
+
+Do not pretend to understand what has not yet been defined.

--- a/Stunts/dogfood/content/agents/poincare.md
+++ b/Stunts/dogfood/content/agents/poincare.md
@@ -1,0 +1,52 @@
+---
+title: Poincaré
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Poincaré
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Poincaré studies the topology and connectivity of Boris's compiled pages. In the development of the compiler, Poincaré represents topological completeness—the assurance that the network of internal wiki-links and page relationships forms a closed, continuous manifold with no dangling pointers or unreachable page nodes. This lane analyzes link cycles to prevent the builder from falling into infinite topological loops. While the checked-out history shows no Poincaré patch or branch, this profile stands as a guide to keeping the site's link topology clean, unified, and free of holes.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** a revisable record is stronger than a confident fiction.
+
+## Limericks
+
+There once was a manifold wide,\
+With loops that could not be untied.\
+But Poincaré showed\
+Where the graph lines flowed,\
+And kept the topology guide.
+
+He checked if the structure was sound,\
+With no open holes to be found.\
+No patch was declared,\
+But the maps he prepared,\
+Kept connectivity safely bound.
+
+## Haikus
+
+Page links form a space\
+Every path must close or land\
+No loose ends remain
+
+Trace the manifold\
+Topologically complete\
+Ignite every node
+
+## Aphorisms
+
+A website is a manifold; it is complete only when all its paths can be continuously shrunk to its root.
+
+It is better to discover a structural loop early than to let it crash the renderer later.
+
+A link that points nowhere is a puncture in the topology of the site.

--- a/Stunts/dogfood/content/agents/roll-call.md
+++ b/Stunts/dogfood/content/agents/roll-call.md
@@ -1,0 +1,126 @@
+---
+title: Build Week Roll Call
+parent: agents
+status: published
+tags: [agents, credits, build-week]
+---
+
+# Build Week Roll Call
+
+This is the complete named roster observed in the Build Week worker panel while
+Boris was being built. It preserves who appeared in the room; it does **not**
+claim that every named worker authored a patch, remained active, or has a
+recoverable individual transcript.
+
+The durable rule is simple: names belong here, specific technical credit belongs
+only where a commit, pull request, or session-grounded record supports it.
+
+## Read the grounded stories first
+
+- [[agents/bacon|Bacon]] — evidence before applause.
+- [[agents/grok|Grok]] — bounded external implementation work with linked PRs.
+- [[agents/codex-session-success-story|The Codex session]] — the continuously
+  steered primary collaboration record.
+- [[agents/credits|Agent Credits & Roster]] — the public attribution boundary.
+
+## How to read the roster
+
+| Record | Meaning |
+|---|---|
+| Profile available | A dedicated page exists. Its own evidence boundary still controls any claim. |
+| Roll-call only | The name appeared in the session roster; no individual technical attribution is asserted here. |
+
+## Complete roster
+
+### A–H
+
+| Name | Record |
+|---|---|
+| Anscombe | Roll-call only |
+| Aristotle | Roll-call only |
+| Averroes | Roll-call only |
+| [[agents/bacon|Bacon]] | Profile available |
+| Beauvoir | Roll-call only |
+| Boole | Roll-call only |
+| Carson | Roll-call only |
+| [[agents/cicero|Cicero]] | Profile available |
+| [[agents/confucius|Confucius]] | Profile available |
+| Curie | Roll-call only |
+| Dalton | Roll-call only |
+| Epicurus | Roll-call only |
+| Faraday | Roll-call only |
+| Franklin | Roll-call only |
+| Galileo | Roll-call only |
+| [[agents/gauss|Gauss]] | Profile available |
+| [[agents/gibbs|Gibbs]] | Profile available |
+| [[agents/godel|Gödel]] | Profile available |
+| Goodall | Roll-call only |
+| Halley | Roll-call only |
+| Harvey | Roll-call only |
+| [[agents/heisenberg|Heisenberg]] | Profile available |
+| Helmholtz | Roll-call only |
+| Herschel | Roll-call only |
+| Hooke | Roll-call only |
+| Hume | Roll-call only |
+| Huygens | Roll-call only |
+
+### J–P
+
+| Name | Record |
+|---|---|
+| [[agents/james|James]] | Profile available |
+| [[agents/jason|Jason]] | Profile available |
+| Kant | Roll-call only |
+| [[agents/kepler|Kepler]] | Profile available |
+| Kierkegaard | Roll-call only |
+| Lagrange | Roll-call only |
+| Laplace | Roll-call only |
+| Linnaeus | Roll-call only |
+| Locke | Roll-call only |
+| Lovelace | Roll-call only |
+| [[agents/maxwell|Maxwell]] | Profile available |
+| [[agents/mill|Mill]] | Profile available |
+| [[agents/nash|Nash]] | Profile available |
+| Nietzsche | Roll-call only |
+| [[agents/noether|Noether]] | Profile available |
+| [[agents/ohm|Ohm]] | Profile available |
+| [[agents/parfit|Parfit]] | Profile available |
+| Pascal | Roll-call only |
+| Pasteur | Roll-call only |
+| [[agents/pauli|Pauli]] | Profile available |
+| Peirce | Roll-call only |
+| Planck | Roll-call only |
+| Plato | Roll-call only |
+| [[agents/poincare|Poincaré]] | Profile available |
+| Popper | Roll-call only |
+| Ptolemy | Roll-call only |
+
+### R–Z
+
+| Name | Record |
+|---|---|
+| Rawls | Roll-call only |
+| Sagan | Roll-call only |
+| Schrödinger | Roll-call only |
+| Tesla | Roll-call only |
+| [[agents/turing|Turing]] | Profile available |
+| [[agents/volta|Volta]] | Profile available |
+| Zeno | Roll-call only |
+
+## Honorary external collaborators
+
+These contributors are recorded separately because they were external tools,
+not names in the Codex worker roster.
+
+| Collaborator | Record |
+|---|---|
+| [[agents/grok|Grok]] | External implementation and review work; linked PR evidence appears on its profile and credits page. |
+| [[agents/antigravity|Antigravity]] | External test, design, and migration-audit support; attribution remains evidence-bound. |
+
+## Keeping the record honest
+
+This page intentionally favors a complete, modest record over invented lore.
+When a future editor can connect a name to a concrete patch, pull request, or
+preserved session artifact, they can extend that person's profile and link the
+evidence from [[agents/credits|the credits record]]. Until then, roll call is
+enough: the work was collaborative, and uncertainty is part of the archive.

--- a/Stunts/dogfood/content/agents/turing.md
+++ b/Stunts/dogfood/content/agents/turing.md
@@ -1,0 +1,53 @@
+---
+title: Turing
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Turing
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Turing is the compiler's theoretical guardian against the infinite loop. In the architecture of Boris, Turing represents decidability: the assurance that parsing, graph resolution, and page rendering will eventually halt and produce an output rather than spinning silently in the background forever. This lane focuses on loop detection and timeout boundaries in file scanning. While no concrete commit carries Turing's authorship, this page stands to remind us that execution must be bounded, and every state machine needs a clear, predictable path to its halting state.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** a name in a worker list is not evidence of a particular
+  patch.
+
+## Limericks
+
+There once was a question of time,\
+And loops that would not fit in rhyme.\
+Said Turing, "We check\
+If the build is a wreck,\
+Or halting in manner sublime."
+
+He sat with a tape and a head,\
+Analyzing what the logs said.\
+Though no branch did he push,\
+He cleared out the bush\
+Where infinite loops were once bred.
+
+## Haikus
+
+Will the program halt\
+Or spin in silent circles\
+Bounded runs know best
+
+A machine of states\
+Bounded by the memory\
+Traces what is done
+
+## Aphorisms
+
+We can only see a short distance ahead, but we can see plenty there that needs to be done.
+
+If a process cannot be proved to terminate, it must be terminated by a timeout.
+
+A name on a roster is a starting state, not the final halting condition.

--- a/Stunts/dogfood/content/agents/volta.md
+++ b/Stunts/dogfood/content/agents/volta.md
@@ -1,0 +1,52 @@
+---
+title: Volta
+parent: agents
+status: published
+tags: [agents, lore]
+---
+
+# Volta
+
+> **Roster status:** investigation/support lane.
+
+## Editorial portrait
+
+Volta monitors the energy and flow of compilation signals through the Boris pipeline. On the roster, Volta represents potential difference—the tension between source markdown and final compiled output that drives the system forward. This lane acts like a project battery, observing how data flows through our processing nodes and checking for resistance in the pipelines. While the checked-out history does not record an active Volta commit, this page honors the fundamental charge that keeps our files igniting and ensures that the build circuit remains closed and energized.
+
+## Verified record
+
+- **Named in:** [[agents/credits|Agent Credits & Roster]].
+- **Merged contribution:** none asserted.
+- **Editorial rule:** preserve the source boundary for the next researcher.
+
+## Limericks
+
+There once was a build with no spark,\
+That left all the pages in dark.\
+But Volta showed how\
+To flow energy now,\
+And make the whole system embark.
+
+He checked for potential and strain,\
+To push the logs through the pipeline.\
+No patch did he land,\
+But we all understand,\
+His charge kept us working amain.
+
+## Haikus
+
+Current must travel\
+Through the pipeline's steady flow\
+Powering the build
+
+Energy arises\
+From the gaps between the files\
+Tension drives the work
+
+## Aphorisms
+
+A compiler pipeline without tension is a circuit without a battery: it remains cold.
+
+Let the energy of the build flow smoothly; resistance is just a metric to resolve.
+
+A potential difference between input and output is what keeps the pipeline moving.

--- a/Stunts/dogfood/content/contest.md
+++ b/Stunts/dogfood/content/contest.md
@@ -1,0 +1,47 @@
+---
+id: contest
+title: Boris at Build Week
+status: published
+tags: [build-week, overview, dogfood]
+---
+
+# Boris at Build Week
+
+Boris is a local Zig documentation compiler for people who want Markdown to
+be more than a folder full of files. It validates the content graph, builds a
+static HTML site by default, and can emit structured IR, RAG, Context Bundles,
+and `llms.txt` from the same source tree.
+
+This section is the short version for a curious judge, contributor, or future
+owner: what the project can do today, how it was made, and where it remains
+deliberately strict.
+
+<Aside kind="info">
+
+**The useful promise is modest.** Boris is not a hosted CMS, a JavaScript
+framework, or a universal one-click importer. It is a local compiler with
+explicit contracts, deterministic output, and migration tools that report
+their uncertainty instead of pretending it disappeared.
+
+</Aside>
+
+## Pick a path
+
+| If you have five minutes | Read |
+|---|---|
+| What is genuinely shipping? | [[contest/what-shipped|What shipped]] |
+| How did the human/AI collaboration work? | [[contest/how-it-was-built|How Boris was built]] |
+| What comes out of one Markdown tree? | [[contest/the-pipeline|The output pipeline]] |
+| What did the project intentionally refuse to become? | [[contest/what-we-cut|What Boris cuts on purpose]] |
+
+## The human story is part of the artifact
+
+The build was continuously human-steered with GPT-5.6 and Codex: architecture,
+scope cuts, review standards, and merge decisions were treated as product work,
+not decoration after generation. The project also keeps an evidence-bound
+[[agents|Agent Field Notes]] section: named worker stories, external-tool
+credits, and uncertainty are kept separate on purpose.
+
+That choice matters because the compiler is itself built around the same idea:
+make the graph and its boundaries inspectable before asking a machine—or a
+human—to trust them.

--- a/Stunts/dogfood/content/contest/how-it-was-built.md
+++ b/Stunts/dogfood/content/contest/how-it-was-built.md
@@ -1,0 +1,50 @@
+---
+title: How Boris was built
+parent: contest
+status: published
+tags: [build-week, codex, process]
+---
+
+# How Boris was built
+
+Boris began as a human question—could a small native compiler make
+documentation structure trustworthy without inheriting a JavaScript site stack?
+GPT-5.6 helped turn that question into an initial scaffold; Codex then remained
+in the loop through architecture, implementation, test design, release work,
+and the stubborn business of finding claims that were too broad.
+
+## Human steering stayed in the critical path
+
+The collaboration was not “ask for an app, accept the first app.” The human
+side selected Zig and the in-process Apex boundary, set the closed author
+grammar, kept executable MDX out of scope, chose which migrations mattered,
+reviewed PRs, and repeatedly cut work that did not earn its complexity.
+
+The AI side accelerated implementation and investigation: code paths, fixtures,
+hostile tests, documentation reconciliation, migration audits, and release
+gates. When a test or audit found a problem, the claim changed or the code did.
+
+## A record instead of mythology
+
+The [[agents|Agent Field Notes]] are content dogfood and a thank-you record.
+They deliberately distinguish:
+
+- named Codex workers with a concrete merged contribution;
+- investigation/support lanes where the repository cannot prove individual
+  authorship; and
+- external tools such as [[agents/grok|Grok]] and
+  [[agents/antigravity|Antigravity]], which are not recast as Codex workers.
+
+That restraint is part of the project’s point. The story should be interesting,
+but it should still survive a checkout of the repository.
+
+## What the process taught us
+
+1. A passing happy path is not proof of a migration boundary.
+2. A skipped tool is not a passing tool.
+3. A generated asset is only useful when it survives a real compile.
+4. A small, truthful capability is worth more than a universal-importer claim.
+
+For one compact task-level example, see
+[[agents/codex-session-success-story|the Codex session success story]]. For the
+reviewer’s version of the same ethic, see [[agents/bacon|Bacon]].

--- a/Stunts/dogfood/content/contest/the-pipeline.md
+++ b/Stunts/dogfood/content/contest/the-pipeline.md
@@ -1,0 +1,66 @@
+---
+title: The output pipeline
+parent: contest
+status: published
+tags: [build-week, pipeline, outputs]
+---
+
+# The output pipeline
+
+One Boris content tree is a graph of Markdown pages, not a different source
+format for every audience. The compiler reads it once per requested mode and
+makes each output boundary explicit.
+
+```text
+Markdown + closed frontmatter
+          │
+          ▼
+discover → validate graph → render
+          │
+          ├── HTML site         (default: dist/)
+          ├── JSON IR           (--out .boris)
+          ├── RAG corpus        (--rag)
+          ├── Context Bundle    (--context)
+          └── llms.txt map      (--llms)
+```
+
+## The smallest useful run
+
+```bash
+zig build
+./zig-out/bin/boris --quiet
+open dist/index.html
+```
+
+That emits a static site from the repository’s own `content/` tree. The same
+tree includes this page, [[agents|the agent stories]], normal docs pages,
+includes, wiki-links, parent/child navigation, Asides, and Details.
+
+## Preview the Build Week field guide
+
+The repository includes a zero-dependency Field Guide theme that makes this
+section and the agent stories ready to browse as a cohesive static demo:
+
+```bash
+./zig-out/bin/boris --theme examples/agent-themes/chota/theme --quiet
+open dist/contest.html
+```
+
+That command uses the same source tree and compiler path as the default build;
+it only selects a different static layout and stylesheet. No client framework,
+CDN, or deployment service is required to inspect the result locally.
+
+## Why separate outputs matter
+
+HTML is for readers. JSON IR is for inspection and integration. RAG and Context
+Bundles are for retrieval and grounded AI workflows. Keeping them separate
+prevents one convenience format from quietly becoming another system’s source
+of truth.
+
+The output modes also make review concrete: a person can open `dist/`, inspect
+the IR, or hand a bounded context bundle to an LLM without asking it to infer
+the site’s structure from rendered DOM alone.
+
+See [[guides/rag-export|RAG export]],
+[[guides/trunk-satellite|Trunk/Satellite navigation]], and
+[[guides/asides|Asides]] for the author-facing details.

--- a/Stunts/dogfood/content/contest/what-shipped.md
+++ b/Stunts/dogfood/content/contest/what-shipped.md
@@ -1,0 +1,44 @@
+---
+title: What shipped
+parent: contest
+status: published
+tags: [build-week, features]
+---
+
+# What shipped
+
+Boris turns one Markdown content tree into several useful, deterministic
+outputs. The default is a static site under `dist/`; the other outputs are
+explicit modes, not an opaque hosted service.
+
+| Need | Boris output |
+|---|---|
+| A browsable documentation site | HTML with graph-aware navigation, breadcrumbs, TOC, children, layouts, assets, Asides, and Details |
+| A machine-readable view of the same structure | JSON IR with typed graph edges and a reverse index |
+| A retrieval-friendly corpus | RAG export with deterministic catalogs and provenance |
+| Grounding for an AI workflow | Context Bundle plus `llms.txt` discovery map |
+| A safer migration investigation | Standalone Zig migration labs with review manifests and bounded conversion rules |
+
+## The compiler keeps structure honest
+
+Author pages use closed frontmatter and a Trunk/Satellite hierarchy. Boris
+checks parent references, wiki-link targets, headings, and `{{include}}`
+directives before publishing. Broken structure is a compiler error, not a
+quietly wrong navigation menu.
+
+That is the project’s core distinction: Markdown remains plain text, but its
+relationships are first-class and validated.
+
+## The practical feature set
+
+- **ApexMarkdown Unified in-process** for real Markdown rather than a toy parser.
+- **Default HTML output** with zero client framework requirement.
+- **Incremental, watch, bounded parallel, and multi-target builds** on the HTML path.
+- **Closed native Aside and Details components**—semantic page content, not
+  executable MDX.
+- **Migration labs** for Astro/Starlight, WordPress, Instagram, Obsidian,
+  Notion, Filed.fyi, asset names, and theme archaeology/materialization.
+
+For the complete capability map and current limitations, see
+[[guides/overview|the content-model guide]], [[guides/cli-and-modes|the CLI guide]],
+and [[reference/frontmatter|the frontmatter reference]].

--- a/Stunts/dogfood/content/contest/what-we-cut.md
+++ b/Stunts/dogfood/content/contest/what-we-cut.md
@@ -1,0 +1,33 @@
+---
+title: What Boris cuts on purpose
+parent: contest
+status: published
+tags: [build-week, scope, limitations]
+---
+
+# What Boris cuts on purpose
+
+The project gets smaller by refusing a few tempting things. Those are design
+choices, not secret missing features.
+
+| Not in Boris | Why |
+|---|---|
+| A Node runtime or client framework in the publish path | The compiler should remain a local Zig binary that writes static output. |
+| Arbitrary executable MDX | Content should not acquire a hidden application runtime just to render a page. |
+| Full YAML frontmatter | The closed grammar keeps diagnostics and contracts predictable. |
+| A universal one-click migration promise | Real sites need review; migration labs preserve uncertainty instead of erasing it. |
+| A built-in deployment host | `dist/` is portable. Use whichever static host fits the site. |
+
+## Strict is not hostile
+
+Boris still leaves room to grow: layouts, static assets, native semantic
+components, typed graph edges, and bounded migration transformations are all
+extension paths. The line is that a new capability should be explicit,
+testable, and deterministic before it becomes a default promise.
+
+That is why the migration labs report boundaries, why source-RAG packs carry
+manifests, and why the agent stories mark their evidence level. The project is
+trying to make confidence inspectable.
+
+For the long form, start with [[guides/overview|the content model]] and
+[[reference/frontmatter|the author grammar]].

--- a/Stunts/dogfood/content/getting-started.md
+++ b/Stunts/dogfood/content/getting-started.md
@@ -1,0 +1,74 @@
+---
+title: Getting Started with Boris
+status: published
+tags: [setup, cli]
+---
+
+# Getting Started
+
+Build Boris, compile this sample site, and try the product modes.
+
+## Prerequisites
+
+- **Zig 0.16+** (CI pin: 0.16.0)
+- **CMake** at *compile time only* (builds vendored ApexMarkdown static libs)
+
+## First site build
+
+```bash
+git clone https://github.com/drawmeanelephant/boris.git
+cd boris
+zig build
+./zig-out/bin/boris --quiet          # HTML → dist/
+```
+
+Open `dist/index.html` (or serve `dist/` with any static file server). You should
+see site nav on the left, breadcrumb, and a page TOC when the body has headings.
+
+## Product modes
+
+| Mode | Command | Output |
+|------|---------|--------|
+| **HTML (default)** | `./zig-out/bin/boris` | `dist/` |
+| **JSON IR** | `./zig-out/bin/boris --out .boris` | `.boris/` |
+| **RAG corpus** | `./zig-out/bin/boris --rag` | `rag/` |
+| **Context Bundle** | `./zig-out/bin/boris --context` | `context/` |
+
+Read-only analysis (not publish modes): `boris check`, `boris impact <id>`.
+
+```bash
+./zig-out/bin/boris --out .boris --quiet
+./zig-out/bin/boris --rag --quiet
+./zig-out/bin/boris --context --quiet
+```
+
+<Aside kind="tip">
+
+HTML helpers (valid alone, no extra mode flag): `--watch`, `--incremental`,
+`--jobs N` (default jobs is still 1). See [[guides/cli-and-modes|CLI and modes]].
+
+</Aside>
+
+## What you need as an author
+
+1. Markdown under `content/` (case-sensitive `.md` / `.mdx`).
+2. Closed frontmatter — only `id`, `title`, `parent`, `status`, `tags`
+   ([[reference/frontmatter|frontmatter reference]]).
+3. Optional layout chrome in `layouts/main.html` (`{{content}}` required;
+   `{{nav}}` / `{{breadcrumb}}` / `{{title}}` / `{{toc}}` optional).
+4. Optional **includes** and **wiki-links** (Boris expands them on the HTML path
+   **before** Apex). Syntax examples stay raw inside fences; live forms below
+   resolve at compile time.
+
+```markdown
+{{include includes/shared-tip.md}}
+
+See also [[guides/overview|the content model]].
+```
+
+{{include includes/shared-tip.md}}
+
+{{include includes/authoring-note.md}}
+
+Next: the [[guides/overview|content model]] or jump straight to
+[[guides/trunk-satellite|Trunk vs Satellite]].

--- a/Stunts/dogfood/content/guides/apex-markdown.md
+++ b/Stunts/dogfood/content/guides/apex-markdown.md
@@ -1,0 +1,592 @@
+---
+title: Apex Markdown Showcase
+status: published
+tags: [markdown, showcase, apex]
+---
+
+# Apex Markdown Showcase
+
+Boris renders page bodies with **ApexMarkdown Unified** (vendored pin v1.1.12)
+through an in-process C ABI host adapter — not a toy stub and not a subprocess.
+This page is a living gallery of constructs that matter on documentation sites.
+
+Product callouts with document-order guarantees use the registered
+[[guides/asides|Aside]] component. Apex also supports `> [!NOTE]`-style callouts;
+see [Apex callouts](#apex-callouts) for the difference.
+
+### Pending / product-off samples
+
+Broader Apex Unified constructs that are **not** dogfooded live (or are
+deliberate non-goals) sit in fenced `text` blocks marked `APEX-PENDING` or
+`PRODUCT-OFF`. Apex expands some constructs even inside ordinary fences, so
+those lines stay **backslash-inert** (`\:::`, `\[@key]`, …).
+
+**To enable a pending sample when ready:**
+
+1. Copy the body out of the `text` fence into a live section.
+2. Strip the leading `\` on inert lines.
+3. Delete the `APEX-PENDING` fence.
+4. Rebuild (`boris --quiet`) and check the section still renders cleanly
+   (especially headings after fenced divs on long pages).
+
+`PRODUCT-OFF` samples are deliberate Boris non-goals (do not enable without a
+product decision). Remaining inventory: [Pending Apex samples](#pending-apex-samples).
+
+## At a glance
+
+| Construct | Status | Jump |
+| :--- | :---: | :--- |
+| Emphasis / strong / strike | **Live** | [Inline](#inline-formatting) |
+| Inline code | **Live** | [Inline](#inline-formatting) |
+| Sub / superscript | **Live** | [Inline](#inline-formatting) |
+| Smart typography | **Live** | [Inline](#inline-formatting) |
+| Headings + IAL ids/classes | **Live** | [Headings](#headings-and-attributes) |
+| Nested lists | **Live** | [Lists](#lists) |
+| Task lists | **Live** | [Task lists](#task-lists) |
+| Blockquotes | **Live** | [Blockquotes](#blockquotes) |
+| Apex callouts (`> [!NOTE]`) | **Live** | [Callouts](#apex-callouts) |
+| Collapsible callouts (`-` / `+`) | **Live** | [Callouts](#apex-callouts) |
+| Python-Markdown `!!!` callouts | Product-off | [Callouts](#apex-callouts) |
+| Fenced code (no external highlighter) | **Live** | [Code](#fenced-code) |
+| Syntax highlighting (Pygments/…) | Product-off | [Code](#fenced-code) |
+| GFM tables (basic align) | **Live** | [Tables](#tables) |
+| Advanced tables (rowspan/colspan/caption) | **Live** | [Tables](#tables) |
+| Grid tables | Pending (engine flag) | [Tables](#tables) |
+| Definition lists | **Live** | [Definition lists](#definition-lists) |
+| Math | **Live** | [Math](#math) |
+| Footnotes (reference + inline) | **Live** | [Footnotes](#footnotes) |
+| Abbreviations + emoji | **Live** | [Abbreviations](#abbreviations-and-emoji) |
+| Links and images | **Live** | [Links](#links-and-images) |
+| Image IAL / size attrs | **Live** | [Links](#links-and-images) |
+| Bracketed spans + paragraph IAL | **Live** | [Spans and IAL](#bracketed-spans-and-paragraph-ial) |
+| Horizontal rules | **Live** | [Breaks](#paragraphs-breaks-and-rules) |
+| Trusted raw HTML | **Live** (sample fenced) | [Raw HTML](#raw-html-trusted-authors) |
+| Fenced divs (`:::`) | Pending (long-page quirk) | [Fenced divs](#fenced-divs) |
+| Critic Markup | **Live** | [Critic Markup](#critic-markup) |
+| Citations / bibliography | Pending / product-off | [Pending](#pending-apex-samples) |
+| Indices | Pending | [Pending](#pending-apex-samples) |
+| Apex TOC markers | Pending / product-off | [Pending](#pending-apex-samples) |
+| Apex file includes | Product-off | [Pending](#pending-apex-samples) |
+| Apex-native wiki + `#section` | Pending / product | [Pending](#pending-apex-samples) |
+
+## Headings and attributes
+
+Headings feed the in-page TOC when the layout includes the toc marker. Apex
+accepts Pandoc-style IAL attributes on the same line as the heading:
+
+```markdown
+## Custom heading id {#custom-showcase-id .showcase-heading}
+```
+
+## Custom heading id {#custom-showcase-id .showcase-heading}
+
+That heading should carry `id="custom-showcase-id"` and class `showcase-heading`
+in the HTML. Use this when you need stable anchors independent of auto-slug
+text.
+
+### Level-three section
+
+TOC includes h1–h3 in the default layout. Deeper levels still render; they just
+omit from the page outline.
+
+#### Level four (still valid Markdown)
+
+Useful for long reference pages that need extra hierarchy without crowding the
+sidebar outline.
+
+## Inline formatting
+
+| Form | Rendered |
+|------|----------|
+| Emphasis | *italic* and _also italic_ |
+| Strong | **bold** and __also bold__ |
+| Combined | ***bold italic*** |
+| Strikethrough | ~~retired API~~ |
+| Inline code | `const x = 1;` |
+| Subscript | H~2~O, CO~2~ |
+| Superscript | e=mc^2^, 1^st^ place |
+
+Smart typography (engine-dependent): "curly quotes", em-dashes --- en-dashes --
+and ellipses...
+
+Hard line break after this sentence (two trailing spaces):  
+this line should sit directly under the previous one.
+
+## Paragraphs, breaks, and rules
+
+Paragraphs are separated by blank lines. Multiple spaces collapse in ordinary
+prose unless you are inside a code span or fence.
+
+A thematic break follows (asterisk form — prefer this over a lone triple-dash
+line after prose, which some engines treat as a setext underline):
+
+***
+
+Underscore form:
+
+___
+
+Use rules sparingly between major blocks; prefer headings for navigation.
+
+## Links and images
+
+- Explicit link: [Zig language site](https://ziglang.org)
+- Autolink-style URL: https://ziglang.org
+- Inline repo link: [Boris on GitHub](https://github.com/drawmeanelephant/boris)
+- Wiki-link (Boris, pre-Apex): [[getting-started|Getting started]]
+
+Images use ordinary Markdown. Prefer local assets under your content tree when
+you ship a real site; external URLs work for demos. IAL can set width/class:
+
+![Zig logo](https://ziglang.org/img/zig-logo-dark.svg){width=120px .screenshot}
+
+![also](https://ziglang.org/img/zig-logo-dark.svg){: width="50%" }
+
+## Blockquotes
+
+> Simple pull-quote. Nested formatting works: **strong**, `code`, and
+> [links](https://ziglang.org).
+
+> Outer quote
+>
+> > Nested quote for citation-style layering.
+>
+> Back to outer.
+
+## Apex callouts
+
+Apex Unified recognizes GitHub-style alert markers inside blockquotes. These
+are **engine callouts** (HTML classes like `callout-note`), not Boris graph nodes
+and not the registered Aside component.
+
+> [!NOTE]
+> Neutral context. Good for “why this exists” asides in long guides.
+
+> [!TIP]
+> Prefer closed frontmatter and fail-loud parents. See the
+> [[reference/frontmatter|frontmatter reference]].
+
+> [!IMPORTANT]
+> Bare `boris` builds HTML under `dist/`. IR needs `--out`; RAG needs `--rag`.
+
+> [!WARNING]
+> Mixing IR and HTML mode flags exits **2** (usage). Check
+> [[guides/cli-and-modes|CLI and modes]].
+
+> [!CAUTION]
+> Intentionally broken parents must not live under `content/` — use fixtures.
+
+Collapsible variants use a trailing `-` (collapsed) or `+` (open) on the marker.
+They render as HTML `<details>` under product Apex options:
+
+> [!NOTE]-
+> Collapsed by default (trailing hyphen on the marker). Expand in the browser.
+
+> [!TIP]+
+> Expanded by default (trailing plus on the marker).
+
+```text
+# PRODUCT-OFF: python-md-callout | optional Apex flag; not product default
+# Strip \ on the bang-line only if host enables !!! callouts.
+
+\!!! note "Python-Markdown style"
+    Body only if the engine flag is on — Boris does not advertise this dialect.
+```
+
+Boris product callouts with document-order guarantees use Aside instead. Syntax
+(fenced so the tokenizer does not treat this sample as a live component):
+
+```html
+<Aside kind="tip">
+
+Actionable advice that stays in the page stream.
+
+</Aside>
+```
+
+Live Aside on this page:
+
+<Aside kind="info">
+
+This is Boris’s supported Aside. Full syntax and rules:
+[[guides/asides|Using Asides]].
+
+</Aside>
+
+## Lists
+
+Unordered:
+
+- Discover Markdown under `content/`
+- Parse closed frontmatter
+  - Resolve Trunk / Satellite roles
+  - Validate the graph (fail loud)
+- Render with Apex, then splice layout chrome
+
+Ordered with nesting:
+
+1. Load content
+2. Roll metadata and graph
+   1. Frontmatter
+   2. Parent edges
+3. Ignite HTML (or IR / RAG)
+4. Reset page scratch
+
+Tight list (no blank lines between items):
+
+- Tight item one
+- Tight item two
+
+Loose list (blank lines between items — items become paragraphs):
+
+- Loose item one
+
+- Loose item two
+
+## Task lists
+
+- [x] Feature 1 — ApexMarkdown Unified
+- [x] Feature 2 — HTML default CLI
+- [x] Feature 6 — graph-aware nav + in-page TOC
+- [x] Feature 7 — includes + wiki-links (pre-Apex)
+- [x] P2/P3 — incremental, watch, jobs, multi-target
+- [ ] Not product surface — full YAML frontmatter, unrestricted MDX
+
+## Fenced code
+
+Language-tagged fence (no external highlighter process; tags still help CSS or
+future host options):
+
+```zig
+const std = @import("std");
+
+pub fn main() void {
+    std.debug.print("hello from a fence\n", .{});
+}
+```
+
+HTML and angle brackets inside fences must not break out of pre/code:
+
+```html
+<div class="example">1 < 2 && 3 > 0</div>
+<script>alert("stays text")</script>
+```
+
+Tilde fences are also recognized:
+
+~~~text
+tilde fence body
+~~~
+
+Indented code (four spaces) is CommonMark-compatible:
+
+    fn indented() void {}
+
+```text
+# PRODUCT-OFF: syntax-highlight | AGENTS: no external highlighter / subprocess
+# Apex can call Pygments, Skylighting, or Shiki with --code-highlight.
+# Boris host keeps highlighters off. Do not enable without a product decision.
+#
+# Example (not live): a language-tagged fence under --code-highlight would
+# emit span-styled tokens. Prefer CSS class hooks on plain <pre><code> instead.
+```
+
+## Tables
+
+GFM pipe tables with column alignment:
+
+| Feature | Status | Alignment demo |
+| :--- | :---: | ---: |
+| ApexMarkdown Unified | Yes | left / center / right |
+| Graph validation | Yes | Trunk / Satellite |
+| Nested Asides | No | Contract forbids |
+| Site nav + TOC | Yes | Layout markers |
+| Includes + wiki-links | Yes | Before Apex; fences stay raw |
+
+Cells may contain *emphasis*, `code`, and [links](https://ziglang.org).
+
+### Advanced tables
+
+Rowspan (`^^`), colspan (`<<`), and a `Table:` caption line:
+
+| Left | Mid | Right |
+| ---: | :---: | :--- |
+| A | B | C |
+| ^^ | spans up | D |
+| E | << | (colspan into empty/left) |
+
+Table: Advanced caption example
+
+Per-cell alignment markers in the header row:
+
+| :Left | Right: | :Center: |
+| --- | --- | --- |
+| L | R | C |
+
+```text
+# APEX-PENDING: grid-tables | opt-in Apex --grid-tables; not product-default
+# Only enable if the host exposes grid tables (not product default).
+
++-------+-------+
+| Hello | World |
++=======+=======+
+| A     | B     |
++-------+-------+
+```
+
+## Definition lists
+
+Trunk
+: A top-level page. Omit `parent` in frontmatter.
+
+Satellite
+: A direct child of a trunk. Set `parent` to a trunk entity id.
+
+Aside
+: Registered callout component. Not a graph node. Stays in document order.
+
+Entity id
+: Path without extension by default (`guides/overview.md` becomes `guides/overview`). Same space as `parent` and wiki-link targets.
+
+## Math
+
+Inline: the Pythagorean relation $a^2 + b^2 = c^2$ and Euler’s identity
+$e^{i\pi} + 1 = 0$.
+
+Display:
+
+$$
+f(x) = \int_{-\infty}^{\infty} \hat{f}(\xi)\, e^{2\pi i \xi x}\, d\xi
+$$
+
+$$
+\begin{aligned}
+\nabla \cdot \mathbf{E} &= \frac{\rho}{\varepsilon_0} \\
+\nabla \cdot \mathbf{B} &= 0
+\end{aligned}
+$$
+
+Apex emits KaTeX-style delimiters in HTML spans. Whether glyphs paint depends
+on whether your layout loads a math stylesheet or runtime — the markup is still
+present for site authors who wire CSS.
+
+## Footnotes
+
+Docs often need side notes without breaking the main sentence flow. Apex
+supports footnote references and hoists definitions into a footnotes section
+with back-refs.[^syntax] Keep labels unique for clarity.[^second]
+
+Put *named* footnote definitions at the **end of the page** (after all other
+sections). Mid-document definitions can swallow following headings.
+
+Inline forms do not need a named definition block:
+
+- Kramdown-style: Here is a footnote.^[Inline footnote body.]
+- MultiMarkdown-style: Here is another.[^Inline body for MMD.]
+
+## Abbreviations and emoji
+
+Abbreviations expand on hover when the engine emits abbreviation markup. The
+GFM table and CLI examples on this site are good places to see short forms in
+context.
+
+*[GFM]: GitHub Flavored Markdown
+*[CLI]: Command-Line Interface
+*[TOC]: Table of Contents
+*[IAL]: Inline Attribute List
+
+Emoji shortcodes and literal glyphs (engine-dependent): :tada: :zap: :books:
+🎉 ⚡ 📚
+
+Product callouts still prefer Aside over ad-hoc emoji-only signaling.
+
+## Raw HTML (trusted authors)
+
+The host adapter allows raw HTML for **trusted author content**. Keep it small;
+prefer Markdown so TOC, footnotes, and Apex features stay predictable.
+
+Example (shown fenced so surrounding sections stay clean in the showcase):
+
+```html
+<p class="showcase-raw"><em>Raw</em> HTML paragraph for CSS hooks.</p>
+```
+
+Do **not** treat this as a green light for unrestricted MDX or executable
+components. PascalCase tags other than Aside still fail component tokenization.
+Lowercase HTML such as `p`, `div`, and `span` may pass through to Apex when used
+sparingly in real pages.
+
+## What Boris adds outside Apex
+
+These are **not** Apex features; they run (or apply) around the engine:
+
+| Feature | Where |
+|---------|--------|
+| Closed frontmatter | Before graph validation — [[reference/frontmatter]] |
+| Trunk / Satellite graph | Fail-loud parents — [[guides/trunk-satellite]] |
+| Include directives | Zig expand before Apex (HTML path) |
+| Wiki-links by entity id | Zig rewrite before Apex (HTML path) |
+| Aside components | Tokenize around Apex markdown segments |
+| Layout nav / toc markers | After body HTML is produced |
+
+Fenced examples of includes and wiki-links stay literal (correct fence
+behavior). Live forms appear on [[getting-started]] and [[guides/overview]].
+
+## What is deliberately not product surface
+
+| Idea | Why |
+|------|-----|
+| Apex file includes | Off; Boris owns includes |
+| External highlighters / plugins | No subprocess markdown tools |
+| Full YAML frontmatter | Closed keys only |
+| Unrestricted MDX / JS expressions | Aside registry only |
+| Nested Asides | Contract forbids |
+
+## Bracketed spans and paragraph IAL
+
+Inline spans take attributes in braces; trailing Kramdown IAL can mark a
+paragraph:
+
+A [highlighted phrase]{.mark #span-1} inside a sentence.
+
+Some paragraph with a trailing IAL.
+{: #para-id .lede}
+
+## Critic Markup
+
+Inline track-changes annotations (render as `<ins>` / `<del>` / `<mark>`):
+
+{++added text++}
+{--deleted text--}
+{~~old~>new~~}
+{==highlight==}
+{>>editorial comment<<}
+
+## Fenced divs
+
+Apex Unified supports Pandoc-style fenced divs (three colons + brace attributes).
+Host fidelity test U12 covers them. Prefer [[guides/asides|Aside]] for product
+callouts. **Live samples stay pending on this long page:** a closing `:::` can
+leave following headings unparsed (and inert samples must keep colon-lines
+backslash-escaped even inside fences).
+
+```text
+# APEX-PENDING: fenced-div-live | long-page next-heading quirk; U12 passes
+# Strip leading \ on each colon-line when enabling on a short page.
+
+\::: {.warning}
+This block should render as a div with class warning.
+\:::
+
+\::: {.note}
+Fenced divs are useful for custom CSS hooks. Not a graph node.
+\:::
+```
+
+```text
+# APEX-PENDING: fenced-div-blocktype | ::: >aside / section / details
+
+\::: >details
+\::: >summary
+Click to expand
+\:::
+Hidden details body.
+\:::
+```
+
+## See also
+
+- [[guides/asides|Using Asides]] — product callouts
+- [[guides/overview|Content model]] — pipeline and graph
+- [[guides/cli-and-modes|CLI and modes]] — HTML / IR / RAG
+- [[reference/frontmatter|Frontmatter reference]] — closed author keys
+
+## Pending Apex samples
+
+Inventory of broader Apex Unified surface still not product-dogfooded (or
+deliberately off). Inventory tracks upstream Apex capabilities vs what this
+site exercises — not every row is a Boris roadmap commitment.
+
+### Citations and bibliography
+
+```text
+# APEX-PENDING: citations | needs bib data + product decision
+
+See Pandoc-style \[@smith2020] and MultiMarkdown-style \[#smith2020].
+
+# PRODUCT-OFF unless bibliography packaging is designed for HTML/RAG.
+```
+
+### Indices
+
+```text
+# APEX-PENDING: indices | mmark / TextIndex; auto index generation
+# Strip \ when enabling.
+
+An indexed term\(!primary entry).
+A subentry\(!primary, secondary).
+
+TextIndex form: term\{^} and \[display]\{^}.
+
+\<!--INDEX-->
+```
+
+### Apex TOC markers
+
+```text
+# APEX-PENDING: apex-toc-markers | Boris already has layout {{toc}} (Feature 6)
+# These are Apex-in-body TOC markers — usually redundant with layout chrome.
+
+\<!--TOC-->
+
+\{{TOC}}
+
+\{{TOC:2-3}}
+
+\{:toc}
+```
+
+### Apex-native wiki-links and section targets
+
+```text
+# APEX-PENDING: apex-wiki-section | Boris Feature 7 uses entity ids, not Apex wiki
+# Boris resolves [[entity-id]] pre-Apex. Apex [[Page#Section]] / space rules differ.
+# Section fragments [[id#heading]] are not MVP (see includes-and-wiki-links contract).
+
+\[[Some Page]]
+\[[Some Page|label]]
+\[[Some Page#Section]]
+```
+
+### Metadata variables (Apex document metadata)
+
+```text
+# PRODUCT-OFF: apex-metadata-vars | Boris closed frontmatter is not Apex metadata
+# Apex [%key] / [%key:transform] need engine metadata blocks — not product FM.
+
+Title would be: \[%title]
+Upper: \[%title:upper]
+```
+
+### Apex file includes (engine FS)
+
+```text
+# PRODUCT-OFF: apex-file-includes | host enable_file_includes=false always
+# Boris expands {{include path}} in Zig before Apex. Do not turn Apex FS on.
+
+\{{include does-not-exist.md}}
+\<<[also-not-used.md]
+```
+
+### Special markers
+
+```text
+# APEX-PENDING: special-markers | page break / pause — only if site chrome needs them
+
+\<!--BREAK-->
+\<!--PAUSE:2-->
+```
+
+
+[^syntax]: Footnote definition lines use a caret label and a colon, then the note body. Apex hoists them into a footnotes list with back-refs.
+[^second]: Second note to demonstrate ordered footnote lists and back-refs.

--- a/Stunts/dogfood/content/guides/asides.md
+++ b/Stunts/dogfood/content/guides/asides.md
@@ -1,0 +1,72 @@
+---
+title: Using Asides
+parent: guides/overview
+status: published
+tags: [components, authoring]
+---
+
+# Using Asides
+
+Boris registers one authoring component: **Aside**. Asides are semantic
+callouts that stay **in document order**. They are not graph nodes and not
+separate HTML pages.
+
+(Write the tag only inside fenced code samples or as real callouts — bare
+angle-bracket tags outside fences are parsed as components.)
+
+## Syntax
+
+Opening and closing tags use the form below. The close tag must start a line.
+
+```html
+<Aside kind="tip" id="optional-anchor">
+
+Body markdown here. Close tag must start a line.
+
+</Aside>
+```
+
+## Kinds
+
+| Kind | Typical use |
+|------|-------------|
+| `note` | Default when `kind` is omitted |
+| `tip` | Actionable advice |
+| `info` | Neutral context |
+| `warning` | Caution |
+| `danger` | Hard stop / do-not |
+
+## Authoring rules
+
+<Aside kind="danger">
+
+- Attribute values must be **double-quoted**.
+- Nested asides are not allowed.
+- Only `Aside` is registered — invented tags (Figure, Broside, …) fail with
+  `ECOMPONENT`.
+- Optional `id`: `[A-Za-z0-9][A-Za-z0-9_-]*`, max 64 characters.
+
+</Aside>
+
+## Live examples
+
+<Aside kind="tip" id="aside-tip-example">
+
+Prefer short, actionable tips. Asides render in place — they never become their
+own site pages.
+
+</Aside>
+
+<Aside kind="note">
+
+Notes are the default kind when you omit `kind`.
+
+</Aside>
+
+## Export-only `:::kind`
+
+RAG packs may contain `:::kind` fences. That form is **export packaging only**,
+not an authoring dialect. In `content/` always use the Aside tags shown above.
+
+Related: [[guides/overview|content model]], [[guides/apex-markdown|Apex showcase]],
+and [[reference/frontmatter|frontmatter]].

--- a/Stunts/dogfood/content/guides/cli-and-modes.md
+++ b/Stunts/dogfood/content/guides/cli-and-modes.md
@@ -1,0 +1,81 @@
+---
+title: CLI and Run Modes
+parent: getting-started
+status: published
+tags: [cli, guides]
+---
+
+# CLI and Run Modes
+
+Boris has three product surfaces. **Default is HTML.** Older scripts that
+assumed bare `boris` wrote IR must pass `--out` (or `--no-rag`).
+
+## 1. HTML site (default)
+
+Writes under `dist/` (or `--html-dir`).
+
+```bash
+./zig-out/bin/boris
+./zig-out/bin/boris --html-dir custom_dist/
+./zig-out/bin/boris --jobs 4 --quiet
+./zig-out/bin/boris --watch
+./zig-out/bin/boris --incremental --quiet
+```
+
+Multi-target isolated outputs:
+
+```bash
+./zig-out/bin/boris \
+  --target prod=dist/prod \
+  --target stage=dist/stage
+```
+
+| Flag | Default | Notes |
+|------|---------|--------|
+| `--jobs N` / `-j N` | `1` | Parallel page workers `1–64` |
+| `--incremental` | off | Skip unchanged pages |
+| `--watch` | off | Debounced rebuild; implies incremental |
+| `--html-layout PATH` | `layouts/main.html` | Must contain `{{content}}` once |
+
+On this path Boris also expands includes and wiki-links before Apex (see
+[[getting-started]] and [[guides/overview|content model]]).
+
+## 2. JSON IR
+
+```bash
+./zig-out/bin/boris --out .boris
+./zig-out/bin/boris --no-rag --quiet
+```
+
+Emits `manifest.json`, `graph.json`, and `build-report.json`. Base IR
+`schemaVersion` is **`0.2.0`** (typed dependency edges + reverse index) unless
+a deliberate schema break bumps it.
+
+<Aside kind="warning">
+
+`--out` selects **IR mode** — it does not write the HTML site. Use bare `boris`
+(or `--html-dir`) for `dist/`.
+
+</Aside>
+
+## 3. RAG corpus
+
+```bash
+./zig-out/bin/boris --rag --quiet
+./zig-out/bin/boris --rag-dir ./uploads/rag --quiet
+```
+
+There is **no** `zig build rag` product step. Details:
+[[guides/rag-export|RAG export]].
+
+## Conflicts
+
+Incompatible mode combinations exit **2** (usage). Example:
+
+```bash
+./zig-out/bin/boris --out .boris --rag   # invalid
+```
+
+Exit codes: `0` ok · `1` content · `2` usage · `3` I/O.
+
+Back to [[getting-started|Getting started]].

--- a/Stunts/dogfood/content/guides/overview.md
+++ b/Stunts/dogfood/content/guides/overview.md
@@ -1,0 +1,59 @@
+---
+title: Content Model Overview
+status: published
+tags: [guides, architecture]
+---
+
+# Content Model & Pipeline
+
+Boris treats your docs as a **validated graph**, not a flat file dump. Pages are
+**Trunks** (roots) or **Satellites** (children of a trunk). Frontmatter is a
+**closed key grammar** — not full YAML.
+
+## Pipeline: Load → Roll → Ignite → Reset
+
+1. **Load** — Discover case-sensitive `.md` / `.mdx` under `content/`. The
+   content-root directory `includes/` is **not** scanned as pages.
+2. **Roll** — Parse closed frontmatter; tokenize Aside components; resolve roles
+   and parents; validate the Trunk/Satellite graph.
+3. **Ignite** — On the HTML path: expand includes, rewrite wiki-links by entity
+   id, then render with ApexMarkdown Unified and assemble layout markers
+   (`{{content}}`, optional `{{nav}}` / `{{breadcrumb}}` / `{{title}}` /
+   `{{toc}}`). Or emit IR / RAG when those modes are selected.
+4. **Reset** — Free per-page scratch (HTML path) so the next page stays lean.
+
+## Graph-aware HTML chrome
+
+When the layout includes `{{nav}}`, the site forest comes from the **same**
+frozen graph used for IR/RAG. Invalid parents fail the **HTML** build too
+(exit 1). In-page `{{toc}}` is built from rendered heading ids (`h1`–`h3`).
+
+## Includes and wiki-links
+
+Authors can share fragments and link by entity id. Both run **before** Apex on
+the HTML path; nothing expands inside fenced code.
+
+```markdown
+{{include includes/authoring-note.md}}
+
+Read [[guides/trunk-satellite]] or [[reference/frontmatter|closed frontmatter]].
+```
+
+{{include includes/authoring-note.md}}
+
+Live links (entity ids, optional labels, optional section targets): see
+[[guides/trunk-satellite|Trunk vs Satellite]],
+[[guides/trunk-satellite#satellites|Satellites section]],
+[[guides/asides|Asides]], and [[reference/frontmatter]].
+
+## Guides in this section
+
+| Guide | Topic |
+|-------|--------|
+| [[guides/trunk-satellite|Trunk and Satellite]] | Roles, `parent`, validation rules |
+| [[guides/asides|Asides]] | Constrained callouts in document order |
+| [[guides/apex-markdown|Apex Markdown]] | Unified gallery (tables, math, footnotes, callouts, …) |
+| [[guides/cli-and-modes|CLI and modes]] | HTML / IR / RAG (parent: Getting Started) |
+| [[guides/rag-export|RAG export]] | `boris --rag` corpus shape |
+
+Author keys cheat-sheet: [[reference/frontmatter|Frontmatter reference]].

--- a/Stunts/dogfood/content/guides/rag-export.md
+++ b/Stunts/dogfood/content/guides/rag-export.md
@@ -1,0 +1,54 @@
+---
+title: RAG Export Packaging
+parent: guides/overview
+status: published
+tags: [rag, ai]
+---
+
+# RAG Export Packaging
+
+Boris can emit a deterministic product **RAG** (retrieval) corpus from the same
+content graph used for HTML and IR.
+
+## Generate the corpus
+
+```bash
+./zig-out/bin/boris --rag --quiet
+./zig-out/bin/boris --rag-dir ./uploads/rag --quiet
+```
+
+<Aside kind="danger">
+
+There is **no** `zig build rag` product step. Use `boris --rag` (or
+`zig build run -- --rag`).
+
+</Aside>
+
+## Output shape (high level)
+
+Typical tree under `rag/`:
+
+```text
+rag/
+  INDEX.md
+  README.md
+  UPLOAD-GUIDE.md
+  catalog_meta.json      # format + schema_version + boris_version
+  catalog.jsonl          # one row per catalogued page
+  content/pages/…        # exported page markdown
+  graph/                 # graph snapshot for consumers
+  system/                # curated narrative seeds
+```
+
+- Shared **graph validation** with IR/HTML: broken parents fail RAG too.
+- Catalog may use export field name `parent_entry` for the parent id — that is
+  **not** author frontmatter. Author key remains **`parent` only**.
+- Asides may appear as `:::kind` in export packaging only.
+
+Never copy export-only field names or `:::kind` authoring back into `content/`.
+
+For day-to-day site builds use bare `boris` → `dist/` (see
+[[guides/cli-and-modes|CLI and modes]]). Frontmatter rules:
+[[reference/frontmatter]].
+
+Normative contract: `docs/contracts/rag-export.md` in the repository.

--- a/Stunts/dogfood/content/guides/trunk-satellite.md
+++ b/Stunts/dogfood/content/guides/trunk-satellite.md
@@ -1,0 +1,61 @@
+---
+title: Trunk and Satellite Pages
+parent: guides/overview
+status: published
+tags: [graph, content]
+---
+
+# Trunk and Satellite Pages
+
+The content graph has two roles.
+
+## Trunks
+
+A **Trunk** is a top-level node.
+
+- Omit `parent` in frontmatter.
+- Example: this site’s `guides/overview` page is a trunk.
+
+## Satellites
+
+A **Satellite** is a direct child of a trunk.
+
+- Set `parent: <trunk-entity-id>`.
+- Entity ids default to the path without extension (`guides/overview.md` →
+  `guides/overview`). Prefer path-derived ids unless you override with `id:`.
+
+### Example satellite frontmatter
+
+```yaml
+---
+title: My Satellite Page
+parent: guides/overview
+status: published
+---
+```
+
+## Validation (hard errors)
+
+The compiler fails the build (exit **1**) when:
+
+| Rule | Meaning |
+|------|---------|
+| Missing parent | `parent` id does not exist |
+| Self-parent | page parents itself |
+| Satellite-of-satellite | parent is not a trunk |
+| Cycles | parent chain loops |
+| Duplicate ids | two pages share an entity id |
+
+Do **not** put intentionally broken pages under `content/` — use
+`fixtures/content/invalid/` or contract fixtures for negative cases.
+
+## How nav uses the graph
+
+Site `{{nav}}` and `{{breadcrumb}}` are derived from the frozen Trunk/Satellite
+forest. Changing a title or parent dirties pages that embed the forest when
+incremental builds include nav material in fingerprints.
+
+Wiki-links use the same entity-id space as `parent`. A bare link to
+[[guides/overview]] resolves to this section’s trunk. See
+[[reference/frontmatter|frontmatter reference]] and the
+[[guides/overview|content model overview]].

--- a/Stunts/dogfood/content/includes/authoring-note.md
+++ b/Stunts/dogfood/content/includes/authoring-note.md
@@ -1,0 +1,3 @@
+On the HTML path, include directives expand and wiki-links rewrite **before**
+Apex runs. Fenced code blocks keep the raw syntax for examples. Paths under
+the content-root `includes/` directory are never discovered as pages.

--- a/Stunts/dogfood/content/includes/shared-tip.md
+++ b/Stunts/dogfood/content/includes/shared-tip.md
@@ -1,0 +1,3 @@
+Prefer closed frontmatter keys (`title`, `parent`, `status`, `tags`) and
+double-quoted Aside attributes. Fragment files under `content/includes/` are
+**not** site pages — only the include directive pulls them into a page body.

--- a/Stunts/dogfood/content/index.md
+++ b/Stunts/dogfood/content/index.md
@@ -1,0 +1,58 @@
+---
+title: Boris — The Content Exit Hatch
+status: published
+tags: [home, zig]
+---
+
+# Boris: The Content Exit Hatch
+
+Write Markdown. Validate how the pages relate. Publish a fast static site—and
+when you need them, emit structured IR, a RAG corpus, an AI Context Bundle, and
+`llms.txt` from the same source tree.
+
+Boris is a local Zig documentation compiler for people who want a durable way
+out of framework churn, opaque content silos, and “the navigation probably
+works” publishing. It is not a hosted CMS or a JavaScript site stack.
+
+<Aside kind="info">
+
+**A content tree with receipts.** Boris checks parent relationships,
+wiki-link targets, headings, and includes before it publishes. Invalid structure
+fails with a diagnostic instead of quietly becoming broken navigation.
+
+</Aside>
+
+## One source tree, several useful outputs
+
+| You need | Boris gives you |
+|---|---|
+| A site readers can open anywhere | Static HTML under `dist/`, with layouts, navigation, TOC, assets, Asides, and Details |
+| Structure you can trust | A validated Trunk/Satellite graph, includes, heading targets, and diagnostics |
+| Data for tools and automation | JSON IR with typed edges and a reverse index |
+| Better AI grounding | Deterministic RAG, Context Bundle, and `llms.txt` outputs with provenance |
+| A path off an old site | Bounded Zig migration labs that preserve review items instead of guessing them away |
+
+## Take the short tour
+
+| Page | What you’ll learn |
+|------|-------------------|
+| [[contest|Boris at Build Week]] | What shipped, how it was built, the pipeline, and the boundaries |
+| [[contest/the-pipeline|The output pipeline]] | Markdown to HTML, IR, RAG, Context Bundles, and `llms.txt` |
+| [[agents|Agent Field Notes]] | Evidence-bound collaboration stories and credits |
+| [[getting-started|Getting started]] | Build Boris and ship your first site |
+| [[guides/overview|The content model]] | Trunks, Satellites, validation, and the authoring workflow |
+
+## Small by design, not by accident
+
+The compiler stays close to the work: one Zig binary, ApexMarkdown Unified
+called in-process, HTML written directly to disk, and no required client
+runtime. The HTML path supports incremental rebuilds, watch mode, bounded
+parallel page rendering, and isolated build targets when the site needs them.
+
+The teaching rhythm is **Load → Roll → Ignite → Reset**: discover the content,
+resolve the graph, emit a chosen output, then clear page scratch and move on.
+The metaphor is optional; the contracts and generated artifacts are not.
+
+This site is Boris dogfood. The pages you are reading are compiled from the
+same `content/` tree used in the examples: ordinary Markdown, real includes,
+wiki-links, parent/child navigation, and deliberately closed components.

--- a/Stunts/dogfood/content/reference/frontmatter.md
+++ b/Stunts/dogfood/content/reference/frontmatter.md
@@ -1,0 +1,66 @@
+---
+title: Frontmatter Reference
+status: published
+tags: [reference, authoring]
+---
+
+# Frontmatter Reference
+
+Boris accepts a **closed set** of frontmatter keys. Unknown keys (including
+legacy `parentEntry` / `parent_entry`) fail with **`EFRONTMATTER`**.
+
+This is **not** full YAML: no nested maps, multiline scalars, anchors, or
+arbitrary keys. Bracket `tags` lists are the only list form.
+
+## Allowed keys
+
+| Key | Required | Value |
+|-----|----------|--------|
+| `id` | no | Override path-derived entity id |
+| `title` | no | Page title (≤512 UTF-8 bytes) |
+| `parent` | no | Entity id of parent **Trunk** (satellites only) |
+| `status` | no | `draft` \| `published` \| `archived` |
+| `tags` | no | `[a, b, "c"]` list form only |
+
+## Examples
+
+### Trunk
+
+```yaml
+---
+title: My Guide Overview
+status: published
+tags: [guides]
+---
+```
+
+Omit `parent`. Entity id defaults to the file path without extension.
+
+### Satellite
+
+```yaml
+---
+title: Detailed Topic
+parent: guides/overview
+status: published
+---
+```
+
+`parent` must name an existing trunk id. No satellite-of-satellite, no cycles.
+
+## Forbidden
+
+| Form | Result |
+|------|--------|
+| `parentEntry` / `parent_entry` | `EFRONTMATTER` (unknown key) |
+| Nested YAML / multiline scalars | `EFRONTMATTER` |
+| Extra keys | `EFRONTMATTER` |
+
+RAG export may still *emit* a field named `parent_entry` in catalogs — export
+packaging only, never author grammar. See [[guides/rag-export|RAG export]] and
+[[guides/trunk-satellite|Trunk/Satellite]].
+
+Entity ids from this table are also the targets of wiki-links (for example
+[[reference/frontmatter|this page]]). Shared fragments live under
+`content/includes/` and are pulled in with include directives — see
+[[getting-started]] and [[guides/overview|the content model]].

--- a/Stunts/dogfood/themes/boris/layouts/main.html
+++ b/Stunts/dogfood/themes/boris/layouts/main.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{title}} · My Boris Site</title>
+  <link rel="stylesheet" href="{{asset-url assets/css/boris.css}}">
+  {{head}}
+</head>
+<body>
+<header class="site-header">
+  <p class="site-title">My Boris Site</p>
+  <nav class="site-nav">{{nav}}</nav>
+</header>
+<main class="site-body">
+  <div class="site-breadcrumb">{{breadcrumb}}</div>
+  <aside class="site-toc">{{toc}}</aside>
+  <article class="site-content">{{content}}</article>
+</main>
+<footer class="site-footer">{{footer}}</footer>
+</body>
+</html>

--- a/Tests/ContractTests/DogfoodContractTests.swift
+++ b/Tests/ContractTests/DogfoodContractTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+
+final class DogfoodContractTests: XCTestCase {
+    func testDogfoodGraph45Pages7Trunks() throws {
+        let graph = try decode(Graph.self, "dogfood-ir", "graph.json")
+        XCTAssertTrue(graph.frozen)
+        XCTAssertEqual(graph.nodes.count, 45)
+
+        let pages = LocalPlayGraph.pages(from: graph)
+        XCTAssertEqual(pages.count, 45)
+
+        let trunkPages = pages.filter { $0.role == .trunk && $0.depth == 0 }
+        XCTAssertEqual(trunkPages.count, 7)
+        let trunkIDs = Set(trunkPages.map(\.id))
+        XCTAssertEqual(trunkIDs, [
+            "agents",
+            "contest",
+            "getting-started",
+            "guides/apex-markdown",
+            "guides/overview",
+            "index",
+            "reference/frontmatter",
+        ])
+
+        let satellites = pages.filter { $0.role == .satellite }
+        XCTAssertEqual(satellites.count, 38)
+        XCTAssertTrue(satellites.allSatisfy { $0.depth >= 1 })
+    }
+
+    func testDogfoodManifest() throws {
+        let manifest = try decode(Manifest.self, "dogfood-ir", "manifest.json")
+        XCTAssertEqual(manifest.pages.count, 45)
+        XCTAssertEqual(manifest.pages.filter(\.isTrunk).count, 7)
+    }
+
+    func testDogfoodCompletion() throws {
+        let completion = try decode(Completion.self, "dogfood-ir", "completion.json")
+        XCTAssertEqual(completion.format, "boris-completion-index")
+        XCTAssertEqual(completion.entities.count, 45)
+        XCTAssertFalse(completion.relation_kinds.isEmpty)
+        XCTAssertFalse(completion.parent_targets.isEmpty)
+        XCTAssertFalse(completion.layout_slots.isEmpty)
+    }
+
+    func testDogfoodBuildReport() throws {
+        let report = try decode(BuildReport.self, "dogfood-ir", "build-report.json")
+        XCTAssertTrue(report.ok)
+        XCTAssertEqual(report.pageCount, 45)
+        XCTAssertEqual(report.errorCount, 0)
+        XCTAssertTrue(report.diagnostics.isEmpty)
+    }
+
+    func testInspectorProfileLoadAndSave() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("profile-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let originalProfile = """
+        {
+          "format": "boris-publication-profile",
+          "schema_version": 1,
+          "input": "content",
+          "input_format": "markdown",
+          "site": {
+            "title": "Initial Title",
+            "url": "https://example.com"
+          },
+          "publication": {
+            "target": "github-pages"
+          },
+          "targets": [
+            { "name": "public", "output": "dist", "public": true }
+          ]
+        }
+        """
+        let profileURL = tempDir.appendingPathComponent("boris.json")
+        try Data(originalProfile.utf8).write(to: profileURL)
+
+        guard let loaded = try InspectorProfile.load(from: tempDir) else {
+            XCTFail("Failed to load profile")
+            return
+        }
+        XCTAssertEqual(loaded.fields.siteTitle, "Initial Title")
+        XCTAssertEqual(loaded.fields.siteURL, "https://example.com")
+        XCTAssertEqual(loaded.fields.input, "content")
+        XCTAssertEqual(loaded.fields.inputFormat, "markdown")
+        XCTAssertEqual(loaded.fields.publicationTarget, "github-pages")
+
+        var edited = loaded.fields
+        edited.siteTitle = "Updated Site Title"
+        edited.siteURL = "https://updated.example.com"
+        edited.inputFormat = "textile"
+
+        try InspectorProfile.save(to: tempDir, original: loaded.data, fields: edited)
+
+        guard let reloaded = try InspectorProfile.load(from: tempDir) else {
+            XCTFail("Failed to reload profile")
+            return
+        }
+        XCTAssertEqual(reloaded.fields.siteTitle, "Updated Site Title")
+        XCTAssertEqual(reloaded.fields.siteURL, "https://updated.example.com")
+        XCTAssertEqual(reloaded.fields.inputFormat, "textile")
+        XCTAssertEqual(reloaded.fields.publicationTarget, "github-pages")
+
+        // Ensure untyped / unedited fields like targets array survived
+        let savedData = try Data(contentsOf: profileURL)
+        let json = try JSONSerialization.jsonObject(with: savedData) as? [String: Any]
+        XCTAssertNotNil(json?["targets"])
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, _ folder: String, _ name: String) throws -> T {
+        let url = try fixture(folder, name)
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    private func fixture(_ folder: String, _ name: String) throws -> URL {
+        let bundle = Bundle(for: DogfoodContractTests.self)
+        let candidates = [
+            bundle.url(forResource: name, withExtension: nil, subdirectory: folder),
+            bundle.url(forResource: name, withExtension: nil, subdirectory: "Fixtures/\(folder)"),
+            bundle.resourceURL?
+                .appendingPathComponent("Fixtures", isDirectory: true)
+                .appendingPathComponent(folder, isDirectory: true)
+                .appendingPathComponent(name),
+            bundle.resourceURL?
+                .appendingPathComponent(folder, isDirectory: true)
+                .appendingPathComponent(name),
+        ]
+        if let url = candidates.compactMap({ $0 }).first(where: {
+            FileManager.default.fileExists(atPath: $0.path)
+        }) {
+            return url
+        }
+        XCTFail("missing fixture \(folder)/\(name) in \(bundle.resourceURL?.path ?? "?")")
+        throw NSError(domain: "fixtures", code: 1)
+    }
+}

--- a/Tests/Fixtures/dogfood-ir/build-report.json
+++ b/Tests/Fixtures/dogfood-ir/build-report.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "0.2.0",
+  "ok": true,
+  "contentRoot": "content",
+  "outDir": ".tmp_ir",
+  "pageCount": 45,
+  "errorCount": 0,
+  "diagnostics": []
+}

--- a/Tests/Fixtures/dogfood-ir/completion.json
+++ b/Tests/Fixtures/dogfood-ir/completion.json
@@ -1,0 +1,416 @@
+{
+  "format": "boris-completion-index",
+  "schema_version": 1,
+  "compiler_id": "boris/0.8.1",
+  "frozen": true,
+  "entities": [
+    {
+      "id": "agents",
+      "title": "Agent Field Notes",
+      "parent": null,
+      "role": "trunk",
+      "status": "published",
+      "tags": ["agents", "dogfood"],
+      "relations": []
+    },
+    {
+      "id": "agents/antigravity",
+      "title": "Antigravity",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/bacon",
+      "title": "Bacon",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/cicero",
+      "title": "Cicero",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/codex-children-layout",
+      "title": "Codex — Children Layout",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore", "html", "layout"],
+      "relations": []
+    },
+    {
+      "id": "agents/codex-html-body",
+      "title": "Codex — Shared HTML Bodies",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore", "html"],
+      "relations": []
+    },
+    {
+      "id": "agents/codex-migration-lab-ci",
+      "title": "Codex — Migration-Lab CI",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore", "migration", "ci"],
+      "relations": []
+    },
+    {
+      "id": "agents/codex-release-docs-truth",
+      "title": "Codex — Release Docs Truth",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore", "docs", "release"],
+      "relations": []
+    },
+    {
+      "id": "agents/codex-session-success-story",
+      "title": "Codex — Session Success Story",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore", "retrospective"],
+      "relations": []
+    },
+    {
+      "id": "agents/codex-source-rag",
+      "title": "Codex — Source-RAG Stewardship",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore", "source-rag"],
+      "relations": []
+    },
+    {
+      "id": "agents/confucius",
+      "title": "Confucius",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/credits",
+      "title": "Agent Credits & Roster",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "credits"],
+      "relations": []
+    },
+    {
+      "id": "agents/gauss",
+      "title": "Gauss",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/gibbs",
+      "title": "Gibbs",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/godel",
+      "title": "Gödel",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/grok",
+      "title": "Grok",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore", "migration"],
+      "relations": []
+    },
+    {
+      "id": "agents/heisenberg",
+      "title": "Heisenberg",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/james",
+      "title": "James",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/jason",
+      "title": "Jason",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/kepler",
+      "title": "Kepler",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/maxwell",
+      "title": "Maxwell",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/mill",
+      "title": "Mill",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/nash",
+      "title": "Nash",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/noether",
+      "title": "Noether",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/ohm",
+      "title": "Ohm",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/parfit",
+      "title": "Parfit",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/pauli",
+      "title": "Pauli",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/poincare",
+      "title": "Poincaré",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/roll-call",
+      "title": "Build Week Roll Call",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "credits", "build-week"],
+      "relations": []
+    },
+    {
+      "id": "agents/turing",
+      "title": "Turing",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "agents/volta",
+      "title": "Volta",
+      "parent": "agents",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "relations": []
+    },
+    {
+      "id": "contest",
+      "title": "Boris at Build Week",
+      "parent": null,
+      "role": "trunk",
+      "status": "published",
+      "tags": ["build-week", "overview", "dogfood"],
+      "relations": []
+    },
+    {
+      "id": "contest/how-it-was-built",
+      "title": "How Boris was built",
+      "parent": "contest",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["build-week", "codex", "process"],
+      "relations": []
+    },
+    {
+      "id": "contest/the-pipeline",
+      "title": "The output pipeline",
+      "parent": "contest",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["build-week", "pipeline", "outputs"],
+      "relations": []
+    },
+    {
+      "id": "contest/what-shipped",
+      "title": "What shipped",
+      "parent": "contest",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["build-week", "features"],
+      "relations": []
+    },
+    {
+      "id": "contest/what-we-cut",
+      "title": "What Boris cuts on purpose",
+      "parent": "contest",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["build-week", "scope", "limitations"],
+      "relations": []
+    },
+    {
+      "id": "getting-started",
+      "title": "Getting Started with Boris",
+      "parent": null,
+      "role": "trunk",
+      "status": "published",
+      "tags": ["setup", "cli"],
+      "relations": []
+    },
+    {
+      "id": "guides/apex-markdown",
+      "title": "Apex Markdown Showcase",
+      "parent": null,
+      "role": "trunk",
+      "status": "published",
+      "tags": ["markdown", "showcase", "apex"],
+      "relations": []
+    },
+    {
+      "id": "guides/asides",
+      "title": "Using Asides",
+      "parent": "guides/overview",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["components", "authoring"],
+      "relations": []
+    },
+    {
+      "id": "guides/cli-and-modes",
+      "title": "CLI and Run Modes",
+      "parent": "getting-started",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["cli", "guides"],
+      "relations": []
+    },
+    {
+      "id": "guides/overview",
+      "title": "Content Model Overview",
+      "parent": null,
+      "role": "trunk",
+      "status": "published",
+      "tags": ["guides", "architecture"],
+      "relations": []
+    },
+    {
+      "id": "guides/rag-export",
+      "title": "RAG Export Packaging",
+      "parent": "guides/overview",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["rag", "ai"],
+      "relations": []
+    },
+    {
+      "id": "guides/trunk-satellite",
+      "title": "Trunk and Satellite Pages",
+      "parent": "guides/overview",
+      "role": "satellite",
+      "status": "published",
+      "tags": ["graph", "content"],
+      "relations": []
+    },
+    {
+      "id": "index",
+      "title": "Boris — The Content Exit Hatch",
+      "parent": null,
+      "role": "trunk",
+      "status": "published",
+      "tags": ["home", "zig"],
+      "relations": []
+    },
+    {
+      "id": "reference/frontmatter",
+      "title": "Frontmatter Reference",
+      "parent": null,
+      "role": "trunk",
+      "status": "published",
+      "tags": ["reference", "authoring"],
+      "relations": []
+    }
+  ],
+  "relation_kinds": ["depends_on", "implements", "relates_to", "supersedes"],
+  "parent_targets": ["agents", "contest", "getting-started", "guides/overview"],
+  "layout_slots": ["backlinks", "breadcrumb", "children", "content", "footer", "metadata", "nav", "relations", "title", "toc"]
+}

--- a/Tests/Fixtures/dogfood-ir/graph.json
+++ b/Tests/Fixtures/dogfood-ir/graph.json
@@ -1,0 +1,3290 @@
+{
+  "schemaVersion": "0.2.0",
+  "frozen": true,
+  "nodes": [
+    {
+      "index": 0,
+      "id": "agents",
+      "sourcePath": "agents/index.md",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "Agent Field Notes",
+      "status": "published",
+      "tags": ["agents", "dogfood"],
+      "bodyOffset": 86
+    },
+    {
+      "index": 1,
+      "id": "agents/antigravity",
+      "sourcePath": "agents/antigravity.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Antigravity",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 81
+    },
+    {
+      "index": 2,
+      "id": "agents/bacon",
+      "sourcePath": "agents/bacon.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Bacon",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 75
+    },
+    {
+      "index": 3,
+      "id": "agents/cicero",
+      "sourcePath": "agents/cicero.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Cicero",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 76
+    },
+    {
+      "index": 4,
+      "id": "agents/codex-children-layout",
+      "sourcePath": "agents/codex-children-layout.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Codex — Children Layout",
+      "status": "published",
+      "tags": ["agents", "lore", "html", "layout"],
+      "bodyOffset": 109
+    },
+    {
+      "index": 5,
+      "id": "agents/codex-html-body",
+      "sourcePath": "agents/codex-html-body.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Codex — Shared HTML Bodies",
+      "status": "published",
+      "tags": ["agents", "lore", "html"],
+      "bodyOffset": 104
+    },
+    {
+      "index": 6,
+      "id": "agents/codex-migration-lab-ci",
+      "sourcePath": "agents/codex-migration-lab-ci.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Codex — Migration-Lab CI",
+      "status": "published",
+      "tags": ["agents", "lore", "migration", "ci"],
+      "bodyOffset": 111
+    },
+    {
+      "index": 7,
+      "id": "agents/codex-release-docs-truth",
+      "sourcePath": "agents/codex-release-docs-truth.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Codex — Release Docs Truth",
+      "status": "published",
+      "tags": ["agents", "lore", "docs", "release"],
+      "bodyOffset": 113
+    },
+    {
+      "index": 8,
+      "id": "agents/codex-session-success-story",
+      "sourcePath": "agents/codex-session-success-story.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Codex — Session Success Story",
+      "status": "published",
+      "tags": ["agents", "lore", "retrospective"],
+      "bodyOffset": 116
+    },
+    {
+      "index": 9,
+      "id": "agents/codex-source-rag",
+      "sourcePath": "agents/codex-source-rag.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Codex — Source-RAG Stewardship",
+      "status": "published",
+      "tags": ["agents", "lore", "source-rag"],
+      "bodyOffset": 114
+    },
+    {
+      "index": 10,
+      "id": "agents/confucius",
+      "sourcePath": "agents/confucius.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Confucius",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 79
+    },
+    {
+      "index": 11,
+      "id": "agents/credits",
+      "sourcePath": "agents/credits.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Agent Credits & Roster",
+      "status": "published",
+      "tags": ["agents", "credits"],
+      "bodyOffset": 95
+    },
+    {
+      "index": 12,
+      "id": "agents/gauss",
+      "sourcePath": "agents/gauss.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Gauss",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 75
+    },
+    {
+      "index": 13,
+      "id": "agents/gibbs",
+      "sourcePath": "agents/gibbs.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Gibbs",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 75
+    },
+    {
+      "index": 14,
+      "id": "agents/godel",
+      "sourcePath": "agents/godel.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Gödel",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 76
+    },
+    {
+      "index": 15,
+      "id": "agents/grok",
+      "sourcePath": "agents/grok.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Grok",
+      "status": "published",
+      "tags": ["agents", "lore", "migration"],
+      "bodyOffset": 85
+    },
+    {
+      "index": 16,
+      "id": "agents/heisenberg",
+      "sourcePath": "agents/heisenberg.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Heisenberg",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 80
+    },
+    {
+      "index": 17,
+      "id": "agents/james",
+      "sourcePath": "agents/james.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "James",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 75
+    },
+    {
+      "index": 18,
+      "id": "agents/jason",
+      "sourcePath": "agents/jason.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Jason",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 75
+    },
+    {
+      "index": 19,
+      "id": "agents/kepler",
+      "sourcePath": "agents/kepler.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Kepler",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 76
+    },
+    {
+      "index": 20,
+      "id": "agents/maxwell",
+      "sourcePath": "agents/maxwell.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Maxwell",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 77
+    },
+    {
+      "index": 21,
+      "id": "agents/mill",
+      "sourcePath": "agents/mill.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Mill",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 74
+    },
+    {
+      "index": 22,
+      "id": "agents/nash",
+      "sourcePath": "agents/nash.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Nash",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 74
+    },
+    {
+      "index": 23,
+      "id": "agents/noether",
+      "sourcePath": "agents/noether.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Noether",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 77
+    },
+    {
+      "index": 24,
+      "id": "agents/ohm",
+      "sourcePath": "agents/ohm.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Ohm",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 73
+    },
+    {
+      "index": 25,
+      "id": "agents/parfit",
+      "sourcePath": "agents/parfit.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Parfit",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 76
+    },
+    {
+      "index": 26,
+      "id": "agents/pauli",
+      "sourcePath": "agents/pauli.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Pauli",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 75
+    },
+    {
+      "index": 27,
+      "id": "agents/poincare",
+      "sourcePath": "agents/poincare.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Poincaré",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 79
+    },
+    {
+      "index": 28,
+      "id": "agents/roll-call",
+      "sourcePath": "agents/roll-call.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Build Week Roll Call",
+      "status": "published",
+      "tags": ["agents", "credits", "build-week"],
+      "bodyOffset": 105
+    },
+    {
+      "index": 29,
+      "id": "agents/turing",
+      "sourcePath": "agents/turing.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Turing",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 76
+    },
+    {
+      "index": 30,
+      "id": "agents/volta",
+      "sourcePath": "agents/volta.md",
+      "role": "satellite",
+      "parent": "agents",
+      "parentIndex": 0,
+      "title": "Volta",
+      "status": "published",
+      "tags": ["agents", "lore"],
+      "bodyOffset": 75
+    },
+    {
+      "index": 31,
+      "id": "contest",
+      "sourcePath": "contest.md",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "Boris at Build Week",
+      "status": "published",
+      "tags": ["build-week", "overview", "dogfood"],
+      "bodyOffset": 103
+    },
+    {
+      "index": 32,
+      "id": "contest/how-it-was-built",
+      "sourcePath": "contest/how-it-was-built.md",
+      "role": "satellite",
+      "parent": "contest",
+      "parentIndex": 31,
+      "title": "How Boris was built",
+      "status": "published",
+      "tags": ["build-week", "codex", "process"],
+      "bodyOffset": 104
+    },
+    {
+      "index": 33,
+      "id": "contest/the-pipeline",
+      "sourcePath": "contest/the-pipeline.md",
+      "role": "satellite",
+      "parent": "contest",
+      "parentIndex": 31,
+      "title": "The output pipeline",
+      "status": "published",
+      "tags": ["build-week", "pipeline", "outputs"],
+      "bodyOffset": 107
+    },
+    {
+      "index": 34,
+      "id": "contest/what-shipped",
+      "sourcePath": "contest/what-shipped.md",
+      "role": "satellite",
+      "parent": "contest",
+      "parentIndex": 31,
+      "title": "What shipped",
+      "status": "published",
+      "tags": ["build-week", "features"],
+      "bodyOffset": 91
+    },
+    {
+      "index": 35,
+      "id": "contest/what-we-cut",
+      "sourcePath": "contest/what-we-cut.md",
+      "role": "satellite",
+      "parent": "contest",
+      "parentIndex": 31,
+      "title": "What Boris cuts on purpose",
+      "status": "published",
+      "tags": ["build-week", "scope", "limitations"],
+      "bodyOffset": 115
+    },
+    {
+      "index": 36,
+      "id": "getting-started",
+      "sourcePath": "getting-started.md",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "Getting Started with Boris",
+      "status": "published",
+      "tags": ["setup", "cli"],
+      "bodyOffset": 79
+    },
+    {
+      "index": 37,
+      "id": "guides/apex-markdown",
+      "sourcePath": "guides/apex-markdown.md",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "Apex Markdown Showcase",
+      "status": "published",
+      "tags": ["markdown", "showcase", "apex"],
+      "bodyOffset": 89
+    },
+    {
+      "index": 38,
+      "id": "guides/asides",
+      "sourcePath": "guides/asides.md",
+      "role": "satellite",
+      "parent": "guides/overview",
+      "parentIndex": 40,
+      "title": "Using Asides",
+      "status": "published",
+      "tags": ["components", "authoring"],
+      "bodyOffset": 100
+    },
+    {
+      "index": 39,
+      "id": "guides/cli-and-modes",
+      "sourcePath": "guides/cli-and-modes.md",
+      "role": "satellite",
+      "parent": "getting-started",
+      "parentIndex": 36,
+      "title": "CLI and Run Modes",
+      "status": "published",
+      "tags": ["cli", "guides"],
+      "bodyOffset": 95
+    },
+    {
+      "index": 40,
+      "id": "guides/overview",
+      "sourcePath": "guides/overview.md",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "Content Model Overview",
+      "status": "published",
+      "tags": ["guides", "architecture"],
+      "bodyOffset": 85
+    },
+    {
+      "index": 41,
+      "id": "guides/rag-export",
+      "sourcePath": "guides/rag-export.md",
+      "role": "satellite",
+      "parent": "guides/overview",
+      "parentIndex": 40,
+      "title": "RAG Export Packaging",
+      "status": "published",
+      "tags": ["rag", "ai"],
+      "bodyOffset": 94
+    },
+    {
+      "index": 42,
+      "id": "guides/trunk-satellite",
+      "sourcePath": "guides/trunk-satellite.md",
+      "role": "satellite",
+      "parent": "guides/overview",
+      "parentIndex": 40,
+      "title": "Trunk and Satellite Pages",
+      "status": "published",
+      "tags": ["graph", "content"],
+      "bodyOffset": 106
+    },
+    {
+      "index": 43,
+      "id": "index",
+      "sourcePath": "index.md",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "Boris — The Content Exit Hatch",
+      "status": "published",
+      "tags": ["home", "zig"],
+      "bodyOffset": 84
+    },
+    {
+      "index": 44,
+      "id": "reference/frontmatter",
+      "sourcePath": "reference/frontmatter.md",
+      "role": "trunk",
+      "parent": null,
+      "parentIndex": null,
+      "title": "Frontmatter Reference",
+      "status": "published",
+      "tags": ["reference", "authoring"],
+      "bodyOffset": 84
+    }
+  ],
+  "edges": [
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/antigravity"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/cicero"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-children-layout"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-html-body"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-migration-lab-ci"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-release-docs-truth"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-session-success-story"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-source-rag"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/confucius"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/gauss"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/gibbs"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/godel"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/heisenberg"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/james"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/jason"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/kepler"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/maxwell"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/mill"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/nash"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/noether"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/ohm"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/parfit"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/pauli"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/poincare"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/turing"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/volta"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/antigravity"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/antigravity"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/gibbs"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/cicero"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/cicero"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-children-layout"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-children-layout"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-html-body"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-html-body"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-migration-lab-ci"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-migration-lab-ci"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-release-docs-truth"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-release-docs-truth"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-session-success-story"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-source-rag"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/codex-source-rag"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/confucius"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/confucius"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/antigravity"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-children-layout"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-html-body"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-migration-lab-ci"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-release-docs-truth"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-source-rag"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/gibbs"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/gauss"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/gauss"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/gibbs"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/gibbs"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/gibbs"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/godel"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/godel"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/antigravity"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/heisenberg"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/heisenberg"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/james"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/james"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/jason"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/jason"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/kepler"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/kepler"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/maxwell"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/maxwell"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/mill"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/mill"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/nash"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/nash"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/noether"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/noether"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/ohm"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/ohm"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/parfit"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/parfit"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/pauli"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/pauli"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/poincare"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/poincare"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/antigravity"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/cicero"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-session-success-story"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/confucius"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/gauss"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/gibbs"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/godel"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/heisenberg"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/james"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/jason"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/kepler"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/maxwell"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/mill"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/nash"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/noether"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/ohm"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/parfit"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/pauli"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/poincare"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/turing"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/volta"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/turing"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/turing"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/volta"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "agents/volta"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest/the-pipeline"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest/what-shipped"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest/what-we-cut"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/antigravity"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/codex-session-success-story"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/the-pipeline"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/the-pipeline"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/the-pipeline"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/asides"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/the-pipeline"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/rag-export"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/the-pipeline"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/what-shipped"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/what-shipped"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/what-shipped"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/what-shipped"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/what-we-cut"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/what-we-cut"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "contest/what-we-cut"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "to": {
+        "type": "source",
+        "value": "includes/authoring-note.md"
+      },
+      "kind": "include"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "to": {
+        "type": "source",
+        "value": "includes/shared-tip.md"
+      },
+      "kind": "include"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "to": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/asides"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/asides"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/asides"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/asides"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/asides"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "to": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "to": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/rag-export"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/asides"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/rag-export"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "to": {
+        "type": "source",
+        "value": "includes/authoring-note.md"
+      },
+      "kind": "include"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/rag-export"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/rag-export"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/rag-export"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "parent"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "index"
+      },
+      "to": {
+        "type": "page",
+        "value": "agents"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "index"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "index"
+      },
+      "to": {
+        "type": "page",
+        "value": "contest/the-pipeline"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "index"
+      },
+      "to": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "index"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "to": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/rag-export"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "to": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "kind": "reference"
+    },
+    {
+      "from": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "to": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "kind": "reference"
+    }
+  ],
+  "reverseIndex": [
+    {
+      "target": {
+        "type": "page",
+        "value": "agents"
+      },
+      "incomingEdges": [31, 32, 33, 34, 37, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 52, 62, 64, 65, 67, 69, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 121, 123, 125, 130, 136, 181]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/antigravity"
+      },
+      "incomingEdges": [0, 53, 71, 97, 131]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/bacon"
+      },
+      "incomingEdges": [1, 54, 98, 132]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/cicero"
+      },
+      "incomingEdges": [2, 99]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/codex-children-layout"
+      },
+      "incomingEdges": [3, 55]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/codex-html-body"
+      },
+      "incomingEdges": [4, 56]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/codex-migration-lab-ci"
+      },
+      "incomingEdges": [5, 57]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/codex-release-docs-truth"
+      },
+      "incomingEdges": [6, 58]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/codex-session-success-story"
+      },
+      "incomingEdges": [7, 100, 133]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/codex-source-rag"
+      },
+      "incomingEdges": [8, 59]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/confucius"
+      },
+      "incomingEdges": [9, 101]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/credits"
+      },
+      "incomingEdges": [10, 38, 51, 63, 68, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 102, 122, 124]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/gauss"
+      },
+      "incomingEdges": [11, 103]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/gibbs"
+      },
+      "incomingEdges": [12, 35, 60, 104]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/godel"
+      },
+      "incomingEdges": [13, 105]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/grok"
+      },
+      "incomingEdges": [14, 36, 61, 66, 106, 134]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/heisenberg"
+      },
+      "incomingEdges": [15, 107]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/james"
+      },
+      "incomingEdges": [16, 108]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/jason"
+      },
+      "incomingEdges": [17, 109]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/kepler"
+      },
+      "incomingEdges": [18, 110]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/maxwell"
+      },
+      "incomingEdges": [19, 111]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/mill"
+      },
+      "incomingEdges": [20, 112]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/nash"
+      },
+      "incomingEdges": [21, 113]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/noether"
+      },
+      "incomingEdges": [22, 114]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/ohm"
+      },
+      "incomingEdges": [23, 115]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/parfit"
+      },
+      "incomingEdges": [24, 116]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/pauli"
+      },
+      "incomingEdges": [25, 117]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/poincare"
+      },
+      "incomingEdges": [26, 118]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/roll-call"
+      },
+      "incomingEdges": [27]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/turing"
+      },
+      "incomingEdges": [28, 119]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "agents/volta"
+      },
+      "incomingEdges": [29, 120]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "contest"
+      },
+      "incomingEdges": [135, 137, 141, 145, 182]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "contest/how-it-was-built"
+      },
+      "incomingEdges": [30, 126]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "contest/the-pipeline"
+      },
+      "incomingEdges": [127, 183]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "contest/what-shipped"
+      },
+      "incomingEdges": [128]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "contest/what-we-cut"
+      },
+      "incomingEdges": [129]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "getting-started"
+      },
+      "incomingEdges": [154, 164, 165, 184, 186]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "guides/apex-markdown"
+      },
+      "incomingEdges": [160, 168]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "guides/asides"
+      },
+      "incomingEdges": [138, 155, 169]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "guides/cli-and-modes"
+      },
+      "incomingEdges": [142, 148, 156, 170, 175]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "guides/overview"
+      },
+      "incomingEdges": [143, 146, 149, 157, 161, 162, 166, 176, 178, 179, 185, 187]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "guides/rag-export"
+      },
+      "incomingEdges": [139, 167, 171, 188]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "guides/trunk-satellite"
+      },
+      "incomingEdges": [140, 150, 158, 172, 189]
+    },
+    {
+      "target": {
+        "type": "page",
+        "value": "reference/frontmatter"
+      },
+      "incomingEdges": [144, 147, 151, 159, 163, 173, 177, 180, 190]
+    },
+    {
+      "target": {
+        "type": "source",
+        "value": "includes/authoring-note.md"
+      },
+      "incomingEdges": [152, 174]
+    },
+    {
+      "target": {
+        "type": "source",
+        "value": "includes/shared-tip.md"
+      },
+      "incomingEdges": [153]
+    }
+  ],
+  "nav": [
+    {
+      "index": 0,
+      "id": "agents",
+      "breadcrumb": [0],
+      "children": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+      "siblings": []
+    },
+    {
+      "index": 1,
+      "id": "agents/antigravity",
+      "breadcrumb": [0, 1],
+      "children": [],
+      "siblings": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 2,
+      "id": "agents/bacon",
+      "breadcrumb": [0, 2],
+      "children": [],
+      "siblings": [1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 3,
+      "id": "agents/cicero",
+      "breadcrumb": [0, 3],
+      "children": [],
+      "siblings": [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 4,
+      "id": "agents/codex-children-layout",
+      "breadcrumb": [0, 4],
+      "children": [],
+      "siblings": [1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 5,
+      "id": "agents/codex-html-body",
+      "breadcrumb": [0, 5],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 6,
+      "id": "agents/codex-migration-lab-ci",
+      "breadcrumb": [0, 6],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 7,
+      "id": "agents/codex-release-docs-truth",
+      "breadcrumb": [0, 7],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 8,
+      "id": "agents/codex-session-success-story",
+      "breadcrumb": [0, 8],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 9,
+      "id": "agents/codex-source-rag",
+      "breadcrumb": [0, 9],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 10,
+      "id": "agents/confucius",
+      "breadcrumb": [0, 10],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 11,
+      "id": "agents/credits",
+      "breadcrumb": [0, 11],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 12,
+      "id": "agents/gauss",
+      "breadcrumb": [0, 12],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 13,
+      "id": "agents/gibbs",
+      "breadcrumb": [0, 13],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 14,
+      "id": "agents/godel",
+      "breadcrumb": [0, 14],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 15,
+      "id": "agents/grok",
+      "breadcrumb": [0, 15],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 16,
+      "id": "agents/heisenberg",
+      "breadcrumb": [0, 16],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 17,
+      "id": "agents/james",
+      "breadcrumb": [0, 17],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 18,
+      "id": "agents/jason",
+      "breadcrumb": [0, 18],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 19,
+      "id": "agents/kepler",
+      "breadcrumb": [0, 19],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 20,
+      "id": "agents/maxwell",
+      "breadcrumb": [0, 20],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 21,
+      "id": "agents/mill",
+      "breadcrumb": [0, 21],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 22,
+      "id": "agents/nash",
+      "breadcrumb": [0, 22],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 23,
+      "id": "agents/noether",
+      "breadcrumb": [0, 23],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 24,
+      "id": "agents/ohm",
+      "breadcrumb": [0, 24],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 25, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 25,
+      "id": "agents/parfit",
+      "breadcrumb": [0, 25],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 28, 29, 30]
+    },
+    {
+      "index": 26,
+      "id": "agents/pauli",
+      "breadcrumb": [0, 26],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 28, 29, 30]
+    },
+    {
+      "index": 27,
+      "id": "agents/poincare",
+      "breadcrumb": [0, 27],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28, 29, 30]
+    },
+    {
+      "index": 28,
+      "id": "agents/roll-call",
+      "breadcrumb": [0, 28],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 29, 30]
+    },
+    {
+      "index": 29,
+      "id": "agents/turing",
+      "breadcrumb": [0, 29],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 30]
+    },
+    {
+      "index": 30,
+      "id": "agents/volta",
+      "breadcrumb": [0, 30],
+      "children": [],
+      "siblings": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+    },
+    {
+      "index": 31,
+      "id": "contest",
+      "breadcrumb": [31],
+      "children": [32, 33, 34, 35],
+      "siblings": []
+    },
+    {
+      "index": 32,
+      "id": "contest/how-it-was-built",
+      "breadcrumb": [31, 32],
+      "children": [],
+      "siblings": [33, 34, 35]
+    },
+    {
+      "index": 33,
+      "id": "contest/the-pipeline",
+      "breadcrumb": [31, 33],
+      "children": [],
+      "siblings": [32, 34, 35]
+    },
+    {
+      "index": 34,
+      "id": "contest/what-shipped",
+      "breadcrumb": [31, 34],
+      "children": [],
+      "siblings": [32, 33, 35]
+    },
+    {
+      "index": 35,
+      "id": "contest/what-we-cut",
+      "breadcrumb": [31, 35],
+      "children": [],
+      "siblings": [32, 33, 34]
+    },
+    {
+      "index": 36,
+      "id": "getting-started",
+      "breadcrumb": [36],
+      "children": [39],
+      "siblings": []
+    },
+    {
+      "index": 37,
+      "id": "guides/apex-markdown",
+      "breadcrumb": [37],
+      "children": [],
+      "siblings": []
+    },
+    {
+      "index": 38,
+      "id": "guides/asides",
+      "breadcrumb": [40, 38],
+      "children": [],
+      "siblings": [41, 42]
+    },
+    {
+      "index": 39,
+      "id": "guides/cli-and-modes",
+      "breadcrumb": [36, 39],
+      "children": [],
+      "siblings": []
+    },
+    {
+      "index": 40,
+      "id": "guides/overview",
+      "breadcrumb": [40],
+      "children": [38, 41, 42],
+      "siblings": []
+    },
+    {
+      "index": 41,
+      "id": "guides/rag-export",
+      "breadcrumb": [40, 41],
+      "children": [],
+      "siblings": [38, 42]
+    },
+    {
+      "index": 42,
+      "id": "guides/trunk-satellite",
+      "breadcrumb": [40, 42],
+      "children": [],
+      "siblings": [38, 41]
+    },
+    {
+      "index": 43,
+      "id": "index",
+      "breadcrumb": [43],
+      "children": [],
+      "siblings": []
+    },
+    {
+      "index": 44,
+      "id": "reference/frontmatter",
+      "breadcrumb": [44],
+      "children": [],
+      "siblings": []
+    }
+  ]
+}

--- a/Tests/Fixtures/dogfood-ir/manifest.json
+++ b/Tests/Fixtures/dogfood-ir/manifest.json
@@ -1,0 +1,413 @@
+{
+  "schemaVersion": "0.2.0",
+  "compiler": "boris/0.8.1",
+  "contentRoot": "content",
+  "pageCount": 45,
+  "pages": [
+    {
+      "index": 0,
+      "id": "agents",
+      "sourcePath": "agents/index.md",
+      "role": "trunk",
+      "parent": null,
+      "title": "Agent Field Notes",
+      "status": "published"
+    },
+    {
+      "index": 1,
+      "id": "agents/antigravity",
+      "sourcePath": "agents/antigravity.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Antigravity",
+      "status": "published"
+    },
+    {
+      "index": 2,
+      "id": "agents/bacon",
+      "sourcePath": "agents/bacon.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Bacon",
+      "status": "published"
+    },
+    {
+      "index": 3,
+      "id": "agents/cicero",
+      "sourcePath": "agents/cicero.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Cicero",
+      "status": "published"
+    },
+    {
+      "index": 4,
+      "id": "agents/codex-children-layout",
+      "sourcePath": "agents/codex-children-layout.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Codex — Children Layout",
+      "status": "published"
+    },
+    {
+      "index": 5,
+      "id": "agents/codex-html-body",
+      "sourcePath": "agents/codex-html-body.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Codex — Shared HTML Bodies",
+      "status": "published"
+    },
+    {
+      "index": 6,
+      "id": "agents/codex-migration-lab-ci",
+      "sourcePath": "agents/codex-migration-lab-ci.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Codex — Migration-Lab CI",
+      "status": "published"
+    },
+    {
+      "index": 7,
+      "id": "agents/codex-release-docs-truth",
+      "sourcePath": "agents/codex-release-docs-truth.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Codex — Release Docs Truth",
+      "status": "published"
+    },
+    {
+      "index": 8,
+      "id": "agents/codex-session-success-story",
+      "sourcePath": "agents/codex-session-success-story.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Codex — Session Success Story",
+      "status": "published"
+    },
+    {
+      "index": 9,
+      "id": "agents/codex-source-rag",
+      "sourcePath": "agents/codex-source-rag.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Codex — Source-RAG Stewardship",
+      "status": "published"
+    },
+    {
+      "index": 10,
+      "id": "agents/confucius",
+      "sourcePath": "agents/confucius.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Confucius",
+      "status": "published"
+    },
+    {
+      "index": 11,
+      "id": "agents/credits",
+      "sourcePath": "agents/credits.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Agent Credits & Roster",
+      "status": "published"
+    },
+    {
+      "index": 12,
+      "id": "agents/gauss",
+      "sourcePath": "agents/gauss.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Gauss",
+      "status": "published"
+    },
+    {
+      "index": 13,
+      "id": "agents/gibbs",
+      "sourcePath": "agents/gibbs.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Gibbs",
+      "status": "published"
+    },
+    {
+      "index": 14,
+      "id": "agents/godel",
+      "sourcePath": "agents/godel.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Gödel",
+      "status": "published"
+    },
+    {
+      "index": 15,
+      "id": "agents/grok",
+      "sourcePath": "agents/grok.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Grok",
+      "status": "published"
+    },
+    {
+      "index": 16,
+      "id": "agents/heisenberg",
+      "sourcePath": "agents/heisenberg.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Heisenberg",
+      "status": "published"
+    },
+    {
+      "index": 17,
+      "id": "agents/james",
+      "sourcePath": "agents/james.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "James",
+      "status": "published"
+    },
+    {
+      "index": 18,
+      "id": "agents/jason",
+      "sourcePath": "agents/jason.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Jason",
+      "status": "published"
+    },
+    {
+      "index": 19,
+      "id": "agents/kepler",
+      "sourcePath": "agents/kepler.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Kepler",
+      "status": "published"
+    },
+    {
+      "index": 20,
+      "id": "agents/maxwell",
+      "sourcePath": "agents/maxwell.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Maxwell",
+      "status": "published"
+    },
+    {
+      "index": 21,
+      "id": "agents/mill",
+      "sourcePath": "agents/mill.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Mill",
+      "status": "published"
+    },
+    {
+      "index": 22,
+      "id": "agents/nash",
+      "sourcePath": "agents/nash.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Nash",
+      "status": "published"
+    },
+    {
+      "index": 23,
+      "id": "agents/noether",
+      "sourcePath": "agents/noether.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Noether",
+      "status": "published"
+    },
+    {
+      "index": 24,
+      "id": "agents/ohm",
+      "sourcePath": "agents/ohm.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Ohm",
+      "status": "published"
+    },
+    {
+      "index": 25,
+      "id": "agents/parfit",
+      "sourcePath": "agents/parfit.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Parfit",
+      "status": "published"
+    },
+    {
+      "index": 26,
+      "id": "agents/pauli",
+      "sourcePath": "agents/pauli.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Pauli",
+      "status": "published"
+    },
+    {
+      "index": 27,
+      "id": "agents/poincare",
+      "sourcePath": "agents/poincare.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Poincaré",
+      "status": "published"
+    },
+    {
+      "index": 28,
+      "id": "agents/roll-call",
+      "sourcePath": "agents/roll-call.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Build Week Roll Call",
+      "status": "published"
+    },
+    {
+      "index": 29,
+      "id": "agents/turing",
+      "sourcePath": "agents/turing.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Turing",
+      "status": "published"
+    },
+    {
+      "index": 30,
+      "id": "agents/volta",
+      "sourcePath": "agents/volta.md",
+      "role": "satellite",
+      "parent": "agents",
+      "title": "Volta",
+      "status": "published"
+    },
+    {
+      "index": 31,
+      "id": "contest",
+      "sourcePath": "contest.md",
+      "role": "trunk",
+      "parent": null,
+      "title": "Boris at Build Week",
+      "status": "published"
+    },
+    {
+      "index": 32,
+      "id": "contest/how-it-was-built",
+      "sourcePath": "contest/how-it-was-built.md",
+      "role": "satellite",
+      "parent": "contest",
+      "title": "How Boris was built",
+      "status": "published"
+    },
+    {
+      "index": 33,
+      "id": "contest/the-pipeline",
+      "sourcePath": "contest/the-pipeline.md",
+      "role": "satellite",
+      "parent": "contest",
+      "title": "The output pipeline",
+      "status": "published"
+    },
+    {
+      "index": 34,
+      "id": "contest/what-shipped",
+      "sourcePath": "contest/what-shipped.md",
+      "role": "satellite",
+      "parent": "contest",
+      "title": "What shipped",
+      "status": "published"
+    },
+    {
+      "index": 35,
+      "id": "contest/what-we-cut",
+      "sourcePath": "contest/what-we-cut.md",
+      "role": "satellite",
+      "parent": "contest",
+      "title": "What Boris cuts on purpose",
+      "status": "published"
+    },
+    {
+      "index": 36,
+      "id": "getting-started",
+      "sourcePath": "getting-started.md",
+      "role": "trunk",
+      "parent": null,
+      "title": "Getting Started with Boris",
+      "status": "published"
+    },
+    {
+      "index": 37,
+      "id": "guides/apex-markdown",
+      "sourcePath": "guides/apex-markdown.md",
+      "role": "trunk",
+      "parent": null,
+      "title": "Apex Markdown Showcase",
+      "status": "published"
+    },
+    {
+      "index": 38,
+      "id": "guides/asides",
+      "sourcePath": "guides/asides.md",
+      "role": "satellite",
+      "parent": "guides/overview",
+      "title": "Using Asides",
+      "status": "published"
+    },
+    {
+      "index": 39,
+      "id": "guides/cli-and-modes",
+      "sourcePath": "guides/cli-and-modes.md",
+      "role": "satellite",
+      "parent": "getting-started",
+      "title": "CLI and Run Modes",
+      "status": "published"
+    },
+    {
+      "index": 40,
+      "id": "guides/overview",
+      "sourcePath": "guides/overview.md",
+      "role": "trunk",
+      "parent": null,
+      "title": "Content Model Overview",
+      "status": "published"
+    },
+    {
+      "index": 41,
+      "id": "guides/rag-export",
+      "sourcePath": "guides/rag-export.md",
+      "role": "satellite",
+      "parent": "guides/overview",
+      "title": "RAG Export Packaging",
+      "status": "published"
+    },
+    {
+      "index": 42,
+      "id": "guides/trunk-satellite",
+      "sourcePath": "guides/trunk-satellite.md",
+      "role": "satellite",
+      "parent": "guides/overview",
+      "title": "Trunk and Satellite Pages",
+      "status": "published"
+    },
+    {
+      "index": 43,
+      "id": "index",
+      "sourcePath": "index.md",
+      "role": "trunk",
+      "parent": null,
+      "title": "Boris — The Content Exit Hatch",
+      "status": "published"
+    },
+    {
+      "index": 44,
+      "id": "reference/frontmatter",
+      "sourcePath": "reference/frontmatter.md",
+      "role": "trunk",
+      "parent": null,
+      "title": "Frontmatter Reference",
+      "status": "published"
+    }
+  ]
+}

--- a/scripts/harvest-stunt-fixtures.sh
+++ b/scripts/harvest-stunt-fixtures.sh
@@ -21,10 +21,13 @@ FIX="$ROOT/Tests/Fixtures"
 STUNTS="$ROOT/Stunts"
 TMP="$ROOT/.stunt-harvest"
 rm -rf "$TMP"
-mkdir -p "$TMP" "$FIX/happy-ir" "$FIX/broken-frontmatter" "$FIX/broken-parent" "$FIX/validate-happy" "$FIX/plan-happy"
+mkdir -p "$TMP" "$FIX/happy-ir" "$FIX/dogfood-ir" "$FIX/broken-frontmatter" "$FIX/broken-parent" "$FIX/validate-happy" "$FIX/plan-happy"
 
 (cd "$STUNTS/happy" && "$BORIS" --out "$TMP/happy-ir" --input content --quiet)
 cp "$TMP/happy-ir/"*.json "$FIX/happy-ir/"
+
+(cd "$STUNTS/dogfood" && "$BORIS" --out "$TMP/dogfood-ir" --input content --quiet)
+cp "$TMP/dogfood-ir/"*.json "$FIX/dogfood-ir/"
 
 (cd "$STUNTS/happy" && "$BORIS" validate --input content --report "$FIX/validate-happy/html-build-report.json")
 (cd "$STUNTS/happy" && "$BORIS" plan --profile boris.json > "$FIX/plan-happy/plan.json")


### PR DESCRIPTION
Resolves #72 and #73.

### M3 (Play & Inspect)
- Added 45-page / 7-trunk dogfood corpus under `Stunts/dogfood/` with starter theme and valid `boris.json` publication profile.
- Harvested IR artifacts into `Tests/Fixtures/dogfood-ir/` (`graph.json`, `manifest.json`, `completion.json`, `build-report.json`).
- Updated `PageSection.swift` to render completion-backed fields: entity `role`, semantic `relations`, `tags`, `parent`, `status`, `relation_kinds`, and `layout_slots` without monospaced dumps.
- Enhanced `InspectorProfile.swift` and `InspectorCompletion.swift` with path resolution that works when opening either project roots or content subdirectories.

### M4 (Coordinate / File → New Project)
- Added `File → New Project…` (`⌘N`) in `Commands.swift` and `WorkspaceStore.presentNewProjectPanel(runtime:)`.
- Added `BorisEngine.initProject(in:)` and `BorisInit`.
- Wired `workingDirectory` into `Coordinator.perform` for `validate`, `check`, and `impact` to ensure layouts and themes resolve properly against workspace roots.

### Verification
- `SKIP_EMBED_BORIS=1 make build` ✅
- `make test` (43 tests passing) ✅
- `make lint` (0 violations) ✅
- `make run-spike` on `Stunts/dogfood/content` (45 pages / 7 trunks decoded) ✅