### PR TITLE
fix(coordinator): own every job; pause watch for builds

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -94,6 +94,8 @@ targets:
       - path: Sources/Inspector/InspectorProfile.swift
       - path: Sources/Inspector/ThemeCatalog.swift
       - path: Sources/Play/Local/LocalPlayGraph.swift
+      - path: Sources/App/CoordinatorProblems.swift
+      - path: Sources/Engine/ChildProcessControl.swift
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Sources/Companions/Preview/PreviewURL.swift
     settings:

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -32,55 +32,60 @@ struct SolipsistCommands: Commands {
                 runtime.coordinator.run(.plan, store: store, runtime: runtime)
             }
             .keyboardShortcut("l", modifiers: [.command, .shift])
-            .disabled(!hasSource || runtime.coordinator.isRunning)
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
             Button("Validate") {
                 runtime.coordinator.run(.validate, store: store, runtime: runtime)
             }
             .keyboardShortcut("k", modifiers: [.command, .shift])
-            .disabled(!hasSource || runtime.coordinator.isRunning)
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
             Button("Build IR") {
                 runtime.coordinator.run(.buildIR, store: store, runtime: runtime)
             }
             .keyboardShortcut("b", modifiers: .command)
-            .disabled(!hasSource || runtime.coordinator.isRunning)
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
             Button("Build HTML") {
                 runtime.coordinator.run(.buildHTML, store: store, runtime: runtime)
             }
             .keyboardShortcut("b", modifiers: [.command, .shift])
-            .disabled(!hasSource || runtime.coordinator.isRunning)
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
             Button("Build All") {
                 runtime.coordinator.run(.buildAll, store: store, runtime: runtime)
             }
             .keyboardShortcut("u", modifiers: [.command, .shift])
-            .disabled(!hasSource || runtime.coordinator.isRunning)
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
+            Button("Build This") {
+                runtime.coordinator.run(.buildThis, store: store, runtime: runtime)
+            }
+            .disabled(!hasOutput || !runtime.coordinator.canRunVerb)
 
             Divider()
 
             Button("Check") {
                 runtime.coordinator.run(.check, store: store, runtime: runtime)
             }
-            .disabled(!hasSource || runtime.coordinator.isRunning)
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
             Button("Impact") {
                 runtime.coordinator.run(.impact, store: store, runtime: runtime)
             }
-            .disabled(!hasPage || runtime.coordinator.isRunning)
+            .disabled(!hasPage || !runtime.coordinator.canRunVerb)
 
             Divider()
 
             Button("Publish to Standard.site") {
                 runtime.coordinator.run(.publishStandardSite, store: store, runtime: runtime)
             }
-            .disabled(!hasSource || runtime.coordinator.isRunning)
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
             Button("Publish to Nostr…") {
                 runtime.coordinator.run(.publishNostr, store: store, runtime: runtime)
             }
-            .disabled(!hasSource || runtime.coordinator.isRunning)
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
             Divider()
 
@@ -88,7 +93,7 @@ struct SolipsistCommands: Commands {
                 runtime.coordinator.stop(runtime: runtime)
             }
             .keyboardShortcut(".", modifiers: .command)
-            .disabled(!runtime.coordinator.isRunning)
+            .disabled(!runtime.coordinator.canStop)
         }
 
         CommandGroup(after: .sidebar) {
@@ -121,4 +126,9 @@ struct SolipsistCommands: Commands {
     private var hasSource: Bool { store.selectedSource != nil }
 
     private var hasPage: Bool { store.selection.noun?.kind == "page" }
+
+    private var hasOutput: Bool {
+        let kind = store.selection.noun?.kind
+        return kind == "target" || kind == "edition"
+    }
 }

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -6,38 +6,30 @@ enum CoordinatorVerb: String, Sendable {
     case validate
     case buildIR
     case buildHTML
+    case buildThis = "build this"
     case buildAll
     case check
     case impact
     case publishStandardSite = "publish Standard.site"
     case publishNostr = "publish Nostr"
+
+    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof).
+    var writesTree: Bool {
+        switch self {
+        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite:
+            true
+        case .plan, .validate, .check, .impact, .publishNostr:
+            false
+        }
+    }
 }
 
