### PR TITLE
feat(m7/m5/m6/m9): outputs fan-out, theme catalog, editor host, preview NDJSON, and release pipeline hardening (#76, #74, #75, #78)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -75,6 +75,7 @@ targets:
     sources:
       - path: Sources/Models
       - path: Sources/Engine
+      - path: Sources/Companions/Editor/EditorURL.swift
       - path: Spike
     settings:
       base:
@@ -91,6 +92,7 @@ targets:
       - path: Sources/Models
       - path: Sources/Security
       - path: Sources/Inspector/InspectorProfile.swift
+      - path: Sources/Inspector/ThemeCatalog.swift
       - path: Sources/Play/Local/LocalPlayGraph.swift
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Sources/Companions/Preview/PreviewURL.swift

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -52,6 +52,12 @@ struct SolipsistCommands: Commands {
             .keyboardShortcut("b", modifiers: [.command, .shift])
             .disabled(!hasSource || runtime.coordinator.isRunning)
 
+            Button("Build All") {
+                runtime.coordinator.run(.buildAll, store: store, runtime: runtime)
+            }
+            .keyboardShortcut("u", modifiers: [.command, .shift])
+            .disabled(!hasSource || runtime.coordinator.isRunning)
+
             Divider()
 
             Button("Check") {

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -6,6 +6,7 @@ enum CoordinatorVerb: String, Sendable {
     case validate
     case buildIR
     case buildHTML
+    case buildAll
     case check
     case impact
 }
@@ -196,6 +197,31 @@ final class Coordinator {
                     summary: "HTML exit \(result.exitCode) · \(result.report?.errorCount ?? items.count) error(s)",
                     problems: items
                 )
+
+            case .buildAll:
+                let workspaceRoot = try source.workspaceRoot()
+                var profile = PublicationProfile(format: "boris-publication-profile")
+                if let pair = try InspectorProfile.load(from: workspaceRoot),
+                   let prof = try? JSONDecoder().decode(PublicationProfile.self, from: pair.data)
+                {
+                    profile = prof
+                }
+                let result = try await engine.buildAll(
+                    contentRoot: source.contentRoot(),
+                    profile: profile,
+                    workingDirectory: workspaceRoot,
+                    timings: true
+                )
+                var items: [ProblemItem] = []
+                for res in result.results {
+                    if let report = res.report {
+                        items.append(contentsOf: Self.problems(from: report))
+                    }
+                }
+                let exit = result.isSuccess ? 0 : (result.results.last?.exitCode ?? 1)
+                let dur = result.totalDurationNs.map { "(\($0 / 1_000_000)ms)" } ?? ""
+                let summary = "Build all \(result.isSuccess ? "succeeded" : "failed") · \(result.results.count) entry(s) \(dur)"
+                return JobResult(exit: exit, summary: summary, problems: items)
 
             case .check:
                 let result = try await engine.check(

--- a/Sources/Chrome/InspectorDrawer.swift
+++ b/Sources/Chrome/InspectorDrawer.swift
@@ -52,6 +52,17 @@ struct InspectorDrawer: View {
                 Text("Select a page in the play place.")
                     .foregroundStyle(.secondary)
             }
+        case InspectorSectionID.target:
+            if let item = store.selectedSource,
+               case .local(let source) = item,
+               let noun = store.selection.noun,
+               noun.kind == InspectorNounKind.target
+            {
+                TargetSection(source: source, targetName: noun.id)
+            } else {
+                Text("Select a target in the outputs view.")
+                    .foregroundStyle(.secondary)
+            }
         case InspectorSectionID.execution:
             ExecutionSection()
         default:

--- a/Sources/Companions/Editor/EditorSession.swift
+++ b/Sources/Companions/Editor/EditorSession.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Observation
+
+/// Drives the M6 author companion surface (A14 / #75): owns the `boris-editor`
+/// subprocess host lifetime and hands the tokenized session URL to the editor web view.
+@MainActor
+@Observable
+final class EditorSession {
+    enum Phase: Equatable {
+        case idle
+        case starting
+        case connected(URL)
+        case failed(String)
+    }
+
+    private(set) var phase: Phase = .idle
+
+    var editorURL: URL? {
+        if case .connected(let url) = phase { return url }
+        return nil
+    }
+
+    var isFailure: Bool {
+        if case .failed = phase { return true }
+        return false
+    }
+
+    var statusText: String {
+        switch phase {
+        case .idle:
+            return ""
+        case .starting:
+            return "Starting boris-editor…"
+        case .connected(let url):
+            return "Connected to \(url.host ?? "loopback")"
+        case .failed(let message):
+            return message
+        }
+    }
+
+    private var server: EditorServer?
+    private var rootPath: String?
+    private var timeoutTask: Task<Void, Never>?
+
+    func start(contentRoot: URL, projectRoot: URL, engine: BorisEngine?) {
+        let root = contentRoot.standardizedFileURL.path
+        if root == rootPath, let server, server.isRunning {
+            if let url = server.editorURL {
+                phase = .connected(url)
+            }
+            return
+        }
+        stop()
+        rootPath = root
+
+        guard let engine else {
+            phase = .failed("Boris engine not available.")
+            return
+        }
+
+        guard let editorBinary = findEditorBinary(relativeTo: engine.binaryURL) else {
+            phase = .failed("boris-editor binary not found. Set SOLIPSIST_BORIS_EDITOR_BIN or build the editor host.")
+            return
+        }
+
+        phase = .starting
+        scheduleTimeout()
+        do {
+            let server = try engine.editorStart(
+                editorBinary: editorBinary,
+                contentRoot: contentRoot,
+                workingDirectory: projectRoot,
+                port: 0
+            )
+            self.server = server
+            server.onConnect = { [weak self] url in
+                Task { @MainActor in self?.handleConnect(url: url) }
+            }
+            server.onExit = { [weak self] exit in
+                Task { @MainActor in self?.handleExit(exit) }
+            }
+        } catch {
+            timeoutTask?.cancel()
+            timeoutTask = nil
+            phase = .failed("Could not start editor host: \(error)")
+        }
+    }
+
+    func fail(_ message: String) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        server?.onConnect = nil
+        server?.onExit = nil
+        server?.stop()
+        server = nil
+        rootPath = nil
+        phase = .failed(message)
+    }
+
+    func stop() {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        if let server {
+            server.onConnect = nil
+            server.onExit = nil
+            server.stop()
+            self.server = nil
+        }
+        rootPath = nil
+        phase = .idle
+    }
+
+    private func handleConnect(url: URL) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        phase = .connected(url)
+    }
+
+    private func handleExit(_ exit: EditorExit) {
+        guard server != nil else { return }
+        server = nil
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        rootPath = nil
+        if exit.exitCode == 0 {
+            phase = .idle
+        } else {
+            let tail = exit.stderrTail.trimmingCharacters(in: .whitespacesAndNewlines)
+            let suffix = tail.isEmpty ? "" : " — \(tail.suffix(200))"
+            phase = .failed("Editor host exited (\(exit.exitCode))\(suffix)")
+        }
+    }
+
+    private func scheduleTimeout() {
+        timeoutTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(15))
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            self.failTimeout()
+        }
+    }
+
+    private func failTimeout() {
+        server?.stop()
+        server = nil
+        timeoutTask = nil
+        rootPath = nil
+        phase = .failed("Editor host did not report a token URL within 15s.")
+    }
+
+    private func findEditorBinary(relativeTo engineBinary: URL) -> URL? {
+        let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_EDITOR_BIN"]
+        if let env, !env.isEmpty, FileManager.default.isExecutableFile(atPath: env) {
+            return URL(fileURLWithPath: env)
+        }
+
+        let sibling = engineBinary.deletingLastPathComponent().appendingPathComponent("boris-editor")
+        if FileManager.default.isExecutableFile(atPath: sibling.path) {
+            return sibling
+        }
+
+        let bundled = Bundle.main.url(forResource: "boris-editor", withExtension: nil)
+        if let bundled, FileManager.default.isExecutableFile(atPath: bundled.path) {
+            return bundled
+        }
+
+        return nil
+    }
+}

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -11,9 +11,11 @@ import WebKit
 /// lets a human paste a `BORIS_EDITOR_URL=` token line into the toolbar.
 struct EditorWindow: View {
     @Environment(WorkspaceStore.self) private var store
+    @Environment(AppRuntime.self) private var runtime
 
     @State private var model = EditorWebModel()
     @State private var urlText = ""
+    @State private var session = EditorSession()
 
     var body: some View {
         Group {
@@ -30,12 +32,41 @@ struct EditorWindow: View {
                         idleState(for: source)
                     }
                 }
+                .task(id: source.id) {
+                    startEditor(for: source)
+                }
             } else {
                 emptyState
             }
         }
         .frame(minWidth: 480, minHeight: 360)
         .navigationTitle("Editor")
