### PR TITLE
fix(publish): pipe secrets on stdin; wire Keychain remember

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -96,6 +96,7 @@ targets:
       - path: Sources/Play/Local/LocalPlayGraph.swift
       - path: Sources/App/CoordinatorProblems.swift
       - path: Sources/Engine/ChildProcessControl.swift
+      - path: Sources/Engine/BorisRunner.swift
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Sources/Companions/Preview/PreviewURL.swift
     settings:

--- a/Project.yml
+++ b/Project.yml
@@ -67,14 +67,15 @@ targets:
           /bin/bash "${SRCROOT}/scripts/embed-boris.sh" "${SRCROOT}" "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 
   # M1 engine spike: a headless CLI that runs the bundled boris binary and
-  # decodes its JSON contracts. Shares Sources/Models and Sources/Engine
-  # with the app.
+  # decodes its JSON contracts. Shares Sources/Models, Sources/Engine, and
+  # Sources/Security (stdin secret buffers) with the app.
   spike:
     type: tool
     platform: macOS
     sources:
       - path: Sources/Models
       - path: Sources/Engine
+      - path: Sources/Security
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Spike
     settings:

--- a/Sources/App/AppRuntime.swift
+++ b/Sources/App/AppRuntime.swift
@@ -10,6 +10,7 @@ final class AppRuntime {
     let enginePath: String?
     let engineError: String?
     let coordinator = Coordinator()
+    let credentials = PublishCredentialManager()
 
     init() {
         if let url = BorisBinary.locate() {

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -16,10 +16,18 @@ enum CoordinatorVerb: String, Sendable {
     /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof).
     var writesTree: Bool {
         switch self {
-        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite:
+        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr:
             true
-        case .plan, .validate, .check, .impact, .publishNostr:
+        case .plan, .validate, .check, .impact:
             false
+        }
+    }
+
+    var secretTarget: String? {
+        switch self {
+        case .publishNostr: PublishTargets.nostr
+        case .publishStandardSite: PublishTargets.standardSite
+        default: nil
         }
     }
 }
@@ -115,6 +123,20 @@ final class Coordinator {
             return
         }
 
+        let secret: SecureBuffer?
+        if let target = verb.secretTarget {
+            guard let taken = Self.takeOrPromptSecret(
+                for: verb,
+                target: target,
+                credentials: runtime.credentials
+            ) else {
+                return
+            }
+            secret = taken
+        } else {
+            secret = nil
+        }
+
         isRunning = true
         state = verb.writesTree ? .building : .validating
         self.verb = verb
@@ -127,7 +149,13 @@ final class Coordinator {
 
         let noun = store.selection.noun
         task = Task {
-            let result = await Self.perform(verb, source: source, noun: noun, engine: engine)
+            let result = await Self.perform(
+                verb,
+                source: source,
+                noun: noun,
+                engine: engine,
+                secret: secret
+            )
             guard !Task.isCancelled else {
                 self.finish(verb: verb, exit: result.exit, summary: "cancelled", problems: result.problems)
                 return
@@ -196,11 +224,33 @@ final class Coordinator {
         var problems: [ProblemItem]
     }
 
+    private static func takeOrPromptSecret(
+        for verb: CoordinatorVerb,
+        target: String,
+        credentials: PublishCredentialManager
+    ) -> SecureBuffer? {
+        if let existing = credentials.takeSecretForUse(for: target) {
+            return existing
+        }
+        guard let answer = PublishSecretPrompt.present(for: verb) else { return nil }
+        do {
+            try credentials.setCredential(
+                answer.secret,
+                for: target,
+                rememberInKeychain: answer.rememberInKeychain
+            )
+        } catch {
+            return nil
+        }
+        return credentials.takeSecretForUse(for: target)
+    }
+
     private static func perform(
         _ verb: CoordinatorVerb,
         source: LocalSource,
         noun: WorkspaceNoun?,
-        engine: BorisEngine
+        engine: BorisEngine,
+        secret: SecureBuffer?
     ) async -> JobResult {
         do {
             switch verb {
@@ -382,42 +432,10 @@ final class Coordinator {
                 )
 
             case .publishStandardSite:
-                guard let profile = source.profileURL() else {
-                    return JobResult(
-                        exit: 3,
-                        summary: "publish: no boris.json",
-                        problems: CoordinatorProblems.fromFailure(code: "standard-site", message: "no boris.json")
-                    )
-                }
-                let result = try await engine.standardSitePublish(profileURL: profile)
-                return JobResult(
-                    exit: result.exitCode,
-                    summary: "Standard.site exit \(result.exitCode)",
-                    problems: CoordinatorProblems.fromCommand(
-                        code: "standard-site",
-                        exitCode: result.exitCode,
-                        stderr: result.stderr
-                    )
-                )
+                return try await publishStandardSite(source: source, engine: engine, secret: secret)
 
             case .publishNostr:
-                guard let profile = source.profileURL() else {
-                    return JobResult(
-                        exit: 3,
-                        summary: "publish: no boris.json",
-                        problems: CoordinatorProblems.fromFailure(code: "nostr", message: "no boris.json")
-                    )
-                }
-                let result = try await engine.nostrPlan(profileURL: profile)
-                return JobResult(
-                    exit: result.exitCode,
-                    summary: "Nostr plan exit \(result.exitCode)",
-                    problems: CoordinatorProblems.fromCommand(
-                        code: "nostr",
-                        exitCode: result.exitCode,
-                        stderr: result.stderr
-                    )
-                )
+                return try await publishNostr(source: source, engine: engine, secret: secret)
             }
         } catch {
             let message = String(describing: error)
@@ -540,6 +558,159 @@ final class Coordinator {
                 )
             )
         }
+    }
+
+    private static func publishStandardSite(
+        source: LocalSource,
+        engine: BorisEngine,
+        secret: SecureBuffer?
+    ) async throws -> JobResult {
+        defer { secret?.wipe() }
+        guard let profileURL = source.profileURL() else {
+            return JobResult(
+                exit: 3,
+                summary: "publish: no boris.json",
+                problems: CoordinatorProblems.fromFailure(code: "standard-site", message: "no boris.json")
+            )
+        }
+        guard let secret else {
+            return JobResult(
+                exit: 3,
+                summary: "publish: no app password",
+                problems: CoordinatorProblems.fromFailure(
+                    code: "standard-site",
+                    message: "no app password (cancelled or empty)"
+                )
+            )
+        }
+
+        let profile = try loadProfile(from: source)
+        let identity = standardSiteIdentity(from: profile?.publication)
+        guard identity.did != nil || identity.handle != nil else {
+            return JobResult(
+                exit: 2,
+                summary: "publish: profile needs publication.did",
+                problems: CoordinatorProblems.fromFailure(
+                    code: "standard-site",
+                    message: "publication.did (or a handle) is required for login --app-password"
+                )
+            )
+        }
+
+        let login = try await engine.standardSiteLogin(
+            did: identity.did,
+            handle: identity.handle,
+            password: secret,
+            workingDirectory: profileURL.deletingLastPathComponent()
+        )
+        if login.exitCode != 0 {
+            return JobResult(
+                exit: login.exitCode,
+                summary: "Standard.site login exit \(login.exitCode)",
+                problems: CoordinatorProblems.fromCommand(
+                    code: "standard-site",
+                    exitCode: login.exitCode,
+                    stderr: login.stderr
+                )
+            )
+        }
+
+        let published = try await engine.standardSitePublish(profileURL: profileURL)
+        return JobResult(
+            exit: published.exitCode,
+            summary: "Standard.site publish exit \(published.exitCode)",
+            problems: CoordinatorProblems.fromCommand(
+                code: "standard-site",
+                exitCode: published.exitCode,
+                stderr: published.stderr
+            )
+        )
+    }
+
+    private static func publishNostr(
+        source: LocalSource,
+        engine: BorisEngine,
+        secret: SecureBuffer?
+    ) async throws -> JobResult {
+        defer { secret?.wipe() }
+        guard let profileURL = source.profileURL() else {
+            return JobResult(
+                exit: 3,
+                summary: "publish: no boris.json",
+                problems: CoordinatorProblems.fromFailure(code: "nostr", message: "no boris.json")
+            )
+        }
+        guard let secret else {
+            return JobResult(
+                exit: 3,
+                summary: "publish: no signing key",
+                problems: CoordinatorProblems.fromFailure(
+                    code: "nostr",
+                    message: "no signing key (cancelled or empty)"
+                )
+            )
+        }
+
+        let work = try source.artifactDirectory(named: "_boris")
+        try FileManager.default.createDirectory(at: work, withIntermediateDirectories: true)
+        let planURL = work.appendingPathComponent("nostr-plan.json")
+        let bundleURL = work.appendingPathComponent("nostr-bundle.json")
+        let reportURL = work.appendingPathComponent("nostr-publish.json")
+
+        let planned = try await engine.nostrPlan(profileURL: profileURL)
+        if planned.exitCode != 0 {
+            return JobResult(
+                exit: planned.exitCode,
+                summary: "Nostr plan exit \(planned.exitCode)",
+                problems: CoordinatorProblems.fromCommand(
+                    code: "nostr",
+                    exitCode: planned.exitCode,
+                    stderr: planned.stderr
+                )
+            )
+        }
+        try Data(planned.stdout.utf8).write(to: planURL, options: .atomic)
+
+        let signed = try await engine.nostrSign(
+            planURL: planURL,
+            outURL: bundleURL,
+            secret: secret,
+            workingDirectory: profileURL.deletingLastPathComponent()
+        )
+        if signed.exitCode != 0 {
+            return JobResult(
+                exit: signed.exitCode,
+                summary: "Nostr sign exit \(signed.exitCode)",
+                problems: CoordinatorProblems.fromCommand(
+                    code: "nostr",
+                    exitCode: signed.exitCode,
+                    stderr: signed.stderr
+                )
+            )
+        }
+
+        let published = try await engine.nostrPublish(bundleURL: bundleURL, reportURL: reportURL)
+        return JobResult(
+            exit: published.exitCode,
+            summary: "Nostr publish exit \(published.exitCode)",
+            problems: CoordinatorProblems.fromCommand(
+                code: "nostr",
+                exitCode: published.exitCode,
+                stderr: published.stderr
+            )
+        )
+    }
+
+    private static func standardSiteIdentity(
+        from publication: PublicationDeclaration?
+    ) -> (did: String?, handle: String?) {
+        guard let raw = publication?.did?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty
+        else { return (nil, nil) }
+        if raw.hasPrefix("did:") {
+            return (raw, nil)
+        }
+        return (nil, raw)
     }
 
     private static func loadProfile(from source: LocalSource) throws -> PublicationProfile? {

--- a/Sources/App/PublishSecretPrompt.swift
+++ b/Sources/App/PublishSecretPrompt.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Foundation
+
+/// Modal prompt for a publish secret. The field is secure; the value is
+/// copied into a `SecureBuffer` and the string is not kept.
+enum PublishSecretPrompt {
+    struct Answer {
+        var secret: SecureBuffer
+        var rememberInKeychain: Bool
+    }
+
+    @MainActor
+    static func present(for verb: CoordinatorVerb) -> Answer? {
+        switch verb {
+        case .publishNostr:
+            return present(
+                title: "Nostr Signing Key",
+                message: "Paste an nsec or 64-character hex key. It is piped to boris on stdin and never placed in argv, env, or the profile.",
+                rememberTitle: "Remember in Keychain"
+            )
+        case .publishStandardSite:
+            return present(
+                title: "Standard.site App Password",
+                message: "Piped to `boris standard-site login --app-password` on stdin. App passwords grant broad account write — use a dedicated identity.",
+                rememberTitle: "Remember in Keychain"
+            )
+        default:
+            return nil
+        }
+    }
+
+    @MainActor
+    static func present(title: String, message: String, rememberTitle: String) -> Answer? {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Continue")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        field.placeholderString = "Secret"
+        let remember = NSButton(checkboxWithTitle: rememberTitle, target: nil, action: nil)
+        remember.state = .off
+
+        let stack = NSStackView(views: [field, remember])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.frame = NSRect(x: 0, y: 0, width: 280, height: 52)
+        alert.accessoryView = stack
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return nil }
+
+        let text = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        field.stringValue = ""
+        guard !text.isEmpty else { return nil }
+        return Answer(
+            secret: SecureBuffer(utf8String: text),
+            rememberInKeychain: remember.state == .on
+        )
+    }
+}

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -660,6 +660,28 @@ public actor BorisEngine {
         return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
     }
 
+    /// Runs `boris standard-site login --app-password` with the password on stdin.
+    /// Identity is `--did` or `--handle` (never a secret).
+    public func standardSiteLogin(
+        did: String? = nil,
+        handle: String? = nil,
+        password: SecureBuffer,
+        workingDirectory: URL? = nil
+    ) throws -> BorisPublishResult {
+        var args = ["standard-site", "login", "--app-password"]
+        if let did, !did.isEmpty {
+            args += ["--did", did]
+        } else if let handle, !handle.isEmpty {
+            args += ["--handle", handle]
+        }
+        let out = try run(
+            arguments: args,
+            workingDirectory: workingDirectory,
+            stdin: password
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
     /// Runs `boris standard-site publish --profile PATH`.
     /// Preserves exit classes 4–9 (denial, timeout, compatibility, partial-publication, verification, session).
     public func standardSitePublish(profileURL: URL) throws -> BorisPublishResult {
@@ -675,6 +697,27 @@ public actor BorisEngine {
         let out = try run(
             arguments: ["nostr", "plan", "--profile", profileURL.lastPathComponent],
             workingDirectory: profileURL.deletingLastPathComponent()
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
+    /// Runs `boris nostr sign --plan PATH --key-stdin --out PATH`.
+    /// The key is written to stdin and wiped; it is never in argv or env.
+    public func nostrSign(
+        planURL: URL,
+        outURL: URL,
+        secret: SecureBuffer,
+        workingDirectory: URL? = nil
+    ) throws -> BorisPublishResult {
+        let out = try run(
+            arguments: [
+                "nostr", "sign",
+                "--plan", planURL.path,
+                "--key-stdin",
+                "--out", outURL.path,
+            ],
+            workingDirectory: workingDirectory ?? planURL.deletingLastPathComponent(),
+            stdin: secret
         )
         return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
     }
@@ -708,13 +751,15 @@ public actor BorisEngine {
 
     private func run(
         arguments: [String],
-        workingDirectory: URL? = nil
+        workingDirectory: URL? = nil,
+        stdin: SecureBuffer? = nil
     ) throws -> RunOutput {
         try BorisRunner.run(
             binary: binaryURL,
             arguments: arguments,
             workingDirectory: workingDirectory,
-            handle: runHandle
+            handle: runHandle,
+            stdin: stdin
         )
     }
 

--- a/Sources/Engine/BorisRunner.swift
+++ b/Sources/Engine/BorisRunner.swift
@@ -66,7 +66,8 @@ public enum BorisRunner {
         binary: URL,
         arguments: [String],
         workingDirectory: URL? = nil,
-        handle: RunHandle? = nil
+        handle: RunHandle? = nil,
+        stdin: SecureBuffer? = nil
     ) throws -> RunOutput {
         let fm = FileManager.default
         let tmpDir = fm.temporaryDirectory
@@ -98,12 +99,28 @@ public enum BorisRunner {
         process.standardOutput = stdoutHandle
         process.standardError = stderrHandle
 
+        let stdinPipe: Pipe?
+        if stdin != nil {
+            let pipe = Pipe()
+            process.standardInput = pipe
+            stdinPipe = pipe
+        } else {
+            process.standardInput = FileHandle.nullDevice
+            stdinPipe = nil
+        }
+
         handle?.attach(process)
         do {
             try process.run()
         } catch {
+            stdin?.wipe()
             throw BorisRunnerError.launchFailed(String(describing: error))
         }
+
+        if let stdin, let stdinPipe {
+            try StdinSecretWriter.writeAndWipe(stdin, to: stdinPipe.fileHandleForWriting)
+        }
+
         process.waitUntilExit()
 
         let stdout = (try? Data(contentsOf: stdoutURL)) ?? Data()

--- a/Sources/Play/Local/PublishPane.swift
+++ b/Sources/Play/Local/PublishPane.swift
@@ -11,6 +11,7 @@ struct PublishPane: View {
     @State private var profile: PublicationProfile?
     @State private var proofFiles: [ProofFileItem] = []
     @State private var loadError: String?
+    @State private var credentialEpoch = 0
 
     var body: some View {
         List {
@@ -47,7 +48,7 @@ struct PublishPane: View {
                         runtime.coordinator.run(.plan, store: store, runtime: runtime)
                     }
                     .controlSize(.small)
-                    .disabled(runtime.coordinator.isRunning)
+                    .disabled(!runtime.coordinator.canRunVerb)
 
                     if let target = profile?.publication?.target {
                         if target == "standard-site" {
@@ -60,7 +61,7 @@ struct PublishPane: View {
                             }
                             .buttonStyle(.borderedProminent)
                             .controlSize(.small)
-                            .disabled(runtime.coordinator.isRunning)
+                            .disabled(!runtime.coordinator.canRunVerb)
                         } else if target == "nostr" {
                             Button("Publish to Nostr…") {
                                 runtime.coordinator.run(
@@ -71,12 +72,14 @@ struct PublishPane: View {
                             }
                             .buttonStyle(.borderedProminent)
                             .controlSize(.small)
-                            .disabled(runtime.coordinator.isRunning)
+                            .disabled(!runtime.coordinator.canRunVerb)
                         }
                     }
                 }
 
-                Text("Results land in the problems list. Stop (⌘.) cancels the job.")
+                credentialRow
+
+                Text("Secrets go to boris on stdin. Results land in the problems list.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -111,8 +114,11 @@ struct PublishPane: View {
             load()
         }
         .onChange(of: runtime.coordinator.isRunning) { wasRunning, isRunning in
-            if wasRunning, !isRunning, let root = try? source.workspaceRoot() {
-                scanProofFiles(in: root)
+            if wasRunning, !isRunning {
+                credentialEpoch += 1
+                if let root = try? source.workspaceRoot() {
+                    scanProofFiles(in: root)
+                }
             }
         }
     }
@@ -137,6 +143,45 @@ struct PublishPane: View {
         }
 
         scanProofFiles(in: root)
+    }
+
+    @ViewBuilder
+    private var credentialRow: some View {
+        let target = credentialTarget
+        HStack {
+            Text("Credential")
+            Spacer()
+            Text(credentialStatus)
+                .foregroundStyle(.secondary)
+            if let target, runtime.credentials.hasSecret(for: target) {
+                Button("Forget") {
+                    try? runtime.credentials.clearCredential(for: target)
+                    credentialEpoch += 1
+                }
+                .controlSize(.small)
+            }
+        }
+        .font(.caption)
+    }
+
+    private var credentialTarget: String? {
+        switch profile?.publication?.target {
+        case "standard-site": PublishTargets.standardSite
+        case "nostr": PublishTargets.nostr
+        default: nil
+        }
+    }
+
+    private var credentialStatus: String {
+        _ = credentialEpoch
+        guard let target = credentialTarget else { return "not required" }
+        if runtime.credentials.isRemembered(for: target) {
+            return "in Keychain"
+        }
+        if runtime.credentials.hasSecret(for: target) {
+            return "this session"
+        }
+        return "not set"
     }
 
     private func scanProofFiles(in root: URL) {

--- a/Sources/Security/PublishCredentialManager.swift
+++ b/Sources/Security/PublishCredentialManager.swift
@@ -48,9 +48,22 @@ public final class PublishCredentialManager: SecretProviding, @unchecked Sendabl
         return nil
     }
 
+    /// Takes a buffer the caller may wipe after one stdin write.
+    /// Ephemeral secrets are consumed; Keychain entries are copied.
+    public func takeSecretForUse(for target: String) -> SecureBuffer? {
+        if ephemeral.hasSecret(for: target) {
+            return ephemeral.consumeSecret(for: target)
+        }
+        return try? keychain.loadSecret(account: target, service: service)
+    }
+
     /// Checks if a credential is saved in the macOS Keychain for the target.
     public func isRemembered(for target: String) -> Bool {
         keychain.hasSecret(account: target, service: service)
+    }
+
+    public func hasSecret(for target: String) -> Bool {
+        ephemeral.hasSecret(for: target) || isRemembered(for: target)
     }
 
     /// Clears any credential stored in both ephemeral memory and Keychain for the target.

--- a/Tests/ContractTests/BorisRunnerStdinTests.swift
+++ b/Tests/ContractTests/BorisRunnerStdinTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+final class BorisRunnerStdinTests: XCTestCase {
+    func testStdinIsPipedAndWipedNeverArgv() throws {
+        let payload = "nsec1testpayload-not-a-real-key"
+        let secret = SecureBuffer(utf8String: payload)
+        let output = try BorisRunner.run(
+            binary: URL(fileURLWithPath: "/bin/cat"),
+            arguments: [],
+            stdin: secret
+        )
+        XCTAssertEqual(output.exitCode, 0)
+        XCTAssertEqual(output.stdoutText, payload + "\n")
+        XCTAssertTrue(secret.isEmpty)
+        XCTAssertFalse(output.stdoutText.contains("key-stdin"))
+    }
+
+    func testNilStdinDoesNotHangCat() throws {
+        // /bin/true ignores stdin and exits 0.
+        let output = try BorisRunner.run(
+            binary: URL(fileURLWithPath: "/usr/bin/true"),
+            arguments: []
+        )
+        XCTAssertEqual(output.exitCode, 0)
+        XCTAssertTrue(output.stdout.isEmpty)
+    }
+}

--- a/Tests/ContractTests/SecurityTests.swift
+++ b/Tests/ContractTests/SecurityTests.swift
@@ -183,4 +183,28 @@ final class SecurityTests: XCTestCase {
         manager.wipeAllEphemeral()
         XCTAssertNil(manager.provideSecret(for: PublishTargets.standardSite))
     }
+
+    func testTakeSecretForUseConsumesEphemeralAndCopiesKeychain() throws {
+        let mockKeychain = MockKeychainStore()
+        let mockEphemeral = EphemeralSecretStore()
+        let manager = PublishCredentialManager(
+            keychain: mockKeychain,
+            ephemeral: mockEphemeral,
+            service: "test.service"
+        )
+
+        let session = SecureBuffer(utf8String: "ephemeral-once")
+        try manager.setCredential(session, for: PublishTargets.nostr, rememberInKeychain: false)
+        let taken = manager.takeSecretForUse(for: PublishTargets.nostr)
+        XCTAssertEqual(taken?.copyBytes(), Array("ephemeral-once".utf8))
+        XCTAssertFalse(manager.hasSecret(for: PublishTargets.nostr))
+
+        let remembered = SecureBuffer(utf8String: "keychain-copy")
+        try manager.setCredential(remembered, for: PublishTargets.standardSite, rememberInKeychain: true)
+        let copy = manager.takeSecretForUse(for: PublishTargets.standardSite)
+        XCTAssertEqual(copy?.copyBytes(), Array("keychain-copy".utf8))
+        XCTAssertTrue(manager.isRemembered(for: PublishTargets.standardSite))
+        copy?.wipe()
+        XCTAssertTrue(manager.hasSecret(for: PublishTargets.standardSite))
+    }
 }

--- a/docs/CREDENTIAL-LIFECYCLE.md
+++ b/docs/CREDENTIAL-LIFECYCLE.md
@@ -1,6 +1,8 @@
 # Publish Credential Lifecycle & Security Design Specification
 
-**Status:** Approved Design Spec (Issue #60 / Roadmap M8 Publish)  
+**Status:** Approved Design Spec (Issue #60 / Roadmap M8 Publish).
+Wired into `BorisRunner` / Coordinator (2026-08-17): publish verbs
+prompt, pipe the secret on stdin, wipe the buffer, optional Keychain.  
 **Author:** draw me an elephant / uncle-gravity  
 **Target:** macOS App Sandbox / Boris Publishing Targets  
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -34,8 +34,8 @@ Every menu verb and keyboard shortcut:
 | Build This | — | Build the selected HTML target or edition (Outputs tab). |
 | Check | — | Run static documentation intelligence and reference checks. |
 | Impact | — | Analyze ripple effects of node changes across the graph (enabled when a page is selected). |
-| Publish to Standard.site | — | Run `boris standard-site publish` for the selected source. |
-| Publish to Nostr… | — | Run `boris nostr plan` for the selected source (sign/publish is not wired yet). |
+| Publish to Standard.site | — | Prompt for an app password (stdin), `login --app-password`, then `publish`. Optional Keychain remember. |
+| Publish to Nostr… | — | Prompt for nsec/hex (stdin), then `nostr plan` → `sign --key-stdin` → `publish`. Optional Keychain remember. |
 | Stop | `⌘.` | Cancel the running job (SIGTERM, then SIGKILL after 2s). With no job, stops preview watch. Tree-writing jobs freeze watch until they finish. |
 
 ### View


### PR DESCRIPTION
## Card

other — M8 integrity (refs #60 / B3-3 wiring after #83)

## What

The Security module was a library. Publish now uses it.

- `BorisRunner` accepts a `SecureBuffer`, writes it to the child stdin, sends EOF, and wipes the buffer. Nothing in argv or env.
- **Publish to Nostr…** prompts for nsec/hex (optional Keychain remember), then `plan` → `sign --key-stdin` → `publish`.
- **Publish to Standard.site** prompts for an app password, then `login --app-password --did/--handle` (from `publication.did`) → `publish`.
- Cancel or empty prompt: no job starts. Ephemeral secrets are consumed after one use. Keychain copies stay until **Forget**.
- Publish pane shows credential status (not set / this session / in Keychain).

`help.md` matches the new verbs. A `/bin/cat` test proves the secret arrives on stdin and the buffer is empty afterward.

**Not this PR:** GitHub Pages evidence-only, browser OAuth login, `boris-package` Proof Pack.

## Gate

- [x] `SKIP_EMBED_BORIS=1 make build` locally
- [x] `make test`
- [x] `make lint`
- [ ] CI `spike` + `app` green
- [x] Did not touch `boris/` or commit `SUPPORT-NOT-FOR-GITHUB/`