-struct ProblemItem: Identifiable, Hashable, Sendable {
-    let id: String
-    let severity: String
-    let code: String
-    let message: String
-    let path: String?
-    let line: Int?
-    let column: Int?
-
-    init(
-        severity: String,
-        code: String,
-        message: String,
-        path: String? = nil,
-        line: Int? = nil,
-        column: Int? = nil
-    ) {
-        self.id = "\(code)|\(path ?? "")|\(line ?? -1)|\(column ?? -1)|\(message)"
-        self.severity = severity
-        self.code = code
-        self.message = message
-        self.path = path
-        self.line = line
-        self.column = column
-    }
+enum CoordinatorState: String, Sendable {
+    case idle
+    case watching
+    case validating
+    case building
+    case terminating
 }
 
 /// Menu verbs against `BorisEngine`. One job at a time. Play and the
@@ -46,37 +38,96 @@ struct ProblemItem: Identifiable, Hashable, Sendable {
 @Observable
 final class Coordinator {
     private(set) var isRunning = false
+    private(set) var state: CoordinatorState = .idle
     private(set) var verb: CoordinatorVerb?
     private(set) var summary = "idle"
     private(set) var exitCode: Int32?
     private(set) var problems: [ProblemItem] = []
     private var task: Task<Void, Never>?
+    private var reapTask: Task<Void, Never>?
+    private weak var activeWatch: WatchServer?
+    private var watchSuspends = 0
+
+    var canRunVerb: Bool { state == .idle || state == .watching }
+
+    var canStop: Bool { state != .idle }
+
+    func registerWatch(_ server: WatchServer) {
+        if let old = activeWatch, old !== server {
+            old.resume()
+            old.stop()
+        }
+        activeWatch = server
+        if !isRunning {
+            state = .watching
+            if summary == "idle" { summary = "watching" }
+        }
+    }
+
+    func unregisterWatch(_ server: WatchServer) {
+        guard activeWatch === server else { return }
+        activeWatch = nil
+        watchSuspends = 0
+        if !isRunning {
+            state = .idle
+            if summary == "watching" || summary == "stopping preview…" {
+                summary = "idle"
+            }
+        }
+    }
+
+    /// Pause watch for any tree-writing invocation, including play's
+    /// implicit IR build. Nested; resume when the last writer ends.
+    func beginTreeWrite() {
+        watchSuspends += 1
+        if watchSuspends == 1 {
+            activeWatch?.suspend()
+        }
+    }
+
+    func endTreeWrite() {
+        guard watchSuspends > 0 else { return }
+        watchSuspends -= 1
+        if watchSuspends == 0 {
+            activeWatch?.resume()
+        }
+    }
 
     func run(_ verb: CoordinatorVerb, store: WorkspaceStore, runtime: AppRuntime) {
-        guard !isRunning else { return }
+        guard canRunVerb else { return }
         guard let engine = runtime.engine else {
+            let message = runtime.engineError ?? "engine not found"
             finish(
                 verb: verb,
                 exit: nil,
-                summary: runtime.engineError ?? "engine not found",
-                problems: []
+                summary: message,
+                problems: CoordinatorProblems.fromFailure(code: "engine", message: message)
             )
             return
         }
         guard case .local(let source) = store.selectedSource, source.isAvailable else {
-            finish(verb: verb, exit: nil, summary: "no local source", problems: [])
+            finish(
+                verb: verb,
+                exit: nil,
+                summary: "no local source",
+                problems: CoordinatorProblems.fromFailure(code: "source", message: "no local source")
+            )
             return
         }
 
         isRunning = true
+        state = verb.writesTree ? .building : .validating
         self.verb = verb
         summary = "\(verb.rawValue)…"
         exitCode = nil
         problems = []
+        if verb.writesTree {
+            beginTreeWrite()
+        }
 
-        let pageID = store.selection.noun?.kind == "page" ? store.selection.noun?.id : nil
+        let noun = store.selection.noun
         task = Task {
-            let result = await Self.perform(verb, source: source, pageID: pageID, engine: engine)
+            let result = await Self.perform(verb, source: source, noun: noun, engine: engine)
             guard !Task.isCancelled else {
                 self.finish(verb: verb, exit: result.exit, summary: "cancelled", problems: result.problems)
                 return
@@ -91,13 +142,31 @@ final class Coordinator {
     }
 
     func stop(runtime: AppRuntime) {
-        task?.cancel()
-        task = nil
-        if let engine = runtime.engine {
-            Task { await engine.interrupt() }
-        }
+        guard state != .terminating else { return }
+        reapTask?.cancel()
+
         if isRunning {
+            state = .terminating
             summary = "stopping…"
+            task?.cancel()
+            let engine = runtime.engine
+            reapTask = Task {
+                await engine?.interrupt()
+                try? await Task.sleep(for: ChildProcessControl.reapGrace)
+                guard !Task.isCancelled else { return }
+                await engine?.forceKill()
+            }
+            return
+        }
+
+        guard let watch = activeWatch, watch.isRunning else { return }
+        state = .terminating
+        summary = "stopping preview…"
+        watch.stop()
+        reapTask = Task {
+            try? await Task.sleep(for: ChildProcessControl.reapGrace)
+            guard !Task.isCancelled else { return }
+            watch.forceKill()
         }
     }
 
@@ -107,12 +176,18 @@ final class Coordinator {
         summary: String,
         problems: [ProblemItem]
     ) {
+        if verb.writesTree {
+            endTreeWrite()
+        }
+        reapTask?.cancel()
+        reapTask = nil
         self.verb = nil
         isRunning = false
         exitCode = exit
         self.summary = summary
         self.problems = problems
         task = nil
+        state = (activeWatch?.isRunning == true) ? .watching : .idle
     }
 
     private struct JobResult: Sendable {
@@ -124,28 +199,30 @@ final class Coordinator {
     private static func perform(
         _ verb: CoordinatorVerb,
         source: LocalSource,
-        pageID: String?,
+        noun: WorkspaceNoun?,
         engine: BorisEngine
     ) async -> JobResult {
         do {
             switch verb {
             case .plan:
                 guard let profile = source.profileURL() else {
-                    return JobResult(exit: 3, summary: "plan: no boris.json", problems: [])
+                    return JobResult(
+                        exit: 3,
+                        summary: "plan: no boris.json",
+                        problems: CoordinatorProblems.fromFailure(code: "plan", message: "no boris.json")
+                    )
                 }
                 let result = try await engine.plan(profileURL: profile)
                 let summary = result.plan == nil
                     ? "plan exit \(result.exitCode)"
                     : "plan ok (\(result.plan?.format ?? "declaration"))"
                 let problems: [ProblemItem]
-                if result.plan == nil, !result.stderr.isEmpty {
-                    problems = [
-                        ProblemItem(
-                            severity: "error",
-                            code: "plan",
-                            message: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-                        )
-                    ]
+                if result.plan == nil {
+                    problems = CoordinatorProblems.fromCommand(
+                        code: "plan",
+                        exitCode: result.exitCode == 0 ? 1 : result.exitCode,
+                        stderr: result.stderr
+                    )
                 } else {
                     problems = []
                 }
@@ -160,7 +237,14 @@ final class Coordinator {
                     reportURL: reportURL,
                     workingDirectory: try source.workspaceRoot()
                 )
-                let items = Self.problems(from: result.report)
+                var items = CoordinatorProblems.from(report: result.report)
+                if items.isEmpty, result.exitCode != 0 {
+                    items = CoordinatorProblems.fromCommand(
+                        code: "validate",
+                        exitCode: result.exitCode,
+                        stderr: result.stderr
+                    )
+                }
                 let count = result.report?.errorCount ?? items.filter { $0.severity == "error" }.count
                 return JobResult(
                     exit: result.exitCode,
@@ -175,7 +259,14 @@ final class Coordinator {
                     outDir: outDir,
                     timings: true
                 )
-                let items = result.report.diagnostics.map(Self.problem(from:))
+                var items = CoordinatorProblems.fromIR(report: result.report)
+                if items.isEmpty, result.exitCode != 0 {
+                    items = CoordinatorProblems.fromCommand(
+                        code: "ir",
+                        exitCode: result.exitCode,
+                        stderr: result.stderr
+                    )
+                }
                 let pages = result.report.pageCount.map { "\($0) pages" } ?? "IR"
                 return JobResult(
                     exit: result.exitCode,
@@ -193,20 +284,38 @@ final class Coordinator {
                     htmlDir: htmlDir,
                     reportURL: reportURL
                 )
-                let items = Self.problems(from: result.report)
+                var items = CoordinatorProblems.from(report: result.report)
+                if items.isEmpty, result.exitCode != 0 {
+                    items = CoordinatorProblems.fromCommand(
+                        code: "html",
+                        exitCode: result.exitCode,
+                        stderr: result.stderr
+                    )
+                }
                 return JobResult(
                     exit: result.exitCode,
                     summary: "HTML exit \(result.exitCode) · \(result.report?.errorCount ?? items.count) error(s)",
                     problems: items
                 )
 
+            case .buildThis:
+                return try await buildThis(noun: noun, source: source, engine: engine)
+
             case .buildAll:
                 let workspaceRoot = try source.workspaceRoot()
-                var profile = PublicationProfile(format: "boris-publication-profile")
-                if let pair = try InspectorProfile.load(from: workspaceRoot),
-                   let prof = try? JSONDecoder().decode(PublicationProfile.self, from: pair.data)
-                {
-                    profile = prof
+                let profile: PublicationProfile
+                do {
+                    profile = try loadProfile(from: source)
+                        ?? PublicationProfile(format: "boris-publication-profile")
+                } catch {
+                    return JobResult(
+                        exit: 3,
+                        summary: "Build all: boris.json did not decode",
+                        problems: CoordinatorProblems.fromFailure(
+                            code: "profile",
+                            message: String(describing: error)
+                        )
+                    )
                 }
                 let result = try await engine.buildAll(
                     contentRoot: source.contentRoot(),
@@ -214,12 +323,15 @@ final class Coordinator {
                     workingDirectory: workspaceRoot,
                     timings: true
                 )
-                var items: [ProblemItem] = []
-                for res in result.results {
-                    if let report = res.report {
-                        items.append(contentsOf: Self.problems(from: report))
-                    }
-                }
+                let items = CoordinatorProblems.fromEntries(result.results.map {
+                    CoordinatorProblems.EntryProblemSource(
+                        name: $0.name,
+                        kind: $0.kind,
+                        exitCode: $0.exitCode,
+                        stderr: $0.stderr,
+                        report: $0.report
+                    )
+                })
                 let exit = result.isSuccess ? 0 : (result.results.last?.exitCode ?? 1)
                 let dur = result.totalDurationNs.map { "(\($0 / 1_000_000)ms)" } ?? ""
                 let summary = "Build all \(result.isSuccess ? "succeeded" : "failed") · \(result.results.count) entry(s) \(dur)"
@@ -245,8 +357,15 @@ final class Coordinator {
                 )
 
             case .impact:
-                guard let pageID else {
-                    return JobResult(exit: 2, summary: "impact: select a page", problems: [])
+                guard let pageID = noun?.kind == "page" ? noun?.id : nil else {
+                    return JobResult(
+                        exit: 2,
+                        summary: "impact: select a page",
+                        problems: CoordinatorProblems.fromFailure(
+                            code: "impact",
+                            message: "select a page"
+                        )
+                    )
                 }
                 let result = try await engine.impact(
                     contentRoot: source.contentRoot(),
@@ -264,49 +383,196 @@ final class Coordinator {
 
             case .publishStandardSite:
                 guard let profile = source.profileURL() else {
-                    return JobResult(exit: 3, summary: "publish: no boris.json", problems: [])
+                    return JobResult(
+                        exit: 3,
+                        summary: "publish: no boris.json",
+                        problems: CoordinatorProblems.fromFailure(code: "standard-site", message: "no boris.json")
+                    )
                 }
                 let result = try await engine.standardSitePublish(profileURL: profile)
-                let problems = result.exitCode == 0 ? [] : [
-                    ProblemItem(severity: "error", code: "standard-site", message: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
-                ]
                 return JobResult(
                     exit: result.exitCode,
                     summary: "Standard.site exit \(result.exitCode)",
-                    problems: problems
+                    problems: CoordinatorProblems.fromCommand(
+                        code: "standard-site",
+                        exitCode: result.exitCode,
+                        stderr: result.stderr
+                    )
                 )
 
             case .publishNostr:
                 guard let profile = source.profileURL() else {
-                    return JobResult(exit: 3, summary: "publish: no boris.json", problems: [])
+                    return JobResult(
+                        exit: 3,
+                        summary: "publish: no boris.json",
+                        problems: CoordinatorProblems.fromFailure(code: "nostr", message: "no boris.json")
+                    )
                 }
                 let result = try await engine.nostrPlan(profileURL: profile)
-                let problems = result.exitCode == 0 ? [] : [
-                    ProblemItem(severity: "error", code: "nostr", message: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
-                ]
                 return JobResult(
                     exit: result.exitCode,
                     summary: "Nostr plan exit \(result.exitCode)",
-                    problems: problems
+                    problems: CoordinatorProblems.fromCommand(
+                        code: "nostr",
+                        exitCode: result.exitCode,
+                        stderr: result.stderr
+                    )
                 )
             }
         } catch {
-            return JobResult(exit: nil, summary: String(describing: error), problems: [])
+            let message = String(describing: error)
+            return JobResult(
+                exit: nil,
+                summary: message,
+                problems: CoordinatorProblems.fromFailure(code: "coordinator", message: message)
+            )
         }
     }
 
-    private static func problems(from report: HTMLBuildReport?) -> [ProblemItem] {
-        (report?.diagnostics ?? []).map(problem(from:))
+    private static func buildThis(
+        noun: WorkspaceNoun?,
+        source: LocalSource,
+        engine: BorisEngine
+    ) async throws -> JobResult {
+        guard let noun else {
+            return JobResult(
+                exit: 2,
+                summary: "build this: select a target or edition",
+                problems: CoordinatorProblems.fromFailure(
+                    code: "build",
+                    message: "select a target or edition"
+                )
+            )
+        }
+
+        let workspaceRoot = try source.workspaceRoot()
+        let profile: PublicationProfile?
+        do {
+            profile = try loadProfile(from: source)
+        } catch {
+            return JobResult(
+                exit: 3,
+                summary: "build this: boris.json did not decode",
+                problems: CoordinatorProblems.fromFailure(
+                    code: "profile",
+                    message: String(describing: error)
+                )
+            )
+        }
+
+        switch noun.kind {
+        case "target":
+            let target: PublicationTarget
+            if let match = profile?.targets?.first(where: { $0.name == noun.id }) {
+                target = match
+            } else if noun.id == "default" {
+                target = PublicationTarget(name: "default", output: "dist")
+            } else {
+                return JobResult(
+                    exit: 2,
+                    summary: "build this: no target \"\(noun.id)\"",
+                    problems: CoordinatorProblems.fromFailure(
+                        code: "target",
+                        message: "no target \"\(noun.id)\" in boris.json"
+                    )
+                )
+            }
+            let result = try await engine.buildTarget(
+                contentRoot: source.contentRoot(),
+                target: target,
+                siteURL: profile?.site?.url,
+                workingDirectory: workspaceRoot,
+                timings: true
+            )
+            let items = CoordinatorProblems.fromEntry(
+                name: result.name,
+                kind: result.kind,
+                exitCode: result.exitCode,
+                stderr: result.stderr,
+                report: result.report
+            )
+            return JobResult(
+                exit: result.exitCode,
+                summary: "\(target.name) exit \(result.exitCode) · \(items.count) problem(s)",
+                problems: items
+            )
+
+        case "edition":
+            guard let spec = editionSpec(id: noun.id, profile: profile) else {
+                return JobResult(
+                    exit: 2,
+                    summary: "build this: no \(noun.id) edition in profile",
+                    problems: CoordinatorProblems.fromFailure(
+                        code: "edition",
+                        message: "no \(noun.id) edition in boris.json"
+                    )
+                )
+            }
+            let result = try await engine.buildEdition(
+                contentRoot: source.contentRoot(),
+                kind: spec.kind,
+                outputDir: spec.output,
+                scope: spec.scope,
+                splitSize: spec.splitSize,
+                workingDirectory: workspaceRoot,
+                timings: true
+            )
+            let items = CoordinatorProblems.fromEntry(
+                name: result.name,
+                kind: result.kind,
+                exitCode: result.exitCode,
+                stderr: result.stderr,
+                report: result.report
+            )
+            return JobResult(
+                exit: result.exitCode,
+                summary: "\(spec.kind) exit \(result.exitCode) · \(items.count) problem(s)",
+                problems: items
+            )
+
+        default:
+            return JobResult(
+                exit: 2,
+                summary: "build this: select a target or edition",
+                problems: CoordinatorProblems.fromFailure(
+                    code: "build",
+                    message: "select a target or edition"
+                )
+            )
+        }
     }
 
-    private static func problem(from diagnostic: Diagnostic) -> ProblemItem {
-        ProblemItem(
-            severity: diagnostic.severity,
-            code: diagnostic.code,
-            message: diagnostic.message,
-            path: diagnostic.sourcePath,
-            line: diagnostic.line,
-            column: diagnostic.column
-        )
+    private static func loadProfile(from source: LocalSource) throws -> PublicationProfile? {
+        let root = try source.workspaceRoot()
+        guard let pair = try InspectorProfile.load(from: root) else { return nil }
+        return try JSONDecoder().decode(PublicationProfile.self, from: pair.data)
+    }
+
+    private struct EditionSpec {
+        var kind: String
+        var output: String
+        var scope: String?
+        var splitSize: Int?
+    }
+
+    private static func editionSpec(id: String, profile: PublicationProfile?) -> EditionSpec? {
+        switch id {
+        case "ir":
+            guard let output = profile?.editions?.ir?.output else { return nil }
+            return EditionSpec(kind: "ir", output: output)
+        case "rag":
+            guard let rag = profile?.editions?.rag else { return nil }
+            return EditionSpec(kind: "rag", output: rag.output, scope: rag.scope, splitSize: rag.split_size)
+        case "context":
+            guard let context = profile?.editions?.context else { return nil }
+            return EditionSpec(
+                kind: "context",
+                output: context.output,
+                scope: context.scope,
+                splitSize: context.split_size
+            )
+        default:
+            return nil
+        }
     }
 }

--- a/Sources/App/CoordinatorProblems.swift
+++ b/Sources/App/CoordinatorProblems.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+struct ProblemItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let severity: String
+    let code: String
+    let message: String
+    let path: String?
+    let line: Int?
+    let column: Int?
+
+    init(
+        severity: String,
+        code: String,
+        message: String,
+        path: String? = nil,
+        line: Int? = nil,
+        column: Int? = nil
+    ) {
+        self.id = "\(code)|\(path ?? "")|\(line ?? -1)|\(column ?? -1)|\(message)"
+        self.severity = severity
+        self.code = code
+        self.message = message
+        self.path = path
+        self.line = line
+        self.column = column
+    }
+}
+
+/// Maps engine results onto the problems list. A non-zero exit with no
+/// report still becomes a row — never swallow stderr or an exit code.
+enum CoordinatorProblems {
+    static func from(report: HTMLBuildReport?) -> [ProblemItem] {
+        (report?.diagnostics ?? []).map(from(diagnostic:))
+    }
+
+    static func from(diagnostic: Diagnostic) -> ProblemItem {
+        ProblemItem(
+            severity: diagnostic.severity,
+            code: diagnostic.code,
+            message: diagnostic.message,
+            path: diagnostic.sourcePath,
+            line: diagnostic.line,
+            column: diagnostic.column
+        )
+    }
+
+    static func fromIR(report: BuildReport) -> [ProblemItem] {
+        report.diagnostics.map(from(diagnostic:))
+    }
+
+    /// Target / edition / fan-out entry. Prefer the report; if the report is
+    /// missing or empty and the process failed, surface stderr (or the exit).
+    static func fromEntry(
+        name: String,
+        kind: String,
+        exitCode: Int32,
+        stderr: String,
+        report: HTMLBuildReport?
+    ) -> [ProblemItem] {
+        let fromReport = from(report: report)
+        if !fromReport.isEmpty { return fromReport }
+        guard exitCode != 0 else { return [] }
+        return [failed(code: kind, name: name, exitCode: exitCode, stderr: stderr)]
+    }
+
+    static func fromEntries(_ results: [EntryProblemSource]) -> [ProblemItem] {
+        results.flatMap {
+            fromEntry(
+                name: $0.name,
+                kind: $0.kind,
+                exitCode: $0.exitCode,
+                stderr: $0.stderr,
+                report: $0.report
+            )
+        }
+    }
+
+    static func fromCommand(code: String, exitCode: Int32, stderr: String) -> [ProblemItem] {
+        guard exitCode != 0 else { return [] }
+        return [failed(code: code, name: nil, exitCode: exitCode, stderr: stderr)]
+    }
+
+    static func fromFailure(code: String, message: String) -> [ProblemItem] {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        return [
+            ProblemItem(
+                severity: "error",
+                code: code,
+                message: trimmed.isEmpty ? code : trimmed
+            )
+        ]
+    }
+
+    struct EntryProblemSource: Sendable {
+        var name: String
+        var kind: String
+        var exitCode: Int32
+        var stderr: String
+        var report: HTMLBuildReport?
+    }
+
+    private static func failed(
+        code: String,
+        name: String?,
+        exitCode: Int32,
+        stderr: String
+    ) -> ProblemItem {
+        let tail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let message: String
+        if !tail.isEmpty {
+            message = tail
+        } else if let name {
+            message = "\(name): exit \(exitCode)"
+        } else {
+            message = "exit \(exitCode)"
+        }
+        return ProblemItem(severity: "error", code: code, message: message)
+    }
+}

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -31,7 +31,7 @@ struct MainWindow: View {
                     Label("Validate", systemImage: "checkmark.circle")
                 }
                 .help("Validate")
-                .disabled(store.selectedSource == nil || runtime.coordinator.isRunning)
+                .disabled(store.selectedSource == nil || !runtime.coordinator.canRunVerb)
 
                 Button {
                     runtime.coordinator.run(.buildIR, store: store, runtime: runtime)
@@ -39,7 +39,7 @@ struct MainWindow: View {
                     Label("Build IR", systemImage: "hammer")
                 }
                 .help("Build IR")
-                .disabled(store.selectedSource == nil || runtime.coordinator.isRunning)
+                .disabled(store.selectedSource == nil || !runtime.coordinator.canRunVerb)
 
                 Button {
                     runtime.coordinator.stop(runtime: runtime)
@@ -47,7 +47,7 @@ struct MainWindow: View {
                     Label("Stop", systemImage: "stop.fill")
                 }
                 .help("Stop")
-                .disabled(!runtime.coordinator.isRunning)
+                .disabled(!runtime.coordinator.canStop)
 
                 Button {
                     openWindow(id: CompanionID.preview)

--- a/Sources/Companions/Preview/PreviewSession.swift
+++ b/Sources/Companions/Preview/PreviewSession.swift
@@ -49,10 +49,13 @@ final class PreviewSession {
     private var server: WatchServer?
     private var rootPath: String?
     private var timeoutTask: Task<Void, Never>?
+    private weak var coordinator: Coordinator?
 
-    func start(contentRoot: URL, projectRoot: URL, engine: BorisEngine?) {
+    func start(contentRoot: URL, projectRoot: URL, engine: BorisEngine?, coordinator: Coordinator?) {
+        self.coordinator = coordinator
         let root = contentRoot.standardizedFileURL.path
         if root == rootPath, let server, server.isRunning {
+            coordinator?.registerWatch(server)
             if let url = server.serveURL {
                 phase = .serving(url)
             }
@@ -61,6 +64,7 @@ final class PreviewSession {
             return
         }
         stop()
+        self.coordinator = coordinator
         rootPath = root
 
         guard let engine else {
@@ -77,6 +81,7 @@ final class PreviewSession {
                 port: 0
             )
             self.server = server
+            coordinator?.registerWatch(server)
             server.onServe = { [weak self] url in
                 Task { @MainActor in self?.handleServe(url: url) }
             }
@@ -93,27 +98,27 @@ final class PreviewSession {
     /// Surfaces a non-server failure (e.g. an unresolvable content root),
     /// tearing down any live server so nothing leaks.
     func fail(_ message: String) {
-        timeoutTask?.cancel()
-        timeoutTask = nil
-        server?.onServe = nil
-        server?.onExit = nil
-        server?.stop()
-        server = nil
+        teardownServer()
         rootPath = nil
         phase = .failed(message)
     }
 
     func stop() {
+        teardownServer()
+        rootPath = nil
+        phase = .idle
+    }
+
+    private func teardownServer() {
         timeoutTask?.cancel()
         timeoutTask = nil
         if let server {
+            coordinator?.unregisterWatch(server)
             server.onServe = nil
             server.onExit = nil
             server.stop()
             self.server = nil
         }
-        rootPath = nil
-        phase = .idle
     }
 
     // MARK: Server callbacks (hopped to the main actor)
@@ -127,8 +132,9 @@ final class PreviewSession {
     private func handleExit(_ exit: WatchExit) {
         // We stopped it on purpose; the callbacks were cleared first, so the
         // only exits that land here are spontaneous ones.
-        guard server != nil else { return }
-        server = nil
+        guard let server else { return }
+        coordinator?.unregisterWatch(server)
+        self.server = nil
         timeoutTask?.cancel()
         timeoutTask = nil
         rootPath = nil
@@ -151,9 +157,7 @@ final class PreviewSession {
     }
 
     private func failTimeout() {
-        server?.stop()
-        server = nil
-        timeoutTask = nil
+        teardownServer()
         rootPath = nil
         phase = .failed("preview server did not report a port within 15s")
     }

--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -68,7 +68,8 @@ struct PreviewWindow: View {
             session.start(
                 contentRoot: contentRoot,
                 projectRoot: projectRoot,
-                engine: runtime.engine
+                engine: runtime.engine,
+                coordinator: runtime.coordinator
             )
         }
     }

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -480,6 +480,11 @@ public actor BorisEngine {
         runHandle.terminate()
     }
 
+    /// SIGKILL the in-flight one-shot if SIGTERM was ignored.
+    public func forceKill() {
+        runHandle.forceKill()
+    }
+
     // MARK: Preview (M4)
 
     /// Starts `boris watch --serve --port 0` for `contentRoot` (D5) and

--- a/Sources/Engine/BorisRunner.swift
+++ b/Sources/Engine/BorisRunner.swift
@@ -50,6 +50,14 @@ public final class RunHandle: @unchecked Sendable {
         guard let process, process.isRunning else { return }
         process.terminate()
     }
+
+    public func forceKill() {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        guard let process, process.isRunning else { return }
+        ChildProcessControl.forceKill(pid: process.processIdentifier)
+    }
 }
 
 public enum BorisRunner {

--- a/Sources/Engine/ChildProcessControl.swift
+++ b/Sources/Engine/ChildProcessControl.swift
@@ -1,0 +1,30 @@
+import Darwin
+import Foundation
+
+/// SIGSTOP / SIGCONT / SIGKILL against a child pid. Shared by the one-shot
+/// `RunHandle` and the long-lived `WatchServer` so teardown stays one path.
+public enum ChildProcessControl {
+    /// Freeze the process. Port stays bound; no further writes.
+    @discardableResult
+    public static func suspend(pid: Int32) -> Bool {
+        guard pid > 1 else { return false }
+        return kill(pid, SIGSTOP) == 0
+    }
+
+    /// Unfreeze a previously stopped process.
+    @discardableResult
+    public static func resume(pid: Int32) -> Bool {
+        guard pid > 1 else { return false }
+        return kill(pid, SIGCONT) == 0
+    }
+
+    /// Last-resort reap. Works on a SIGSTOP'd child.
+    @discardableResult
+    public static func forceKill(pid: Int32) -> Bool {
+        guard pid > 1 else { return false }
+        return kill(pid, SIGKILL) == 0
+    }
+
+    /// Seconds to wait after SIGTERM before SIGKILL.
+    public static let reapGrace: Duration = .seconds(2)
+}

--- a/Sources/Engine/WatchServer.swift
+++ b/Sources/Engine/WatchServer.swift
@@ -77,6 +77,21 @@ public final class WatchServer: @unchecked Sendable {
         return process?.isRunning ?? false
     }
 
+    public var isSuspended: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _suspended
+    }
+
+    public var processIdentifier: Int32? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let process, process.isRunning else { return nil }
+        return process.processIdentifier
+    }
+
+    private var _suspended = false
+
     /// Launches the process. Throws `BorisRunnerError.launchFailed` when the
     /// binary cannot be spawned.
     public func start() throws {
@@ -106,13 +121,55 @@ public final class WatchServer: @unchecked Sendable {
     }
 
     /// SIGTERM the server (afterparty exits 0 gracefully — A12). Cannot be
-    /// restarted; create a new `WatchServer` instead.
+    /// restarted; create a new `WatchServer` instead. A SIGSTOP'd child is
+    /// continued first so the signal is delivered.
     public func stop() {
         lock.lock()
         let process = self.process
+        let suspended = _suspended
+        let pid = process?.processIdentifier
+        _suspended = false
         lock.unlock()
         guard let process, process.isRunning else { return }
+        if suspended, let pid {
+            ChildProcessControl.resume(pid: pid)
+        }
         process.terminate()
+    }
+
+    /// Freeze watch so a tree-writing job can own `dist/` / `.boris`.
+    /// The helper URL and bound port stay valid.
+    public func suspend() {
+        lock.lock()
+        let pid = process?.isRunning == true ? process?.processIdentifier : nil
+        let already = _suspended
+        lock.unlock()
+        guard let pid, !already else { return }
+        guard ChildProcessControl.suspend(pid: pid) else { return }
+        lock.lock()
+        _suspended = true
+        lock.unlock()
+    }
+
+    /// Continue a frozen watch. No-op if it already exited.
+    public func resume() {
+        lock.lock()
+        let pid = process?.isRunning == true ? process?.processIdentifier : nil
+        let was = _suspended
+        _suspended = false
+        lock.unlock()
+        guard was, let pid else { return }
+        ChildProcessControl.resume(pid: pid)
+    }
+
+    /// SIGKILL if SIGTERM was ignored. Safe on a stopped child.
+    public func forceKill() {
+        lock.lock()
+        let pid = process?.isRunning == true ? process?.processIdentifier : nil
+        _suspended = false
+        lock.unlock()
+        guard let pid else { return }
+        ChildProcessControl.forceKill(pid: pid)
     }
 
     // MARK: stderr streaming
@@ -154,6 +211,7 @@ public final class WatchServer: @unchecked Sendable {
         )
         let onExit = self.onExit
         self.process = nil
+        _suspended = false
         lock.unlock()
         onExit?(exit)
     }

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -179,6 +179,8 @@ struct LocalPlay: PlaySurface {
             return
         }
 
+        runtime.coordinator.beginTreeWrite()
+        defer { runtime.coordinator.endTreeWrite() }
         do {
             let build = try await engine.buildIR(contentRoot: contentRoot, outDir: outDir)
             guard !Task.isCancelled else { return }

--- a/Sources/Play/Local/OutputsPane.swift
+++ b/Sources/Play/Local/OutputsPane.swift
@@ -42,20 +42,28 @@ struct OutputsPane: View {
             Section {
                 if let targets = profile.targets, !targets.isEmpty {
                     ForEach(targets, id: \.name) { target in
-                        TargetRow(target: target, onBuild: { buildTarget(target) })
-                            .tag("target:\(target.name)")
+                        TargetRow(
+                            target: target,
+                            isBusy: runtime.coordinator.isRunning,
+                            onBuild: { requestBuild(kind: "target", id: target.name, title: target.name) }
+                        )
+                        .tag("target:\(target.name)")
                     }
                 } else {
                     let defaultTarget = PublicationTarget(name: "default", output: "dist")
-                    TargetRow(target: defaultTarget, onBuild: { buildTarget(defaultTarget) })
-                        .tag("target:default")
+                    TargetRow(
+                        target: defaultTarget,
+                        isBusy: runtime.coordinator.isRunning,
+                        onBuild: { requestBuild(kind: "target", id: "default", title: "default") }
+                    )
+                    .tag("target:default")
                 }
             } header: {
                 HStack {
                     Text("HTML Targets")
                     Spacer()
                     Button("Build All") {
-                        buildAll(profile)
+                        runtime.coordinator.run(.buildAll, store: store, runtime: runtime)
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
@@ -66,31 +74,33 @@ struct OutputsPane: View {
             if let editions = profile.editions {
                 Section("Editions") {
                     if let ir = editions.ir {
-                        EditionRow(name: "IR (.boris)", output: ir.output, kind: "ir", onBuild: {
-                            buildEdition(kind: "ir", output: ir.output)
-                        })
+                        EditionRow(
+                            name: "IR (.boris)",
+                            output: ir.output,
+                            kind: "ir",
+                            isBusy: runtime.coordinator.isRunning,
+                            onBuild: { requestBuild(kind: "edition", id: "ir", title: "IR") }
+                        )
                         .tag("edition:ir")
                     }
                     if let rag = editions.rag {
-                        EditionRow(name: "RAG", output: rag.output, kind: "rag", onBuild: {
-                            buildEdition(
-                                kind: "rag",
-                                output: rag.output,
-                                scope: rag.scope,
-                                splitSize: rag.split_size
-                            )
-                        })
+                        EditionRow(
+                            name: "RAG",
+                            output: rag.output,
+                            kind: "rag",
+                            isBusy: runtime.coordinator.isRunning,
+                            onBuild: { requestBuild(kind: "edition", id: "rag", title: "RAG") }
+                        )
                         .tag("edition:rag")
                     }
                     if let context = editions.context {
-                        EditionRow(name: "Context", output: context.output, kind: "context", onBuild: {
-                            buildEdition(
-                                kind: "context",
-                                output: context.output,
-                                scope: context.scope,
-                                splitSize: context.split_size
-                            )
-                        })
+                        EditionRow(
+                            name: "Context",
+                            output: context.output,
+                            kind: "context",
+                            isBusy: runtime.coordinator.isRunning,
+                            onBuild: { requestBuild(kind: "edition", id: "context", title: "Context") }
+                        )
                         .tag("edition:context")
                     }
                 }
@@ -129,8 +139,13 @@ struct OutputsPane: View {
         }
         do {
             if let pair = try InspectorProfile.load(from: root) {
-                profile = try? JSONDecoder().decode(PublicationProfile.self, from: pair.data)
-                loadError = nil
+                do {
+                    profile = try JSONDecoder().decode(PublicationProfile.self, from: pair.data)
+                    loadError = nil
+                } catch {
+                    profile = nil
+                    loadError = error.localizedDescription
+                }
             } else {
                 profile = nil
                 loadError = nil
@@ -140,63 +155,16 @@ struct OutputsPane: View {
         }
     }
 
-    private func buildTarget(_ target: PublicationTarget) {
-        guard let engine = runtime.engine else { return }
-        guard let contentRoot = try? source.contentRoot() else { return }
-        let cwd = try? source.workspaceRoot()
-
-        Task {
-            _ = try? await engine.buildTarget(
-                contentRoot: contentRoot,
-                target: target,
-                siteURL: profile?.site?.url,
-                workingDirectory: cwd,
-                timings: true
-            )
-        }
-    }
-
-    private func buildEdition(
-        kind: String,
-        output: String,
-        scope: String? = nil,
-        splitSize: Int? = nil
-    ) {
-        guard let engine = runtime.engine else { return }
-        guard let contentRoot = try? source.contentRoot() else { return }
-        let cwd = try? source.workspaceRoot()
-
-        Task {
-            _ = try? await engine.buildEdition(
-                contentRoot: contentRoot,
-                kind: kind,
-                outputDir: output,
-                scope: scope,
-                splitSize: splitSize,
-                workingDirectory: cwd,
-                timings: true
-            )
-        }
-    }
-
-    private func buildAll(_ profile: PublicationProfile) {
-        guard let engine = runtime.engine else { return }
-        guard let contentRoot = try? source.contentRoot() else { return }
-        let cwd = try? source.workspaceRoot()
-
-        Task {
-            _ = try? await engine.buildAll(
-                contentRoot: contentRoot,
-                profile: profile,
-                workingDirectory: cwd,
-                timings: true
-            )
-        }
+    /// Select the row, then ask the coordinator. Play never spawns `boris`.
+    private func requestBuild(kind: String, id: String, title: String) {
+        store.select(noun: WorkspaceNoun(kind: kind, id: id, title: title))
+        runtime.coordinator.run(.buildThis, store: store, runtime: runtime)
     }
 }
 
 private struct TargetRow: View {
     let target: PublicationTarget
+    let isBusy: Bool
     let onBuild: () -> Void
 
     var body: some View {
@@ -218,6 +186,7 @@ private struct TargetRow: View {
                 Spacer()
                 Button("Build", action: onBuild)
                     .controlSize(.small)
+                    .disabled(isBusy)
             }
             HStack(spacing: 12) {
                 Label(target.output, systemImage: "folder")
@@ -263,6 +232,7 @@ private struct EditionRow: View {
     let name: String
     let output: String
     let kind: String
+    let isBusy: Bool
     let onBuild: () -> Void
 
     var body: some View {
@@ -279,6 +249,7 @@ private struct EditionRow: View {
             Spacer()
             Button("Build", action: onBuild)
                 .controlSize(.small)
+                .disabled(isBusy)
         }
         .padding(.vertical, 2)
     }

--- a/Sources/Play/Local/PublishPane.swift
+++ b/Sources/Play/Local/PublishPane.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 /// Publish pane (M8 / #77): renders publication target details, plan,
-/// evidence chain (`_boris/proof/`), Proof Pack archives, and publish actions.
+/// evidence chain (`_boris/proof/`), and publish actions. Actions go through
+/// the coordinator — this view never spawns `boris`.
 struct PublishPane: View {
     let source: LocalSource
 
@@ -9,12 +10,17 @@ struct PublishPane: View {
     @Environment(AppRuntime.self) private var runtime
     @State private var profile: PublicationProfile?
     @State private var proofFiles: [ProofFileItem] = []
-    @State private var planSummary: String?
-    @State private var publishStatus: String?
     @State private var loadError: String?
 
     var body: some View {
         List {
+            if let loadError {
+                Section {
+                    Text(loadError)
+                        .foregroundStyle(.red)
+                }
+            }
+
             Section("Publication Declaration") {
                 if let pub = profile?.publication {
                     LabeledContent("Target", value: pub.target)
@@ -38,43 +44,41 @@ struct PublishPane: View {
             Section("Publish Actions") {
                 HStack(spacing: 12) {
                     Button("Plan Publication") {
-                        planPublication()
+                        runtime.coordinator.run(.plan, store: store, runtime: runtime)
                     }
                     .controlSize(.small)
+                    .disabled(runtime.coordinator.isRunning)
 
                     if let target = profile?.publication?.target {
                         if target == "standard-site" {
                             Button("Publish to Standard.site") {
-                                publishStandardSite()
+                                runtime.coordinator.run(
+                                    .publishStandardSite,
+                                    store: store,
+                                    runtime: runtime
+                                )
                             }
                             .buttonStyle(.borderedProminent)
                             .controlSize(.small)
+                            .disabled(runtime.coordinator.isRunning)
                         } else if target == "nostr" {
                             Button("Publish to Nostr…") {
-                                publishNostr()
+                                runtime.coordinator.run(
+                                    .publishNostr,
+                                    store: store,
+                                    runtime: runtime
+                                )
                             }
                             .buttonStyle(.borderedProminent)
                             .controlSize(.small)
+                            .disabled(runtime.coordinator.isRunning)
                         }
                     }
                 }
 
-                if let planSummary {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Plan Output")
-                            .font(.caption.bold())
-                            .foregroundStyle(.secondary)
-                        Text(planSummary)
-                            .font(.caption.monospaced())
-                    }
-                    .padding(.vertical, 4)
-                }
-
-                if let publishStatus {
-                    Text(publishStatus)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                Text("Results land in the problems list. Stop (⌘.) cancels the job.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Evidence Chain (_boris/proof/)") {
@@ -106,6 +110,11 @@ struct PublishPane: View {
         .task(id: source.id) {
             load()
         }
+        .onChange(of: runtime.coordinator.isRunning) { wasRunning, isRunning in
+            if wasRunning, !isRunning, let root = try? source.workspaceRoot() {
+                scanProofFiles(in: root)
+            }
+        }
     }
 
     private func load() {
@@ -115,7 +124,13 @@ struct PublishPane: View {
         }
         do {
             if let pair = try InspectorProfile.load(from: root) {
-                profile = try? JSONDecoder().decode(PublicationProfile.self, from: pair.data)
+                do {
+                    profile = try JSONDecoder().decode(PublicationProfile.self, from: pair.data)
+                    loadError = nil
+                } catch {
+                    profile = nil
+                    loadError = error.localizedDescription
+                }
             }
         } catch {
             loadError = error.localizedDescription
@@ -146,44 +161,6 @@ struct PublishPane: View {
             ))
         }
         proofFiles = items.sorted(by: { $0.name < $1.name })
-    }
-
-    private func planPublication() {
-        guard let root = try? source.workspaceRoot(), let engine = runtime.engine else { return }
-        let profileURL = root.appendingPathComponent("boris.json")
-        Task {
-            if let result = try? await engine.plan(profileURL: profileURL) {
-                planSummary = result.stdout.isEmpty ? "Exit code: \(result.exitCode)" : result.stdout
-            }
-        }
-    }
-
-    private func publishStandardSite() {
-        guard let root = try? source.workspaceRoot(), let engine = runtime.engine else { return }
-        let profileURL = root.appendingPathComponent("boris.json")
-        Task {
-            do {
-                let result = try await engine.standardSitePublish(profileURL: profileURL)
-                publishStatus = "Standard.site publish finished with exit code \(result.exitCode)."
-                scanProofFiles(in: root)
-            } catch {
-                publishStatus = "Standard.site publish error: \(error.localizedDescription)"
-            }
-        }
-    }
-
-    private func publishNostr() {
-        guard let root = try? source.workspaceRoot(), let engine = runtime.engine else { return }
-        let profileURL = root.appendingPathComponent("boris.json")
-        Task {
-            do {
-                let planResult = try await engine.nostrPlan(profileURL: profileURL)
-                publishStatus = "Nostr plan: exit \(planResult.exitCode)"
-                scanProofFiles(in: root)
-            } catch {
-                publishStatus = "Nostr error: \(error.localizedDescription)"
-            }
-        }
     }
 }
 

--- a/Tests/ContractTests/ChildProcessControlTests.swift
+++ b/Tests/ContractTests/ChildProcessControlTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+final class ChildProcessControlTests: XCTestCase {
+    func testSuspendResumeAndForceKill() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        let pid = process.processIdentifier
+        defer {
+            if process.isRunning {
+                ChildProcessControl.forceKill(pid: pid)
+                process.waitUntilExit()
+            }
+        }
+
+        XCTAssertTrue(process.isRunning)
+        XCTAssertTrue(ChildProcessControl.suspend(pid: pid))
+        XCTAssertTrue(processStat(pid).contains("T"), "suspended child should be in T state")
+
+        XCTAssertTrue(ChildProcessControl.resume(pid: pid))
+        // Give the kernel a tick to leave T.
+        Thread.sleep(forTimeInterval: 0.05)
+        XCTAssertFalse(processStat(pid).contains("T"), "resumed child should leave T state")
+        XCTAssertTrue(process.isRunning)
+
+        XCTAssertTrue(ChildProcessControl.forceKill(pid: pid))
+        process.waitUntilExit()
+        XCTAssertFalse(process.isRunning)
+        XCTAssertEqual(process.terminationReason, .uncaughtSignal)
+    }
+
+    func testRefusesPidZeroAndOne() {
+        XCTAssertFalse(ChildProcessControl.suspend(pid: 0))
+        XCTAssertFalse(ChildProcessControl.resume(pid: 1))
+        XCTAssertFalse(ChildProcessControl.forceKill(pid: 0))
+    }
+
+    private func processStat(_ pid: Int32) -> String {
+        let listing = Process()
+        listing.executableURL = URL(fileURLWithPath: "/bin/ps")
+        listing.arguments = ["-o", "stat=", "-p", "\(pid)"]
+        let pipe = Pipe()
+        listing.standardOutput = pipe
+        listing.standardError = FileHandle.nullDevice
+        do {
+            try listing.run()
+            listing.waitUntilExit()
+        } catch {
+            return ""
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(bytes: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}

--- a/Tests/ContractTests/CoordinatorProblemsTests.swift
+++ b/Tests/ContractTests/CoordinatorProblemsTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+final class CoordinatorProblemsTests: XCTestCase {
+    func testReportDiagnosticsBecomeRows() {
+        let report = HTMLBuildReport(
+            schemaVersion: "html-build-report-0.1.0",
+            compilerId: "boris",
+            ok: false,
+            contentRoot: nil,
+            outDir: nil,
+            errorCount: 1,
+            diagnostics: [
+                Diagnostic(
+                    severity: "error",
+                    code: "EFRONTMATTER",
+                    message: "bad yaml",
+                    remediation: "fix it",
+                    sourcePath: "index.md",
+                    line: 3,
+                    column: 1,
+                    id: nil
+                )
+            ]
+        )
+        let items = CoordinatorProblems.from(report: report)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].code, "EFRONTMATTER")
+        XCTAssertEqual(items[0].path, "index.md")
+        XCTAssertEqual(items[0].line, 3)
+    }
+
+    func testFailedEntryWithoutReportSurfacesStderr() {
+        let items = CoordinatorProblems.fromEntry(
+            name: "rag",
+            kind: "rag",
+            exitCode: 1,
+            stderr: "rag: split-size too small\n",
+            report: nil
+        )
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].severity, "error")
+        XCTAssertEqual(items[0].code, "rag")
+        XCTAssertEqual(items[0].message, "rag: split-size too small")
+    }
+
+    func testFailedEntryWithoutStderrSurfacesExit() {
+        let items = CoordinatorProblems.fromEntry(
+            name: "public",
+            kind: "target",
+            exitCode: 2,
+            stderr: "   ",
+            report: nil
+        )
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].message, "public: exit 2")
+    }
+
+    func testSuccessfulEntryWithoutReportIsSilent() {
+        let items = CoordinatorProblems.fromEntry(
+            name: "ir",
+            kind: "ir",
+            exitCode: 0,
+            stderr: "",
+            report: nil
+        )
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    func testCommandFailureNeverDropsEmptyStderr() {
+        let items = CoordinatorProblems.fromCommand(code: "standard-site", exitCode: 7, stderr: "")
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].code, "standard-site")
+        XCTAssertEqual(items[0].message, "exit 7")
+    }
+
+    func testFanoutKeepsEveryFailedEntry() {
+        let items = CoordinatorProblems.fromEntries([
+            .init(name: "public", kind: "target", exitCode: 0, stderr: "", report: nil),
+            .init(name: "rag", kind: "rag", exitCode: 1, stderr: "rag failed", report: nil),
+            .init(name: "context", kind: "context", exitCode: 1, stderr: "context failed", report: nil),
+        ])
+        XCTAssertEqual(items.map(\.message), ["rag failed", "context failed"])
+    }
+}

--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -13,15 +13,15 @@ watch"* (ROADMAP §7).
 
 | Piece | Current behavior |
 |-------|------------------|
-| `BorisEngine` (actor) | One `RunHandle` = one `Process?` slot for one-shots. `run()` is **synchronous** (`waitUntilExit`) — serialized by the actor, so one-shot jobs never overlap. |
-| `BorisRunner.run` | stdout/stderr → temp files (no pipe deadlock). `RunHandle.terminate()` = SIGTERM. Cancel detected via `terminationReason == .uncaughtSignal`. |
-| `Coordinator` (MainActor) | `isRunning` / `verb` / `summary` / `exitCode` / `problems`. One `Task` per job; `stop()` cancels + `engine.interrupt()`. Verbs: Plan, Validate, Build IR, Build HTML, Check, Impact, Stop (⌘.). |
-| `WatchServer` | Long-lived `boris watch --serve` subprocess, own `Process` + `terminationHandler`, stderr pipe for the port line. One-shot: `stop()` = SIGTERM (graceful exit 0, A12). |
-| `PreviewSession` | Owns the `WatchServer` per selected source; idempotent reuse per content root; 15 s port-line timeout; `onExit` → `idle`/`failed`. |
+| `BorisEngine` (actor) | One `RunHandle` = one `Process?` slot for one-shots. `run()` is **synchronous** (`waitUntilExit`) — serialized by the actor, so one-shot jobs never overlap. `interrupt()` = SIGTERM; `forceKill()` = SIGKILL. |
+| `BorisRunner.run` | stdout/stderr → temp files (no pipe deadlock). `RunHandle.terminate()` = SIGTERM; `forceKill()` = SIGKILL. |
+| `ChildProcessControl` | Shared SIGSTOP / SIGCONT / SIGKILL primitive. |
+| `Coordinator` (MainActor) | `state` (`idle` / `watching` / `validating` / `building` / `terminating`) plus `isRunning` / `verb` / `summary` / `exitCode` / `problems`. Weak watch registry. Tree-writing verbs (`buildIR` / `buildHTML` / `buildThis` / `buildAll` / `publishStandardSite`) SIGSTOP watch, resume on finish. Stop: SIGTERM then SIGKILL after 2s; with no job, Stop tears down preview watch. |
+| `WatchServer` | Long-lived `boris watch --serve`. `suspend()` / `resume()` / `forceKill()`. `stop()` continues a frozen child before SIGTERM. |
+| `PreviewSession` | Owns the `WatchServer`; registers/unregisters with the coordinator on start/stop/exit/timeout. |
 
-**Gaps the lane must close:** no watch registry (builds cannot see
-watch), no suspend/resume, no save-triggered validate, no debounce, no
-hang timeout, no SIGKILL escalation.
+**Still open:** save-triggered validate + debounce, job hang watchdog
+(timeouts in §5), moving `waitUntilExit` off the engine actor.
 
 ## 2. Canonical states
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -7,7 +7,7 @@ Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeane
 Solipsist organizes its workspace into a three-column spatial model:
 
 - **Sources (Left)**: Switch between opened Boris publication folders (`File → Open…` or `⌘O`) and dogfood test corpora under `Stunts/`.
-- **Play (Center)**: Displays publication pages, node graph relationships, and generated artifacts derived from compiler contracts.
+- **Play (Center)**: Pages, Outputs, and Publish tabs. The problems list under play is where every coordinator job reports its exit and diagnostics.
 - **Inspector Drawer (Right)**: Inspect publication configuration (`boris.json`), page frontmatter completion index (`completion.json`), and execution options.
 
 ## Menu Reference
@@ -18,6 +18,7 @@ Every menu verb and keyboard shortcut:
 
 | Verb | Shortcut | Description |
 | --- | --- | --- |
+| New Project… | `⌘N` | Initialize a new Boris project in a folder (`boris init`) and add it as a source. |
 | Open… | `⌘O` | Open a Boris publication folder as a source. |
 | Remove Source | — | Remove the currently selected source from the workspace (enabled when a source is selected). |
 
@@ -29,9 +30,13 @@ Every menu verb and keyboard shortcut:
 | Validate | `⌘⇧K` | Validate publication structure and HTML output. |
 | Build IR | `⌘B` | Compile documents into the deterministic IR graph. |
 | Build HTML | `⌘⇧B` | Build the HTML distribution from the IR graph. |
+| Build All | `⌘⇧U` | Fan out every HTML target and edition in the publication profile. |
+| Build This | — | Build the selected HTML target or edition (Outputs tab). |
 | Check | — | Run static documentation intelligence and reference checks. |
 | Impact | — | Analyze ripple effects of node changes across the graph (enabled when a page is selected). |
-| Stop | `⌘.` | Terminate any currently running compiler subprocess. |
+| Publish to Standard.site | — | Run `boris standard-site publish` for the selected source. |
+| Publish to Nostr… | — | Run `boris nostr plan` for the selected source (sign/publish is not wired yet). |
+| Stop | `⌘.` | Cancel the running job (SIGTERM, then SIGKILL after 2s). With no job, stops preview watch. Tree-writing jobs freeze watch until they finish. |
 
 ### View
 


### PR DESCRIPTION
## Card

other — integrity holes on M4/M5/M7/M8 (refs #58)

## What

Two coordinator integrity holes from the post-#81/#82 audit.

**1. Play no longer swallows engine jobs.** Outputs Build / Build All and Publish Plan / Publish were calling `BorisEngine` with `try?` and dropping the exit. They now only call `Coordinator.run`. New **Boris → Build This** verb (row buttons select the noun, then run it). A failed target/edition with no report still becomes a problems-list row (stderr, or `name: exit N`). `boris.json` decode failures are errors, not a silent empty profile.

**2. Watch is paused for tree-writing jobs.** Preview registers its `WatchServer` with the coordinator. Build IR / HTML / This / All, Standard.site publish, and play's implicit IR build SIGSTOP watch and SIGCONT when they finish — same port, same `/__boris/` URL. Validate / plan / check / impact still run beside a live watch. **Stop (⌘.)** is enabled whenever we are not idle: SIGTERM, then SIGKILL after 2s. With no job, Stop tears down preview watch.

`help.md` matches the real menu (New Project, Build All, Build This, both publish verbs). Nostr is labeled plan-only.

**Not this PR:** save-triggered validate, job hang timeouts, moving `waitUntilExit` off the engine actor, stdin publish secrets.

## Gate

- [x] `SKIP_EMBED_BORIS=1 make build` locally
- [x] `make test` (57 tests, including suspend → `T` → resume → SIGKILL against `/bin/sleep`)
- [x] `make lint`
- [ ] CI `spike` + `app` green
- [x] Did not touch `boris/` or commit `SUPPORT-NOT-FOR-GITHUB/`