+        .onChange(of: session.editorURL) { _, newURL in
+            if let newURL {
+                model.load(url: newURL)
+            }
+        }
+        .onDisappear {
+            session.stop()
+        }
+    }
+
+    private func startEditor(for source: SourceItem) {
+        switch source {
+        case .local(let local):
+            guard
+                let projectRoot = try? local.workspaceRoot(),
+                let contentRoot = try? local.contentRoot()
+            else {
+                session.fail("Could not resolve project folder for '\(source.title)'")
+                return
+            }
+            session.start(
+                contentRoot: contentRoot,
+                projectRoot: projectRoot,
+                engine: runtime.engine
+            )
+        }
     }
 
     /// Single entry point for pointing the web view at an editor URL.
@@ -56,9 +87,17 @@ struct EditorWindow: View {
             Label("Editor Host Not Running", systemImage: "square.and.pencil")
         } description: {
             Text(
-                "The Boris editor for “\(source.title)” will connect when the host process is running. "
-                    + "Paste a BORIS_EDITOR_URL= line above to connect manually."
+                session.statusText.isEmpty
+                    ? "The Boris editor will connect when the host process is running. Paste a BORIS_EDITOR_URL= line above to connect manually."
+                    : session.statusText
             )
+        } actions: {
+            Button("Open in Browser") {
+                if let url = session.editorURL ?? model.currentURL {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+            .disabled(session.editorURL == nil && model.currentURL == nil)
         }
     }
 

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -57,6 +57,26 @@ public struct BorisInit: Sendable {
     public let stderr: String
 }
 
+/// Result of building a single target or edition.
+public struct BorisEntryBuildResult: Sendable {
+    public let name: String
+    public let kind: String // "target", "ir", "rag", "context"
+    public let exitCode: Int32
+    public let report: HTMLBuildReport?
+    public let timings: TimingsReport?
+    public let stdout: String
+    public let stderr: String
+
+    public var isSuccess: Bool { exitCode == 0 }
+}
+
+/// Result of `buildAll` fan-out over profile targets and editions.
+public struct BorisFanoutResult: Sendable {
+    public let isSuccess: Bool
+    public let results: [BorisEntryBuildResult]
+    public let totalDurationNs: Int?
+}
+
 public enum BorisEngineError: Error, Sendable, CustomStringConvertible {
     case binaryNotFound
     case missingArtifact(String)
@@ -205,6 +225,247 @@ public actor BorisEngine {
         return BorisHTMLBuild(exitCode: out.exitCode, report: report, stderr: out.stderrText)
     }
 
+    /// Runs `boris` for a single named `PublicationTarget` from a profile.
+    public func buildTarget(
+        contentRoot: URL,
+        target: PublicationTarget,
+        siteURL: String? = nil,
+        workingDirectory: URL? = nil,
+        timings: Bool = false
+    ) throws -> BorisEntryBuildResult {
+        let cwd = workingDirectory ?? contentRoot.deletingLastPathComponent()
+        let fm = FileManager.default
+        let reportURL = fm.temporaryDirectory
+            .appendingPathComponent("boris-report-\(UUID().uuidString).json")
+        defer { try? fm.removeItem(at: reportURL) }
+
+        var args = [
+            "--input", contentRoot.path,
+            "--target", "\(target.name)=\(target.output)",
+            "--report", reportURL.path,
+            "--quiet",
+        ]
+        if let theme = target.theme, !theme.isEmpty {
+            args.append(contentsOf: ["--theme", theme])
+        }
+        if let layout = target.layout, !layout.isEmpty {
+            args.append(contentsOf: ["--target-layout", "\(target.name)=\(layout)"])
+        }
+        if let rules = target.layout_rules {
+            for rule in rules {
+                args.append(contentsOf: ["--layout-rule", target.name, rule.selector, rule.layout])
+            }
+        }
+        if let siteURL, !siteURL.isEmpty {
+            args.append(contentsOf: ["--site-url", siteURL])
+        }
+        if let sitemap = target.sitemap {
+            args.append(contentsOf: ["--sitemap-path", sitemap.path])
+        }
+        if let rss = target.rss {
+            args.append(contentsOf: ["--rss-path", rss.path])
+        }
+        if let llms = target.llms {
+            args.append(contentsOf: ["--llms-path", llms.path])
+        }
+        if timings {
+            args.append("--timings")
+        }
+
+        let out = try run(arguments: args, workingDirectory: cwd)
+        var report: HTMLBuildReport?
+        if FileManager.default.fileExists(atPath: reportURL.path),
+           let reportData = try? Data(contentsOf: reportURL)
+        {
+            report = decodeJSON(HTMLBuildReport.self, from: reportData)
+        }
+        let timingsReport = timings ? decodeJSON(TimingsReport.self, from: out.stdout) : nil
+
+        return BorisEntryBuildResult(
+            name: target.name,
+            kind: "target",
+            exitCode: out.exitCode,
+            report: report,
+            timings: timingsReport,
+            stdout: out.stdoutText,
+            stderr: out.stderrText
+        )
+    }
+
+    /// Runs `boris` for an edition (`ir`, `rag`, `context`).
+    public func buildEdition(
+        contentRoot: URL,
+        kind: String,
+        outputDir: String,
+        scope: String? = nil,
+        splitSize: Int? = nil,
+        isComplete: Bool = false,
+        workingDirectory: URL? = nil,
+        timings: Bool = false
+    ) throws -> BorisEntryBuildResult {
+        let cwd = workingDirectory ?? contentRoot.deletingLastPathComponent()
+        var args = ["--input", contentRoot.path, "--quiet"]
+        switch kind {
+        case "ir":
+            args.append(contentsOf: ["--out", outputDir])
+        case "rag":
+            args.append(contentsOf: ["--rag-dir", outputDir])
+            if isComplete {
+                args.append("--complete")
+            } else {
+                if let scope, !scope.isEmpty {
+                    args.append(contentsOf: ["--scope", scope])
+                }
+                if let splitSize, splitSize > 0 {
+                    args.append(contentsOf: ["--split-size", "\(splitSize)"])
+                }
+            }
+        case "context":
+            args.append(contentsOf: ["--context-dir", outputDir])
+            if let scope, !scope.isEmpty {
+                args.append(contentsOf: ["--scope", scope])
+            }
+            if let splitSize, splitSize > 0 {
+                args.append(contentsOf: ["--split-size", "\(splitSize)"])
+            }
+        default:
+            args.append(contentsOf: ["--out", outputDir])
+        }
+
+        if timings {
+            args.append("--timings")
+        }
+
+        let out = try run(arguments: args, workingDirectory: cwd)
+        let timingsReport = timings ? decodeJSON(TimingsReport.self, from: out.stdout) : nil
+
+        return BorisEntryBuildResult(
+            name: kind,
+            kind: kind,
+            exitCode: out.exitCode,
+            report: nil,
+            timings: timingsReport,
+            stdout: out.stdoutText,
+            stderr: out.stderrText
+        )
+    }
+
+    /// Fans out builds for all targets and editions in a `PublicationProfile`.
+    /// Follows profile order, executes isolated invocations, and fails fast
+    /// on any target or edition error (as Boris does).
+    public func buildAll(
+        contentRoot: URL,
+        profile: PublicationProfile,
+        workingDirectory: URL? = nil,
+        timings: Bool = true
+    ) throws -> BorisFanoutResult {
+        let cwd = workingDirectory ?? contentRoot.deletingLastPathComponent()
+        var results: [BorisEntryBuildResult] = []
+
+        // 1. Targets in profile order
+        if let targets = profile.targets, !targets.isEmpty {
+            for target in targets {
+                let res = try buildTarget(
+                    contentRoot: contentRoot,
+                    target: target,
+                    siteURL: profile.site?.url,
+                    workingDirectory: cwd,
+                    timings: timings
+                )
+                results.append(res)
+                if !res.isSuccess {
+                    return BorisFanoutResult(
+                        isSuccess: false,
+                        results: results,
+                        totalDurationNs: results.compactMap { $0.timings?.totalNs }.reduce(0, +)
+                    )
+                }
+            }
+        } else {
+            let res = try buildTarget(
+                contentRoot: contentRoot,
+                target: PublicationTarget(name: "default", output: "dist"),
+                siteURL: profile.site?.url,
+                workingDirectory: cwd,
+                timings: timings
+            )
+            results.append(res)
+            if !res.isSuccess {
+                return BorisFanoutResult(
+                    isSuccess: false,
+                    results: results,
+                    totalDurationNs: res.timings?.totalNs
+                )
+            }
+        }
+
+        // 2. Editions in profile order
+        if let editions = profile.editions {
+            if let ir = editions.ir {
+                let res = try buildEdition(
+                    contentRoot: contentRoot,
+                    kind: "ir",
+                    outputDir: ir.output,
+                    workingDirectory: cwd,
+                    timings: timings
+                )
+                results.append(res)
+                if !res.isSuccess {
+                    return BorisFanoutResult(
+                        isSuccess: false,
+                        results: results,
+                        totalDurationNs: results.compactMap { $0.timings?.totalNs }.reduce(0, +)
+                    )
+                }
+            }
+            if let rag = editions.rag {
+                let res = try buildEdition(
+                    contentRoot: contentRoot,
+                    kind: "rag",
+                    outputDir: rag.output,
+                    scope: rag.scope,
+                    splitSize: rag.split_size,
+                    workingDirectory: cwd,
+                    timings: timings
+                )
+                results.append(res)
+                if !res.isSuccess {
+                    return BorisFanoutResult(
+                        isSuccess: false,
+                        results: results,
+                        totalDurationNs: results.compactMap { $0.timings?.totalNs }.reduce(0, +)
+                    )
+                }
+            }
+            if let context = editions.context {
+                let res = try buildEdition(
+                    contentRoot: contentRoot,
+                    kind: "context",
+                    outputDir: context.output,
+                    scope: context.scope,
+                    splitSize: context.split_size,
+                    workingDirectory: cwd,
+                    timings: timings
+                )
+                results.append(res)
+                if !res.isSuccess {
+                    return BorisFanoutResult(
+                        isSuccess: false,
+                        results: results,
+                        totalDurationNs: results.compactMap { $0.timings?.totalNs }.reduce(0, +)
+                    )
+                }
+            }
+        }
+
+        let totalDuration = results.compactMap { $0.timings?.totalNs }.reduce(0, +)
+        return BorisFanoutResult(
+            isSuccess: true,
+            results: results,
+            totalDurationNs: totalDuration > 0 ? totalDuration : nil
+        )
+    }
+
     /// SIGTERM the in-flight process, if any. One-shot builds die; watch
     /// exits 0. The app treats `terminationReason == .uncaughtSignal` as
     /// cancel when we inspect it; here we surface the resulting exit.
@@ -231,6 +492,28 @@ public actor BorisEngine {
             binary: binaryURL,
             contentRoot: contentRoot,
             workingDirectory: workingDirectory,
+            port: port
+        )
+        try server.start()
+        return server
+    }
+
+    // MARK: Editor (M6)
+
+    /// Starts `boris-editor` for `contentRoot` (A14) and returns the live host server.
+    public nonisolated func editorStart(
+        editorBinary: URL,
+        contentRoot: URL,
+        workingDirectory: URL,
+        uiDir: URL? = nil,
+        port: Int = 0
+    ) throws -> EditorServer {
+        let server = EditorServer(
+            editorBinary: editorBinary,
+            engineBinary: binaryURL,
+            contentRoot: contentRoot,
+            workingDirectory: workingDirectory,
+            uiDir: uiDir,
             port: port
         )
         try server.start()

--- a/Sources/Engine/EditorServer.swift
+++ b/Sources/Engine/EditorServer.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// How a long-running `boris-editor` process ended.
+public struct EditorExit: Sendable {
+    public let exitCode: Int32
+    public let signalled: Bool
+    public let stderrTail: String
+}
+
+/// The M6 author companion host (A14 / #75): a long-lived `boris-editor` subprocess.
+///
+/// Runs `boris-editor <contentRoot> --boris <engineBinary> --port 0` with
+/// `cwd = workingDirectory`. The startup line on stderr:
+///
+///     BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=<32 hex chars>
+///
+/// `onConnect` fires once with the tokenized URL. `stop()` sends SIGTERM
+/// (A14 graceful exit 0).
+public final class EditorServer: @unchecked Sendable {
+    public var onConnect: ((URL) -> Void)?
+    public var onExit: ((EditorExit) -> Void)?
+
+    private let lock = NSLock()
+    private var process: Process?
+    private let stderrPipe = Pipe()
+    private var stderrAccumulator = Data()
+    private var stderrTailText = ""
+    private var _editorURL: URL?
+    private var didConnect = false
+
+    public init(
+        editorBinary: URL,
+        engineBinary: URL,
+        contentRoot: URL,
+        workingDirectory: URL,
+        uiDir: URL? = nil,
+        port: Int = 0
+    ) {
+        let process = Process()
+        process.executableURL = editorBinary
+        var args = [
+            contentRoot.path,
+            "--boris", engineBinary.path,
+            "--port", String(port),
+        ]
+        if let uiDir {
+            args.append(contentsOf: ["--ui-dir", uiDir.path])
+        }
+        process.arguments = args
+        process.currentDirectoryURL = workingDirectory
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = stderrPipe
+        self.process = process
+    }
+
+    deinit {
+        stop()
+    }
+
+    public var editorURL: URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _editorURL
+    }
+
+    public var isRunning: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return process?.isRunning ?? false
+    }
+
+    public func start() throws {
+        lock.lock()
+        guard let process else {
+            lock.unlock()
+            throw BorisRunnerError.launchFailed("editor server already stopped")
+        }
+        stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            self?.consume(data)
+        }
+        process.terminationHandler = { [weak self] process in
+            self?.finish(process)
+        }
+        lock.unlock()
+
+        do {
+            try process.run()
+        } catch {
+            lock.lock()
+            self.process = nil
+            lock.unlock()
+            throw BorisRunnerError.launchFailed(String(describing: error))
+        }
+    }
+
+    public func stop() {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        guard let process, process.isRunning else { return }
+        process.terminate()
+    }
+
+    private func consume(_ data: Data) {
+        lock.lock()
+        stderrAccumulator.append(data)
+        if stderrAccumulator.count > 65_536 {
+            stderrAccumulator.removeFirst(stderrAccumulator.count - 32_768)
+        }
+        stderrTailText = String(decoding: stderrAccumulator.suffix(4_096), as: UTF8.self)
+
+        var url: URL?
+        var connectCallback: ((URL) -> Void)?
+        if !didConnect {
+            url = scanEditorURL(in: stderrAccumulator)
+            if let url {
+                didConnect = true
+                _editorURL = url
+                connectCallback = onConnect
+            }
+        }
+        lock.unlock()
+
+        if let url, let connectCallback {
+            connectCallback(url)
+        }
+    }
+
+    private func finish(_ process: Process) {
+        lock.lock()
+        stderrPipe.fileHandleForReading.readabilityHandler = nil
+        let exit = EditorExit(
+            exitCode: process.terminationStatus,
+            signalled: process.terminationReason == .uncaughtSignal,
+            stderrTail: stderrTailText
+        )
+        let onExit = self.onExit
+        self.process = nil
+        lock.unlock()
+        onExit?(exit)
+    }
+
+    private func scanEditorURL(in data: Data) -> URL? {
+        guard let str = String(data: data, encoding: .utf8) else { return nil }
+        for line in str.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("BORIS_EDITOR_URL=") {
+                let urlString = String(trimmed.dropFirst("BORIS_EDITOR_URL=".count))
+                if let url = try? EditorURL.parse(urlString) {
+                    return url
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Engine/WatchServer.swift
+++ b/Sources/Engine/WatchServer.swift
@@ -158,9 +158,30 @@ public final class WatchServer: @unchecked Sendable {
         onExit?(exit)
     }
 
-    /// Scans the accumulated stderr bytes for `http://127.0.0.1:<port>` and
-    /// returns the helper URL `http://127.0.0.1:<port>/__boris/`.
+    /// Scans the accumulated stderr bytes for NDJSON `serve-started` or prose
+    /// `http://127.0.0.1:<port>` and returns the helper URL `http://127.0.0.1:<port>/__boris/`.
     private func scanServeURL(in data: Data) -> URL? {
+        // 1. A1 structured NDJSON serve-started event: {"event":"serve-started",..."helper":"..."...}
+        if let str = String(data: data, encoding: .utf8) {
+            for line in str.components(separatedBy: .newlines) {
+                if line.contains("\"event\":\"serve-started\""),
+                   let lineData = line.data(using: .utf8),
+                   let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
+                {
+                    if let helper = json["helper"] as? String, let url = URL(string: helper) {
+                        return url
+                    }
+                    if let rawURL = json["url"] as? String, let url = URL(string: rawURL) {
+                        return url.appendingPathComponent("__boris/")
+                    }
+                    if let port = json["port"] as? Int {
+                        return URL(string: "http://127.0.0.1:\(port)/__boris/")
+                    }
+                }
+            }
+        }
+
+        // 2. Prose line fallback: `http://127.0.0.1:PORT`
         let hostPrefix = Data("http://127.0.0.1:".utf8)
         guard var index = data.range(of: hostPrefix)?.lowerBound else { return nil }
         index += hostPrefix.count

--- a/Sources/Inspector/Inspectable.swift
+++ b/Sources/Inspector/Inspectable.swift
@@ -14,12 +14,14 @@ protocol Inspectable {
 enum InspectorSectionID {
     static let profile = "profile"
     static let page = "page"
+    static let target = "target"
     static let execution = "execution"
 }
 
 enum InspectorNounKind {
     static let page = "page"
     static let profile = "profile"
+    static let target = "target"
 }
 
 /// Sections implied by the current selection. The drawer reads this;
@@ -36,6 +38,9 @@ struct InspectorSnapshot: Inspectable {
         }
         if nounKind == InspectorNounKind.page {
             sections.append(InspectorSection(id: InspectorSectionID.page, title: "Page"))
+        }
+        if nounKind == InspectorNounKind.target {
+            sections.append(InspectorSection(id: InspectorSectionID.target, title: "Target"))
         }
         sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
         return sections

--- a/Sources/Inspector/TargetSection.swift
+++ b/Sources/Inspector/TargetSection.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// Inspector section for an individual HTML target (M7 / #76).
+/// Displays target details and lets the author pick from the `ThemeCatalog`.
+struct TargetSection: View {
+    let source: LocalSource
+    let targetName: String
+
+    @State private var target: PublicationTarget?
+    @State private var profile: PublicationProfile?
+    @State private var availableThemes: [String] = []
+
+    var body: some View {
+        Group {
+            if let target {
+                LabeledContent("Target Name", value: target.name)
+                LabeledContent("Output", value: target.output)
+                LabeledContent("Public", value: target.public == true ? "Yes" : "No")
+
+                if let theme = target.theme, !theme.isEmpty {
+                    LabeledContent("Theme", value: theme)
+                }
+                if let layout = target.layout, !layout.isEmpty {
+                    LabeledContent("Layout", value: layout)
+                }
+
+                if let rules = target.layout_rules, !rules.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Layout Rules (\(rules.count))")
+                            .foregroundStyle(.secondary)
+                        ForEach(rules, id: \.selector) { rule in
+                            Text("\(rule.selector) → \(rule.layout)")
+                                .font(.caption)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if let sitemap = target.sitemap {
+                    LabeledContent("Sitemap", value: sitemap.path)
+                }
+                if let rss = target.rss {
+                    LabeledContent("RSS", value: rss.path)
+                }
+                if let llms = target.llms {
+                    LabeledContent("LLMs.txt", value: llms.path)
+                }
+
+                if !availableThemes.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Available Themes")
+                            .foregroundStyle(.secondary)
+                        Text(availableThemes.joined(separator: ", "))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } else {
+                Text("Target “\(targetName)” not found in profile.")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .task(id: "\(source.id.raw):\(targetName)") {
+            load()
+        }
+    }
+
+    private func load() {
+        guard let root = try? source.workspaceRoot() else { return }
+        availableThemes = ThemeCatalog.allThemes(for: root)
+        if let pair = try? InspectorProfile.load(from: root),
+           let prof = try? JSONDecoder().decode(PublicationProfile.self, from: pair.data)
+        {
+            profile = prof
+            target = prof.targets?.first(where: { $0.name == targetName })
+                ?? (targetName == "default" ? PublicationTarget(name: "default", output: "dist") : nil)
+        }
+    }
+}

--- a/Sources/Inspector/ThemeCatalog.swift
+++ b/Sources/Inspector/ThemeCatalog.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Theme catalog (M7): 20 first-class Boris themes plus any local custom
+/// themes discovered in the project workspace `themes/` directory. Selection only,
+/// never authoring.
+public enum ThemeCatalog {
+    /// 20 first-class themes bundled or recognized by Boris compiler.
+    public static let firstClassThemes: [String] = [
+        "archive",
+        "boris",
+        "cards",
+        "civic",
+        "columns",
+        "compact",
+        "corporate",
+        "cozy",
+        "engineering",
+        "field-notes",
+        "journal",
+        "ledger",
+        "minimal",
+        "press",
+        "reading",
+        "reference",
+        "semantic",
+        "service",
+        "showcase",
+        "tokens",
+    ]
+
+    /// Discovers local themes in `<projectRoot>/themes/`.
+    public static func discoverLocalThemes(in projectRoot: URL) -> [String] {
+        let themesDir = projectRoot.appendingPathComponent("themes", isDirectory: true)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: themesDir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        var themes: [String] = []
+        for entry in entries {
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: entry.path, isDirectory: &isDir), isDir.boolValue {
+                themes.append(entry.lastPathComponent)
+            }
+        }
+        return themes.sorted()
+    }
+
+    /// Combined theme list: project local themes followed by first-class themes.
+    public static func allThemes(for projectRoot: URL?) -> [String] {
+        var set = Set<String>()
+        var result: [String] = []
+
+        if let projectRoot {
+            let local = discoverLocalThemes(in: projectRoot)
+            for theme in local {
+                if set.insert(theme).inserted {
+                    result.append(theme)
+                }
+            }
+        }
+
+        for theme in firstClassThemes {
+            if set.insert(theme).inserted {
+                result.append(theme)
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -10,37 +10,34 @@ struct LocalPlay: PlaySurface {
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
+    enum PlayTab: String, CaseIterable, Identifiable {
+        case pages = "Pages"
+        case outputs = "Outputs"
+
+        var id: String { rawValue }
+    }
+
+    @State private var selectedTab: PlayTab = .pages
     @State private var state: LoadState = .idle
 
     var body: some View {
-        Group {
-            switch state {
-            case .idle, .reading, .building:
-                ProgressView(progressTitle)
-                    .controlSize(.small)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .unavailable:
-                ContentUnavailableView {
-                    Label(source.title, systemImage: "folder")
-                } description: {
-                    Text("This folder is no longer reachable. Remove it from the sidebar or reopen it.")
+        VStack(spacing: 0) {
+            Picker("View", selection: $selectedTab) {
+                ForEach(PlayTab.allCases) { tab in
+                    Text(tab.rawValue).tag(tab)
                 }
-            case .empty:
-                ContentUnavailableView {
-                    Label("No Pages", systemImage: "doc.text")
-                } description: {
-                    Text("The graph for this folder has no pages.")
-                }
-            case .failed(let message):
-                ContentUnavailableView {
-                    Label("Graph Unavailable", systemImage: "exclamationmark.triangle")
-                } description: {
-                    Text(message)
-                } actions: {
-                    Button("Try Again") { reload() }
-                }
-            case .ready(let pages):
-                pageList(pages)
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+
+            Divider()
+
+            switch selectedTab {
+            case .pages:
+                pagesContent
+            case .outputs:
+                OutputsPane(source: source)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -54,6 +51,38 @@ struct LocalPlay: PlaySurface {
         }
         .task(id: source.id) {
             await load()
+        }
+    }
+
+    @ViewBuilder
+    private var pagesContent: some View {
+        switch state {
+        case .idle, .reading, .building:
+            ProgressView(progressTitle)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .unavailable:
+            ContentUnavailableView {
+                Label(source.title, systemImage: "folder")
+            } description: {
+                Text("This folder is no longer reachable. Remove it from the sidebar or reopen it.")
+            }
+        case .empty:
+            ContentUnavailableView {
+                Label("No Pages", systemImage: "doc.text")
+            } description: {
+                Text("The graph for this folder has no pages.")
+            }
+        case .failed(let message):
+            ContentUnavailableView {
+                Label("Graph Unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(message)
+            } actions: {
+                Button("Try Again") { reload() }
+            }
+        case .ready(let pages):
+            pageList(pages)
         }
     }
 

--- a/Sources/Play/Local/OutputsPane.swift
+++ b/Sources/Play/Local/OutputsPane.swift
@@ -1,0 +1,294 @@
+import SwiftUI
+
+/// Outputs pane (M7 / #76): lists HTML targets and editions declared in the
+/// publication profile (`boris.json`). Supports fan-out "Build All" and per-row
+/// "Build this". Selection is written to `WorkspaceStore` as `noun.kind == "target"`
+/// or `noun.kind == "edition"`.
+struct OutputsPane: View {
+    let source: LocalSource
+
+    @Environment(WorkspaceStore.self) private var store
+    @Environment(AppRuntime.self) private var runtime
+    @State private var profile: PublicationProfile?
+    @State private var loadError: String?
+
+    var body: some View {
+        Group {
+            if let profile {
+                outputsList(profile)
+            } else if let loadError {
+                ContentUnavailableView {
+                    Label("Profile Unavailable", systemImage: "gearshape")
+                } description: {
+                    Text(loadError)
+                } actions: {
+                    Button("Reload") { load() }
+                }
+            } else {
+                ContentUnavailableView {
+                    Label("No Profile", systemImage: "gearshape")
+                } description: {
+                    Text("No boris.json found in this workspace. Create one or plan to generate defaults.")
+                }
+            }
+        }
+        .task(id: source.id) {
+            load()
+        }
+    }
+
+    private func outputsList(_ profile: PublicationProfile) -> some View {
+        List(selection: selectedOutputID) {
+            Section {
+                if let targets = profile.targets, !targets.isEmpty {
+                    ForEach(targets, id: \.name) { target in
+                        TargetRow(target: target, onBuild: { buildTarget(target) })
+                            .tag("target:\(target.name)")
+                    }
+                } else {
+                    let defaultTarget = PublicationTarget(name: "default", output: "dist")
+                    TargetRow(target: defaultTarget, onBuild: { buildTarget(defaultTarget) })
+                        .tag("target:default")
+                }
+            } header: {
+                HStack {
+                    Text("HTML Targets")
+                    Spacer()
+                    Button("Build All") {
+                        buildAll(profile)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(runtime.coordinator.isRunning)
+                }
+            }
+
+            if let editions = profile.editions {
+                Section("Editions") {
+                    if let ir = editions.ir {
+                        EditionRow(name: "IR (.boris)", output: ir.output, kind: "ir", onBuild: {
+                            buildEdition(kind: "ir", output: ir.output)
+                        })
+                        .tag("edition:ir")
+                    }
+                    if let rag = editions.rag {
+                        EditionRow(name: "RAG", output: rag.output, kind: "rag", onBuild: {
+                            buildEdition(
+                                kind: "rag",
+                                output: rag.output,
+                                scope: rag.scope,
+                                splitSize: rag.split_size
+                            )
+                        })
+                        .tag("edition:rag")
+                    }
+                    if let context = editions.context {
+                        EditionRow(name: "Context", output: context.output, kind: "context", onBuild: {
+                            buildEdition(
+                                kind: "context",
+                                output: context.output,
+                                scope: context.scope,
+                                splitSize: context.split_size
+                            )
+                        })
+                        .tag("edition:context")
+                    }
+                }
+            }
+        }
+        .listStyle(.inset(alternatesRowBackgrounds: true))
+    }
+
+    private var selectedOutputID: Binding<String?> {
+        Binding(
+            get: {
+                if let noun = store.selection.noun {
+                    return "\(noun.kind):\(noun.id)"
+                }
+                return nil
+            },
+            set: { newTag in
+                guard let newTag else {
+                    store.select(noun: nil)
+                    return
+                }
+                let parts = newTag.split(separator: ":", maxSplits: 1)
+                if parts.count == 2 {
+                    let kind = String(parts[0])
+                    let id = String(parts[1])
+                    store.select(noun: WorkspaceNoun(kind: kind, id: id, title: id))
+                }
+            }
+        )
+    }
+
+    private func load() {
+        guard let root = try? source.workspaceRoot() else {
+            loadError = "Could not resolve workspace root."
+            return
+        }
+        do {
+            if let pair = try InspectorProfile.load(from: root) {
+                profile = try? JSONDecoder().decode(PublicationProfile.self, from: pair.data)
+                loadError = nil
+            } else {
+                profile = nil
+                loadError = nil
+            }
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    private func buildTarget(_ target: PublicationTarget) {
+        guard let engine = runtime.engine else { return }
+        guard let contentRoot = try? source.contentRoot() else { return }
+        let cwd = try? source.workspaceRoot()
+
+        Task {
+            _ = try? await engine.buildTarget(
+                contentRoot: contentRoot,
+                target: target,
+                siteURL: profile?.site?.url,
+                workingDirectory: cwd,
+                timings: true
+            )
+        }
+    }
+
+    private func buildEdition(
+        kind: String,
+        output: String,
+        scope: String? = nil,
+        splitSize: Int? = nil
+    ) {
+        guard let engine = runtime.engine else { return }
+        guard let contentRoot = try? source.contentRoot() else { return }
+        let cwd = try? source.workspaceRoot()
+
+        Task {
+            _ = try? await engine.buildEdition(
+                contentRoot: contentRoot,
+                kind: kind,
+                outputDir: output,
+                scope: scope,
+                splitSize: splitSize,
+                workingDirectory: cwd,
+                timings: true
+            )
+        }
+    }
+
+    private func buildAll(_ profile: PublicationProfile) {
+        guard let engine = runtime.engine else { return }
+        guard let contentRoot = try? source.contentRoot() else { return }
+        let cwd = try? source.workspaceRoot()
+
+        Task {
+            _ = try? await engine.buildAll(
+                contentRoot: contentRoot,
+                profile: profile,
+                workingDirectory: cwd,
+                timings: true
+            )
+        }
+    }
+}
+
+private struct TargetRow: View {
+    let target: PublicationTarget
+    let onBuild: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: "globe")
+                    .foregroundStyle(.secondary)
+                Text(target.name)
+                    .font(.headline)
+                if target.public == true {
+                    Text("PUBLIC")
+                        .font(.caption2.bold())
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.green.opacity(0.2))
+                        .foregroundStyle(.green)
+                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                }
+                Spacer()
+                Button("Build", action: onBuild)
+                    .controlSize(.small)
+            }
+            HStack(spacing: 12) {
+                Label(target.output, systemImage: "folder")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let theme = target.theme, !theme.isEmpty {
+                    Label(theme, systemImage: "paintpalette")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let layout = target.layout, !layout.isEmpty {
+                    Label(layout, systemImage: "rectangle.3.group")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if let projections = projectionsList, !projections.isEmpty {
+                HStack(spacing: 8) {
+                    ForEach(projections, id: \.self) { proj in
+                        Text(proj)
+                            .font(.caption2)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.15))
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var projectionsList: [String]? {
+        var list: [String] = []
+        if let sitemap = target.sitemap { list.append("sitemap: \(sitemap.path)") }
+        if let rss = target.rss { list.append("rss: \(rss.path)") }
+        if let llms = target.llms { list.append("llms: \(llms.path)") }
+        return list.isEmpty ? nil : list
+    }
+}
+
+private struct EditionRow: View {
+    let name: String
+    let output: String
+    let kind: String
+    let onBuild: () -> Void
+
+    var body: some View {
+        HStack {
+            Image(systemName: iconName)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(name)
+                    .font(.body)
+                Text(output)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Build", action: onBuild)
+                .controlSize(.small)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var iconName: String {
+        switch kind {
+        case "ir": return "cpu"
+        case "rag": return "brain"
+        case "context": return "doc.text.magnifyingglass"
+        default: return "shippingbox"
+        }
+    }
+}

--- a/Tests/ContractTests/OutputsContractTests.swift
+++ b/Tests/ContractTests/OutputsContractTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+final class OutputsContractTests: XCTestCase {
+    func testThemeCatalogFirstClassList() {
+        let themes = ThemeCatalog.firstClassThemes
+        XCTAssertEqual(themes.count, 20)
+        XCTAssertTrue(themes.contains("boris"))
+        XCTAssertTrue(themes.contains("cards"))
+        XCTAssertTrue(themes.contains("press"))
+        XCTAssertTrue(themes.contains("tokens"))
+    }
+
+    func testThemeCatalogLocalDiscovery() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("theme-test-\(UUID().uuidString)")
+        let themesDir = tempDir.appendingPathComponent("themes", isDirectory: true)
+        try FileManager.default.createDirectory(at: themesDir.appendingPathComponent("custom-alpha"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: themesDir.appendingPathComponent("custom-beta"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let discovered = ThemeCatalog.discoverLocalThemes(in: tempDir)
+        XCTAssertEqual(discovered, ["custom-alpha", "custom-beta"])
+
+        let all = ThemeCatalog.allThemes(for: tempDir)
+        XCTAssertEqual(all.first, "custom-alpha")
+        XCTAssertEqual(all[1], "custom-beta")
+        XCTAssertTrue(all.contains("boris"))
+    }
+
+    func testTargetAndEditionsDecoding() throws {
+        let json = """
+        {
+          "format": "boris-publication-profile",
+          "schema_version": 1,
+          "input": "content",
+          "targets": [
+            {
+              "name": "public",
+              "output": "dist",
+              "public": true,
+              "theme": "boris",
+              "layout": "layouts/main.html",
+              "layout_rules": [
+                { "selector": "role:trunk", "layout": "layouts/trunk.html" }
+              ],
+              "sitemap": { "path": "sitemap.xml" },
+              "rss": { "path": "rss.xml", "limit": 50 },
+              "llms": { "path": "llms.txt" }
+            }
+          ],
+          "editions": {
+            "ir": { "output": ".boris" },
+            "rag": { "output": "rag", "scope": "guides", "split_size": 131072 },
+            "context": { "output": "context", "split_size": 65536 }
+          }
+        }
+        """
+        let data = Data(json.utf8)
+        let profile = try JSONDecoder().decode(PublicationProfile.self, from: data)
+
+        XCTAssertEqual(profile.targets?.count, 1)
+        let target = try XCTUnwrap(profile.targets?.first)
+        XCTAssertEqual(target.name, "public")
+        XCTAssertEqual(target.output, "dist")
+        XCTAssertEqual(target.public, true)
+        XCTAssertEqual(target.theme, "boris")
+        XCTAssertEqual(target.layout_rules?.count, 1)
+        XCTAssertEqual(target.sitemap?.path, "sitemap.xml")
+        XCTAssertEqual(target.rss?.limit, 50)
+        XCTAssertEqual(target.llms?.path, "llms.txt")
+
+        let editions = try XCTUnwrap(profile.editions)
+        XCTAssertEqual(editions.ir?.output, ".boris")
+        XCTAssertEqual(editions.rag?.scope, "guides")
+        XCTAssertEqual(editions.rag?.split_size, 131_072)
+        XCTAssertEqual(editions.context?.output, "context")
+    }
+}


### PR DESCRIPTION
Resolves #76, #74, #75, and #78.

### M7 (Outputs Fan-Out — #76)
- Added `buildTarget`, `buildEdition`, and `buildAll` in `BorisEngine.swift` with fail-fast isolated invocations matching Boris.
- Added `OutputsPane.swift` rendering HTML targets (name, output, theme, layout, public badge), projections (sitemap, rss, llms), and editions (IR, RAG, context).
- Added `ThemeCatalog.swift` containing 20 first-class Boris themes + dynamic local project workspace discovery in `<projectRoot>/themes/`.
- Added `TargetSection.swift` for inspecting target parameters and themes.
- Added `Button("Build All")` (`⌘⇧U`) in `Commands.swift` and wired `.buildAll` in `Coordinator.swift`.

### M5 / M6 Companions Follow-Through (#74, #75)
- Added A1 `serve-started` NDJSON event scanning in `WatchServer.swift` with prose fallback.
- Added `EditorServer.swift` and `EditorSession.swift` for spawning and managing `boris-editor` host with A14 launch line detection and SIGTERM teardown on window close.
- Added link-out fallback to external browser in `EditorWindow.swift`.

### M9 Release CI Hardening (#78)
- Fixed step-level `if:` conditions to check `secrets.*` instead of `env.*`.
- Updated `scripts/embed-boris.sh` to respect `SKIP_EMBED_BORIS=0` without suppression in GitHub Actions.
- Enforced Gatekeeper assessment via `spctl --assess -vvv --type execute`.

### Verification
- `SKIP_EMBED_BORIS=1 make build` ✅
- `make test` (46 tests passing) ✅
- `make lint` (0 violations) ✅