### PR TITLE
fix(coordinator): save-triggered validate, hang watchdog, async one-shots (#58)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -96,6 +96,8 @@ targets:
       - path: Sources/Inspector/ThemeCatalog.swift
       - path: Sources/Play/Local/LocalPlayGraph.swift
       - path: Sources/App/CoordinatorProblems.swift
+      - path: Sources/App/CoordinatorPolicy.swift
+      - path: Sources/App/SaveValidateGate.swift
       - path: Sources/Engine/ChildProcessControl.swift
       - path: Sources/Engine/BorisRunner.swift
       - path: Sources/Companions/Editor/EditorURL.swift

--- a/Sources/App/ContentTreeWatcher.swift
+++ b/Sources/App/ContentTreeWatcher.swift
@@ -1,0 +1,50 @@
+import CoreServices
+import Foundation
+
+/// Recursive FSEvents watcher on a content root. Each coalesced change
+/// calls `handler` on an arbitrary queue — hop to the main actor before
+/// touching the coordinator.
+final class ContentTreeWatcher: @unchecked Sendable {
+    private var stream: FSEventStreamRef?
+    private let queue = DispatchQueue(label: "dev.drawmeanelephant.solipsist.content-watch")
+    var handler: (@Sendable () -> Void)?
+
+    deinit { stop() }
+
+    func start(path: String) {
+        stop()
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+        let callback: FSEventStreamCallback = { _, info, _, _, _, _ in
+            guard let info else { return }
+            Unmanaged<ContentTreeWatcher>.fromOpaque(info).takeUnretainedValue().handler?()
+        }
+        guard let created = FSEventStreamCreate(
+            nil,
+            callback,
+            &context,
+            [path] as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.05,
+            FSEventStreamCreateFlags(
+                kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagWatchRoot
+            )
+        ) else { return }
+        stream = created
+        FSEventStreamSetDispatchQueue(created, queue)
+        FSEventStreamStart(created)
+    }
+
+    func stop() {
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+        self.stream = nil
+    }
+}

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -23,6 +23,10 @@ enum CoordinatorVerb: String, Sendable {
         }
     }
 
+    var timeout: Duration {
+        writesTree ? CoordinatorPolicy.buildTimeout : CoordinatorPolicy.oneShotTimeout
+    }
+
     var secretTarget: String? {
         switch self {
         case .publishNostr: PublishTargets.nostr
@@ -30,14 +34,6 @@ enum CoordinatorVerb: String, Sendable {
         default: nil
         }
     }
-}
-
-enum CoordinatorState: String, Sendable {
-    case idle
-    case watching
-    case validating
-    case building
-    case terminating
 }
 
 /// Menu verbs against `BorisEngine`. One job at a time. Play and the
@@ -53,12 +49,29 @@ final class Coordinator {
     private(set) var problems: [ProblemItem] = []
     private var task: Task<Void, Never>?
     private var reapTask: Task<Void, Never>?
+    private var watchdogTask: Task<Void, Never>?
+    private var debounceTask: Task<Void, Never>?
     private weak var activeWatch: WatchServer?
     private var watchSuspends = 0
+    private var saveGate = SaveValidateGate()
+    @ObservationIgnored
+    private var saveWatcher = ContentTreeWatcher()
+    private var jobOrigin: JobOrigin = .manual
+    private var timedOut = false
+    private var watchingSourceID: SourceID?
+    @ObservationIgnored
+    private weak var boundStore: WorkspaceStore?
+    @ObservationIgnored
+    private weak var boundRuntime: AppRuntime?
+
+    private enum JobOrigin {
+        case manual
+        case save
+    }
 
     var canRunVerb: Bool { state == .idle || state == .watching }
 
-    var canStop: Bool { state != .idle }
+    var canStop: Bool { state != .idle && state != .terminating }
 
     func registerWatch(_ server: WatchServer) {
         if let old = activeWatch, old !== server {
@@ -101,7 +114,63 @@ final class Coordinator {
         }
     }
 
+    func syncSaveWatch(store: WorkspaceStore, runtime: AppRuntime) {
+        boundStore = store
+        boundRuntime = runtime
+        guard case .local(let source) = store.selectedSource, source.isAvailable,
+              let root = try? source.contentRoot(),
+              FileManager.default.fileExists(atPath: root.path)
+        else {
+            saveWatcher.stop()
+            watchingSourceID = nil
+            return
+        }
+        guard watchingSourceID != source.id else { return }
+        watchingSourceID = source.id
+        saveWatcher.handler = { [weak self] in
+            Task { @MainActor in
+                self?.noteSave()
+            }
+        }
+        saveWatcher.start(path: root.path)
+    }
+
+    func noteSave() {
+        if saveGate.noteSave(now: .now, state: state) == .armDebounce {
+            armDebounce()
+        }
+    }
+
+    func terminateAll(runtime: AppRuntime) {
+        saveGate.dropAll()
+        debounceTask?.cancel()
+        debounceTask = nil
+        watchdogTask?.cancel()
+        watchdogTask = nil
+        saveWatcher.stop()
+        watchingSourceID = nil
+        if state != .terminating {
+            stop(runtime: runtime)
+        }
+        runtime.engine?.forceKill()
+        activeWatch?.forceKill()
+    }
+
     func run(_ verb: CoordinatorVerb, store: WorkspaceStore, runtime: AppRuntime) {
+        start(verb, store: store, runtime: runtime, origin: .manual)
+    }
+
+    private func startSaveValidate() {
+        guard let store = boundStore, let runtime = boundRuntime else { return }
+        start(.validate, store: store, runtime: runtime, origin: .save)
+    }
+
+    private func start(
+        _ verb: CoordinatorVerb,
+        store: WorkspaceStore,
+        runtime: AppRuntime,
+        origin: JobOrigin
+    ) {
         guard canRunVerb else { return }
         guard let engine = runtime.engine else {
             let message = runtime.engineError ?? "engine not found"
@@ -137,14 +206,29 @@ final class Coordinator {
             secret = nil
         }
 
+        if origin == .manual {
+            saveGate.manualVerbStarted()
+            debounceTask?.cancel()
+            debounceTask = nil
+        }
+
         isRunning = true
         state = verb.writesTree ? .building : .validating
         self.verb = verb
+        jobOrigin = origin
+        timedOut = false
         summary = "\(verb.rawValue)…"
         exitCode = nil
         problems = []
         if verb.writesTree {
             beginTreeWrite()
+        }
+
+        watchdogTask?.cancel()
+        watchdogTask = Task { [timeout = verb.timeout] in
+            try? await Task.sleep(for: timeout)
+            guard !Task.isCancelled else { return }
+            self.handleTimeout(runtime: runtime)
         }
 
         let noun = store.selection.noun
@@ -172,17 +256,15 @@ final class Coordinator {
     func stop(runtime: AppRuntime) {
         guard state != .terminating else { return }
         reapTask?.cancel()
+        watchdogTask?.cancel()
 
         if isRunning {
             state = .terminating
-            summary = "stopping…"
+            summary = timedOut ? "timing out…" : "stopping…"
             task?.cancel()
             let engine = runtime.engine
             reapTask = Task {
-                await engine?.interrupt()
-                try? await Task.sleep(for: ChildProcessControl.reapGrace)
-                guard !Task.isCancelled else { return }
-                await engine?.forceKill()
+                await engine?.escalate()
             }
             return
         }
@@ -209,13 +291,56 @@ final class Coordinator {
         }
         reapTask?.cancel()
         reapTask = nil
+        watchdogTask?.cancel()
+        watchdogTask = nil
+
+        let origin = jobOrigin
+        let wasTimeout = timedOut
+        timedOut = false
+        jobOrigin = .manual
+
         self.verb = nil
         isRunning = false
         exitCode = exit
-        self.summary = summary
-        self.problems = problems
+        if wasTimeout {
+            self.summary = exit.map { "\(verb.rawValue) timed out · exit \($0)" }
+                ?? "\(verb.rawValue) timed out"
+            self.problems = CoordinatorProblems.fromFailure(
+                code: "timeout",
+                message: "\(verb.rawValue) exceeded its time limit"
+            )
+        } else {
+            self.summary = summary
+            self.problems = problems
+        }
         task = nil
         state = (activeWatch?.isRunning == true) ? .watching : .idle
+
+        if origin == .manual, verb == .validate, !wasTimeout {
+            saveGate.manualValidateFinished(now: .now, skip: CoordinatorPolicy.manualSkip)
+        }
+        if saveGate.jobFinished(now: .now, freshness: CoordinatorPolicy.queuedFreshness)
+            == .startValidate
+        {
+            startSaveValidate()
+        }
+    }
+
+    private func armDebounce() {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: CoordinatorPolicy.saveDebounce)
+            guard !Task.isCancelled else { return }
+            if self.saveGate.debounceFired(now: .now, state: self.state) == .startValidate {
+                self.startSaveValidate()
+            }
+        }
+    }
+
+    private func handleTimeout(runtime: AppRuntime) {
+        guard isRunning, state != .terminating else { return }
+        timedOut = true
+        stop(runtime: runtime)
     }
 
     private struct JobResult: Sendable {

--- a/Sources/App/CoordinatorPolicy.swift
+++ b/Sources/App/CoordinatorPolicy.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Coordinator states from the #58 state machine. `validating` is any
+/// non-tree-writing one-shot; `building` is any tree-writing one-shot.
+enum CoordinatorState: String, Sendable {
+    case idle
+    case watching
+    case validating
+    case building
+    case terminating
+}
+
+/// Machine-local timings (D2: app plist / UserDefaults, never `boris.json`).
+enum CoordinatorPolicy {
+    static let saveDebounceDefault: Duration = .milliseconds(300)
+    static let queuedFreshnessDefault: Duration = .seconds(2)
+    static let manualSkipDefault: Duration = .seconds(2)
+    static let oneShotTimeoutDefault: Duration = .seconds(60)
+    static let buildTimeoutDefault: Duration = .seconds(300)
+
+    private static let debounceKey = "solipsist.coordinator.saveDebounceMs"
+    private static let freshnessKey = "solipsist.coordinator.queuedFreshnessMs"
+    private static let skipKey = "solipsist.coordinator.manualSkipMs"
+    private static let oneShotKey = "solipsist.coordinator.oneShotTimeoutMs"
+    private static let buildKey = "solipsist.coordinator.buildTimeoutMs"
+
+    static var saveDebounce: Duration { milliseconds(debounceKey, default: 300) }
+    static var queuedFreshness: Duration { milliseconds(freshnessKey, default: 2_000) }
+    static var manualSkip: Duration { milliseconds(skipKey, default: 2_000) }
+    static var oneShotTimeout: Duration { milliseconds(oneShotKey, default: 60_000) }
+    static var buildTimeout: Duration { milliseconds(buildKey, default: 300_000) }
+
+    private static func milliseconds(_ key: String, default value: Int) -> Duration {
+        let stored = UserDefaults.standard.object(forKey: key) as? Int
+        return .milliseconds(stored ?? value)
+    }
+}

--- a/Sources/App/SaveValidateGate.swift
+++ b/Sources/App/SaveValidateGate.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Pure save-triggered validate policy. Timers live on the coordinator;
+/// this type only decides what happens next.
+struct SaveValidateGate: Sendable {
+    var lastSave: ContinuousClock.Instant?
+    var skipUntil: ContinuousClock.Instant?
+    var queued = false
+
+    enum Action: Equatable, Sendable {
+        case armDebounce
+        case startValidate
+        case dropPending
+        case none
+    }
+
+    mutating func noteSave(now: ContinuousClock.Instant, state: CoordinatorState) -> Action {
+        lastSave = now
+        switch state {
+        case .terminating:
+            queued = false
+            return .none
+        case .building, .validating:
+            queued = true
+            return .none
+        case .idle, .watching:
+            if let skipUntil, now < skipUntil {
+                return .none
+            }
+            queued = false
+            return .armDebounce
+        }
+    }
+
+    mutating func debounceFired(now: ContinuousClock.Instant, state: CoordinatorState) -> Action {
+        switch state {
+        case .terminating:
+            queued = false
+            return .dropPending
+        case .building, .validating:
+            queued = true
+            return .none
+        case .idle, .watching:
+            if let skipUntil, now < skipUntil {
+                return .none
+            }
+            queued = false
+            return .startValidate
+        }
+    }
+
+    mutating func manualVerbStarted() {
+        queued = false
+    }
+
+    mutating func manualValidateFinished(now: ContinuousClock.Instant, skip: Duration) {
+        skipUntil = now.advanced(by: skip)
+    }
+
+    mutating func jobFinished(
+        now: ContinuousClock.Instant,
+        freshness: Duration
+    ) -> Action {
+        guard queued else { return .none }
+        guard let lastSave, now - lastSave <= freshness else {
+            queued = false
+            return .dropPending
+        }
+        if let skipUntil, now < skipUntil {
+            queued = false
+            return .none
+        }
+        queued = false
+        return .startValidate
+    }
+
+    mutating func dropAll() {
+        queued = false
+        lastSave = nil
+        skipUntil = nil
+    }
+}

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @main
@@ -11,6 +12,11 @@ struct SolipsistApp: App {
             MainWindow(inspectorPresented: $inspectorPresented)
                 .environment(store)
                 .environment(runtime)
+                .onReceive(NotificationCenter.default.publisher(
+                    for: NSApplication.willTerminateNotification
+                )) { _ in
+                    runtime.coordinator.terminateAll(runtime: runtime)
+                }
         }
         .defaultSize(width: 1100, height: 700)
         .commands {

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -66,6 +66,12 @@ struct MainWindow: View {
                 .disabled(store.selectedSource == nil)
             }
         }
+        .onAppear {
+            runtime.coordinator.syncSaveWatch(store: store, runtime: runtime)
+        }
+        .onChange(of: store.selection.sourceID) {
+            runtime.coordinator.syncSaveWatch(store: store, runtime: runtime)
+        }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             statusBar
         }

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -138,7 +138,7 @@ public actor BorisEngine {
         contentRoot: URL,
         outDir: URL,
         timings: Bool = false
-    ) throws -> BorisBuild {
+    ) async throws -> BorisBuild {
         try FileManager.default.createDirectory(
             at: outDir, withIntermediateDirectories: true
         )
@@ -150,7 +150,7 @@ public actor BorisEngine {
         if timings {
             arguments.append("--timings")
         }
-        let out = try run(
+        let out = try await run(
             arguments: arguments,
             workingDirectory: outDir.deletingLastPathComponent()
         )
@@ -205,7 +205,7 @@ public actor BorisEngine {
         contentRoot: URL,
         htmlDir: URL,
         reportURL: URL? = nil
-    ) throws -> BorisHTMLBuild {
+    ) async throws -> BorisHTMLBuild {
         try FileManager.default.createDirectory(
             at: htmlDir, withIntermediateDirectories: true
         )
@@ -217,7 +217,7 @@ public actor BorisEngine {
         if let reportURL {
             arguments += ["--report", reportURL.path]
         }
-        let out = try run(
+        let out = try await run(
             arguments: arguments,
             workingDirectory: htmlDir.deletingLastPathComponent()
         )
@@ -239,7 +239,7 @@ public actor BorisEngine {
         siteURL: String? = nil,
         workingDirectory: URL? = nil,
         timings: Bool = false
-    ) throws -> BorisEntryBuildResult {
+    ) async throws -> BorisEntryBuildResult {
         let cwd = workingDirectory ?? contentRoot.deletingLastPathComponent()
         let fm = FileManager.default
         let reportURL = fm.temporaryDirectory
@@ -279,7 +279,7 @@ public actor BorisEngine {
             args.append("--timings")
         }
 
-        let out = try run(arguments: args, workingDirectory: cwd)
+        let out = try await run(arguments: args, workingDirectory: cwd)
         var report: HTMLBuildReport?
         if FileManager.default.fileExists(atPath: reportURL.path),
            let reportData = try? Data(contentsOf: reportURL)
@@ -309,7 +309,7 @@ public actor BorisEngine {
         isComplete: Bool = false,
         workingDirectory: URL? = nil,
         timings: Bool = false
-    ) throws -> BorisEntryBuildResult {
+    ) async throws -> BorisEntryBuildResult {
         let cwd = workingDirectory ?? contentRoot.deletingLastPathComponent()
         var args = ["--input", contentRoot.path, "--quiet"]
         switch kind {
@@ -343,7 +343,7 @@ public actor BorisEngine {
             args.append("--timings")
         }
 
-        let out = try run(arguments: args, workingDirectory: cwd)
+        let out = try await run(arguments: args, workingDirectory: cwd)
         let timingsReport = timings ? decodeJSON(TimingsReport.self, from: out.stdout) : nil
 
         return BorisEntryBuildResult(
@@ -365,14 +365,14 @@ public actor BorisEngine {
         profile: PublicationProfile,
         workingDirectory: URL? = nil,
         timings: Bool = true
-    ) throws -> BorisFanoutResult {
+    ) async throws -> BorisFanoutResult {
         let cwd = workingDirectory ?? contentRoot.deletingLastPathComponent()
         var results: [BorisEntryBuildResult] = []
 
         // 1. Targets in profile order
         if let targets = profile.targets, !targets.isEmpty {
             for target in targets {
-                let res = try buildTarget(
+                let res = try await buildTarget(
                     contentRoot: contentRoot,
                     target: target,
                     siteURL: profile.site?.url,
@@ -389,7 +389,7 @@ public actor BorisEngine {
                 }
             }
         } else {
-            let res = try buildTarget(
+            let res = try await buildTarget(
                 contentRoot: contentRoot,
                 target: PublicationTarget(name: "default", output: "dist"),
                 siteURL: profile.site?.url,
@@ -409,7 +409,7 @@ public actor BorisEngine {
         // 2. Editions in profile order
         if let editions = profile.editions {
             if let ir = editions.ir {
-                let res = try buildEdition(
+                let res = try await buildEdition(
                     contentRoot: contentRoot,
                     kind: "ir",
                     outputDir: ir.output,
@@ -426,7 +426,7 @@ public actor BorisEngine {
                 }
             }
             if let rag = editions.rag {
-                let res = try buildEdition(
+                let res = try await buildEdition(
                     contentRoot: contentRoot,
                     kind: "rag",
                     outputDir: rag.output,
@@ -445,7 +445,7 @@ public actor BorisEngine {
                 }
             }
             if let context = editions.context {
-                let res = try buildEdition(
+                let res = try await buildEdition(
                     contentRoot: contentRoot,
                     kind: "context",
                     outputDir: context.output,
@@ -476,13 +476,18 @@ public actor BorisEngine {
     /// SIGTERM the in-flight process, if any. One-shot builds die; watch
     /// exits 0. The app treats `terminationReason == .uncaughtSignal` as
     /// cancel when we inspect it; here we surface the resulting exit.
-    public func interrupt() {
+    public nonisolated func interrupt() {
         runHandle.terminate()
     }
 
     /// SIGKILL the in-flight one-shot if SIGTERM was ignored.
-    public func forceKill() {
+    public nonisolated func forceKill() {
         runHandle.forceKill()
+    }
+
+    /// SIGTERM, wait, SIGKILL. Yields so Stop stays responsive.
+    public nonisolated func escalate(grace: Duration = ChildProcessControl.reapGrace) async {
+        await runHandle.escalate(grace: grace)
     }
 
     // MARK: Preview (M4)
@@ -540,12 +545,12 @@ public actor BorisEngine {
     /// `--report PATH` to write the rendered JSON to a file instead. On
     /// afterparty, `check` exits 0 with findings by default and only exits 1
     /// with `--fail-on-unreferenced` — either way the report decodes fine.
-    public func check(contentRoot: URL, workingDirectory: URL? = nil) throws -> BorisAnalysis {
+    public func check(contentRoot: URL, workingDirectory: URL? = nil) async throws -> BorisAnalysis {
         let fm = FileManager.default
         let reportURL = fm.temporaryDirectory
             .appendingPathComponent("boris-check-\(UUID().uuidString).json")
         defer { try? fm.removeItem(at: reportURL) }
-        let out = try run(
+        let out = try await run(
             arguments: [
                 "check",
                 "--input", contentRoot.path,
@@ -561,12 +566,12 @@ public actor BorisEngine {
 
     /// Runs `boris impact <pageID> --format json --report <file>` and decodes
     /// the report.
-    public func impact(contentRoot: URL, pageID: String, workingDirectory: URL? = nil) throws -> BorisAnalysis {
+    public func impact(contentRoot: URL, pageID: String, workingDirectory: URL? = nil) async throws -> BorisAnalysis {
         let fm = FileManager.default
         let reportURL = fm.temporaryDirectory
             .appendingPathComponent("boris-impact-\(UUID().uuidString).json")
         defer { try? fm.removeItem(at: reportURL) }
-        let out = try run(
+        let out = try await run(
             arguments: [
                 "impact", pageID,
                 "--input", contentRoot.path,
@@ -583,16 +588,16 @@ public actor BorisEngine {
     // MARK: Version / plan / validate / init
 
     /// Runs `boris --version` and returns the stdout line (e.g. `boris/0.8.1`).
-    public func version() throws -> BorisVersion {
-        let out = try run(arguments: ["--version"])
+    public func version() async throws -> BorisVersion {
+        let out = try await run(arguments: ["--version"])
         let line = out.stdoutText.trimmingCharacters(in: .whitespacesAndNewlines)
         return BorisVersion(exitCode: out.exitCode, line: line)
     }
 
     /// Runs `boris plan --profile PATH` with cwd = the profile's parent
     /// (the publication workspace). Does not invent a profile.
-    public func plan(profileURL: URL) throws -> BorisPlan {
-        let out = try run(
+    public func plan(profileURL: URL) async throws -> BorisPlan {
+        let out = try await run(
             arguments: ["plan", "--profile", profileURL.lastPathComponent],
             workingDirectory: profileURL.deletingLastPathComponent()
         )
@@ -610,8 +615,8 @@ public actor BorisEngine {
         contentRoot: URL,
         reportURL: URL,
         workingDirectory: URL? = nil
-    ) throws -> BorisValidate {
-        let out = try run(
+    ) async throws -> BorisValidate {
+        let out = try await run(
             arguments: [
                 "validate",
                 "--input", contentRoot.path,
@@ -635,16 +640,16 @@ public actor BorisEngine {
     }
 
     /// Runs `boris init` in `directory`.
-    public func initProject(in directory: URL) throws -> BorisInit {
-        let out = try run(arguments: ["init"], workingDirectory: directory)
+    public func initProject(in directory: URL) async throws -> BorisInit {
+        let out = try await run(arguments: ["init"], workingDirectory: directory)
         return BorisInit(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
     }
 
     // MARK: Publication (M8)
 
     /// Runs `boris standard-site plan --profile PATH`.
-    public func standardSitePlan(profileURL: URL) throws -> BorisPublishResult {
-        let out = try run(
+    public func standardSitePlan(profileURL: URL) async throws -> BorisPublishResult {
+        let out = try await run(
             arguments: ["standard-site", "plan", "--profile", profileURL.lastPathComponent],
             workingDirectory: profileURL.deletingLastPathComponent()
         )
@@ -652,8 +657,8 @@ public actor BorisEngine {
     }
 
     /// Runs `boris standard-site records --profile PATH`.
-    public func standardSiteRecords(profileURL: URL) throws -> BorisPublishResult {
-        let out = try run(
+    public func standardSiteRecords(profileURL: URL) async throws -> BorisPublishResult {
+        let out = try await run(
             arguments: ["standard-site", "records", "--profile", profileURL.lastPathComponent],
             workingDirectory: profileURL.deletingLastPathComponent()
         )
@@ -667,14 +672,14 @@ public actor BorisEngine {
         handle: String? = nil,
         password: SecureBuffer,
         workingDirectory: URL? = nil
-    ) throws -> BorisPublishResult {
+    ) async throws -> BorisPublishResult {
         var args = ["standard-site", "login", "--app-password"]
         if let did, !did.isEmpty {
             args += ["--did", did]
         } else if let handle, !handle.isEmpty {
             args += ["--handle", handle]
         }
-        let out = try run(
+        let out = try await run(
             arguments: args,
             workingDirectory: workingDirectory,
             stdin: password
@@ -684,8 +689,8 @@ public actor BorisEngine {
 
     /// Runs `boris standard-site publish --profile PATH`.
     /// Preserves exit classes 4–9 (denial, timeout, compatibility, partial-publication, verification, session).
-    public func standardSitePublish(profileURL: URL) throws -> BorisPublishResult {
-        let out = try run(
+    public func standardSitePublish(profileURL: URL) async throws -> BorisPublishResult {
+        let out = try await run(
             arguments: ["standard-site", "publish", "--profile", profileURL.lastPathComponent],
             workingDirectory: profileURL.deletingLastPathComponent()
         )
@@ -693,8 +698,8 @@ public actor BorisEngine {
     }
 
     /// Runs `boris nostr plan --profile PATH`.
-    public func nostrPlan(profileURL: URL) throws -> BorisPublishResult {
-        let out = try run(
+    public func nostrPlan(profileURL: URL) async throws -> BorisPublishResult {
+        let out = try await run(
             arguments: ["nostr", "plan", "--profile", profileURL.lastPathComponent],
             workingDirectory: profileURL.deletingLastPathComponent()
         )
@@ -708,8 +713,8 @@ public actor BorisEngine {
         outURL: URL,
         secret: SecureBuffer,
         workingDirectory: URL? = nil
-    ) throws -> BorisPublishResult {
-        let out = try run(
+    ) async throws -> BorisPublishResult {
+        let out = try await run(
             arguments: [
                 "nostr", "sign",
                 "--plan", planURL.path,
@@ -723,12 +728,12 @@ public actor BorisEngine {
     }
 
     /// Runs `boris nostr publish --bundle PATH --out PATH`.
-    public func nostrPublish(bundleURL: URL, reportURL: URL? = nil) throws -> BorisPublishResult {
+    public func nostrPublish(bundleURL: URL, reportURL: URL? = nil) async throws -> BorisPublishResult {
         var args = ["nostr", "publish", "--bundle", bundleURL.path]
         if let reportURL {
             args.append(contentsOf: ["--out", reportURL.path])
         }
-        let out = try run(
+        let out = try await run(
             arguments: args,
             workingDirectory: bundleURL.deletingLastPathComponent()
         )
@@ -738,8 +743,8 @@ public actor BorisEngine {
     // MARK: Probe
 
     /// Sanity probe: runs `boris --help` and returns the first lines.
-    public func probe() throws -> String {
-        let out = try run(arguments: ["--help"])
+    public func probe() async throws -> String {
+        let out = try await run(arguments: ["--help"])
         let head = out.stdoutText
             .split(separator: "\n")
             .prefix(3)
@@ -753,8 +758,8 @@ public actor BorisEngine {
         arguments: [String],
         workingDirectory: URL? = nil,
         stdin: SecureBuffer? = nil
-    ) throws -> RunOutput {
-        try BorisRunner.run(
+    ) async throws -> RunOutput {
+        try await BorisRunner.run(
             binary: binaryURL,
             arguments: arguments,
             workingDirectory: workingDirectory,

--- a/Sources/Engine/BorisRunner.swift
+++ b/Sources/Engine/BorisRunner.swift
@@ -23,12 +23,6 @@ public enum BorisRunnerError: Error, Sendable, CustomStringConvertible {
     }
 }
 
-/// Runs the `boris` binary as a subprocess and captures its output.
-///
-/// stdout/stderr are redirected to temp files rather than pipes: regular
-/// files cannot deadlock (OS pipe buffers cap at ~64 KB and Boris JSON
-/// reports can exceed that) and need no concurrent reader threads. The
-/// child inherits the file descriptors; after exit we read the files back.
 /// Lets the engine interrupt an in-flight `Process` (Stop). Additive —
 /// capture/wait behavior is unchanged.
 public final class RunHandle: @unchecked Sendable {
@@ -41,6 +35,21 @@ public final class RunHandle: @unchecked Sendable {
         lock.lock()
         self.process = process
         lock.unlock()
+    }
+
+    public var isRunning: Bool {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        return process?.isRunning == true
+    }
+
+    public var processIdentifier: Int32? {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        guard let process, process.isRunning else { return nil }
+        return process.processIdentifier
     }
 
     public func terminate() {
@@ -58,17 +67,29 @@ public final class RunHandle: @unchecked Sendable {
         guard let process, process.isRunning else { return }
         ChildProcessControl.forceKill(pid: process.processIdentifier)
     }
+
+    /// SIGTERM, wait `grace`, then SIGKILL if the child is still up.
+    public func escalate(grace: Duration = ChildProcessControl.reapGrace) async {
+        terminate()
+        try? await Task.sleep(for: grace)
+        if isRunning {
+            forceKill()
+        }
+    }
 }
 
 public enum BorisRunner {
 
+    /// Launch and wait off the caller's executor. Completion uses
+    /// `terminationHandler` so an actor can still `interrupt()` / `forceKill()`
+    /// a wedged child.
     public static func run(
         binary: URL,
         arguments: [String],
         workingDirectory: URL? = nil,
         handle: RunHandle? = nil,
         stdin: SecureBuffer? = nil
-    ) throws -> RunOutput {
+    ) async throws -> RunOutput {
         let fm = FileManager.default
         let tmpDir = fm.temporaryDirectory
             .appendingPathComponent("boris-run-\(UUID().uuidString)")
@@ -84,10 +105,6 @@ public enum BorisRunner {
             let stderrHandle = FileHandle(forWritingAtPath: stderrURL.path)
         else {
             throw BorisRunnerError.launchFailed("could not create capture files")
-        }
-        defer {
-            stdoutHandle.closeFile()
-            stderrHandle.closeFile()
         }
 
         let process = Process()
@@ -110,21 +127,54 @@ public enum BorisRunner {
         }
 
         handle?.attach(process)
-        do {
-            try process.run()
-        } catch {
-            stdin?.wipe()
-            throw BorisRunnerError.launchFailed(String(describing: error))
+        defer {
+            stdoutHandle.closeFile()
+            stderrHandle.closeFile()
         }
 
-        if let stdin, let stdinPipe {
-            try StdinSecretWriter.writeAndWipe(stdin, to: stdinPipe.fileHandleForWriting)
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let box = OnceResume()
+            process.terminationHandler = { _ in
+                box.resume {
+                    cont.resume()
+                }
+            }
+            do {
+                try process.run()
+            } catch {
+                box.resume {
+                    cont.resume(throwing: BorisRunnerError.launchFailed(String(describing: error)))
+                }
+                return
+            }
+            if let stdin, let stdinPipe {
+                do {
+                    try StdinSecretWriter.writeAndWipe(stdin, to: stdinPipe.fileHandleForWriting)
+                } catch {
+                    process.terminate()
+                    box.resume {
+                        cont.resume(throwing: error)
+                    }
+                }
+            }
         }
-
-        process.waitUntilExit()
 
         let stdout = (try? Data(contentsOf: stdoutURL)) ?? Data()
         let stderr = (try? Data(contentsOf: stderrURL)) ?? Data()
         return RunOutput(stdout: stdout, stderr: stderr, exitCode: process.terminationStatus)
+    }
+}
+
+/// `terminationHandler` and launch-failure can race; resume once.
+private final class OnceResume: @unchecked Sendable {
+    private let lock = NSLock()
+    private var done = false
+
+    func resume(_ body: () -> Void) {
+        lock.lock()
+        let first = !done
+        done = true
+        lock.unlock()
+        if first { body() }
     }
 }

--- a/Tests/ContractTests/BorisRunnerAsyncTests.swift
+++ b/Tests/ContractTests/BorisRunnerAsyncTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+final class BorisRunnerAsyncTests: XCTestCase {
+    func testInterruptUnblocksSleep() async throws {
+        let handle = RunHandle()
+        let started = ContinuousClock.now
+        async let output = BorisRunner.run(
+            binary: URL(fileURLWithPath: "/bin/sleep"),
+            arguments: ["30"],
+            handle: handle
+        )
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertTrue(handle.isRunning)
+        handle.terminate()
+        let result = try await output
+        let elapsed = ContinuousClock.now - started
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertLessThan(elapsed, .seconds(3))
+        XCTAssertFalse(handle.isRunning)
+    }
+
+    func testEscalateKillsProcessThatIgnoresSIGTERM() async throws {
+        let handle = RunHandle()
+        let started = ContinuousClock.now
+        async let output = BorisRunner.run(
+            binary: URL(fileURLWithPath: "/bin/bash"),
+            arguments: ["-c", "trap '' TERM; exec sleep 30"],
+            handle: handle
+        )
+        try await Task.sleep(for: .milliseconds(200))
+        XCTAssertTrue(handle.isRunning)
+        await handle.escalate(grace: .milliseconds(80))
+        let result = try await output
+        let elapsed = ContinuousClock.now - started
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertLessThan(elapsed, .seconds(3))
+        XCTAssertFalse(handle.isRunning)
+    }
+
+    func testTrueStillExitsZero() async throws {
+        let output = try await BorisRunner.run(
+            binary: URL(fileURLWithPath: "/usr/bin/true"),
+            arguments: []
+        )
+        XCTAssertEqual(output.exitCode, 0)
+        XCTAssertTrue(output.stdout.isEmpty)
+    }
+}

--- a/Tests/ContractTests/BorisRunnerStdinTests.swift
+++ b/Tests/ContractTests/BorisRunnerStdinTests.swift
@@ -1,10 +1,10 @@
 import XCTest
 
 final class BorisRunnerStdinTests: XCTestCase {
-    func testStdinIsPipedAndWipedNeverArgv() throws {
+    func testStdinIsPipedAndWipedNeverArgv() async throws {
         let payload = "nsec1testpayload-not-a-real-key"
         let secret = SecureBuffer(utf8String: payload)
-        let output = try BorisRunner.run(
+        let output = try await BorisRunner.run(
             binary: URL(fileURLWithPath: "/bin/cat"),
             arguments: [],
             stdin: secret
@@ -15,9 +15,9 @@ final class BorisRunnerStdinTests: XCTestCase {
         XCTAssertFalse(output.stdoutText.contains("key-stdin"))
     }
 
-    func testNilStdinDoesNotHangCat() throws {
+    func testNilStdinDoesNotHangCat() async throws {
         // /bin/true ignores stdin and exits 0.
-        let output = try BorisRunner.run(
+        let output = try await BorisRunner.run(
             binary: URL(fileURLWithPath: "/usr/bin/true"),
             arguments: []
         )

--- a/Tests/ContractTests/SaveValidateGateTests.swift
+++ b/Tests/ContractTests/SaveValidateGateTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+
+final class SaveValidateGateTests: XCTestCase {
+    func testSaveStormArmsDebounceEachTimeThenStartsOnce() {
+        var gate = SaveValidateGate()
+        let start = ContinuousClock.now
+
+        XCTAssertEqual(gate.noteSave(now: start, state: .idle), .armDebounce)
+        XCTAssertEqual(
+            gate.noteSave(now: start.advanced(by: .milliseconds(80)), state: .idle),
+            .armDebounce
+        )
+        XCTAssertEqual(
+            gate.noteSave(now: start.advanced(by: .milliseconds(160)), state: .idle),
+            .armDebounce
+        )
+        XCTAssertEqual(
+            gate.debounceFired(now: start.advanced(by: .milliseconds(460)), state: .idle),
+            .startValidate
+        )
+        XCTAssertFalse(gate.queued)
+    }
+
+    func testSaveDuringBuildQueuesAndStartsIfFresh() {
+        var gate = SaveValidateGate()
+        let start = ContinuousClock.now
+
+        XCTAssertEqual(gate.noteSave(now: start, state: .building), .none)
+        XCTAssertTrue(gate.queued)
+        XCTAssertEqual(
+            gate.jobFinished(now: start.advanced(by: .milliseconds(400)), freshness: .seconds(2)),
+            .startValidate
+        )
+    }
+
+    func testQueuedSaveDropsWhenStale() {
+        var gate = SaveValidateGate()
+        let start = ContinuousClock.now
+
+        XCTAssertEqual(gate.noteSave(now: start, state: .validating), .none)
+        XCTAssertEqual(
+            gate.jobFinished(now: start.advanced(by: .seconds(3)), freshness: .seconds(2)),
+            .dropPending
+        )
+        XCTAssertFalse(gate.queued)
+    }
+
+    func testManualVerbCancelsPendingQueue() {
+        var gate = SaveValidateGate()
+        let start = ContinuousClock.now
+        _ = gate.noteSave(now: start, state: .building)
+        XCTAssertTrue(gate.queued)
+        gate.manualVerbStarted()
+        XCTAssertFalse(gate.queued)
+        XCTAssertEqual(
+            gate.jobFinished(now: start.advanced(by: .milliseconds(10)), freshness: .seconds(2)),
+            .none
+        )
+    }
+
+    func testManualValidateSkipWindowSuppressesSaves() {
+        var gate = SaveValidateGate()
+        let start = ContinuousClock.now
+        gate.manualValidateFinished(now: start, skip: .seconds(2))
+        XCTAssertEqual(
+            gate.noteSave(now: start.advanced(by: .milliseconds(200)), state: .idle),
+            .none
+        )
+        XCTAssertEqual(
+            gate.noteSave(now: start.advanced(by: .seconds(3)), state: .watching),
+            .armDebounce
+        )
+    }
+
+    func testTerminatingDropsSaves() {
+        var gate = SaveValidateGate()
+        let start = ContinuousClock.now
+        XCTAssertEqual(gate.noteSave(now: start, state: .terminating), .none)
+        XCTAssertFalse(gate.queued)
+        XCTAssertEqual(gate.debounceFired(now: start, state: .terminating), .dropPending)
+    }
+
+    func testDebounceDuringJobQueues() {
+        var gate = SaveValidateGate()
+        let start = ContinuousClock.now
+        XCTAssertEqual(gate.debounceFired(now: start, state: .building), .none)
+        XCTAssertTrue(gate.queued)
+    }
+
+    func testPolicyDefaults() {
+        XCTAssertEqual(CoordinatorPolicy.saveDebounceDefault, .milliseconds(300))
+        XCTAssertEqual(CoordinatorPolicy.oneShotTimeoutDefault, .seconds(60))
+        XCTAssertEqual(CoordinatorPolicy.buildTimeoutDefault, .seconds(300))
+        XCTAssertEqual(CoordinatorPolicy.queuedFreshnessDefault, .seconds(2))
+        XCTAssertEqual(CoordinatorPolicy.manualSkipDefault, .seconds(2))
+    }
+
+    func testStateTransitionsStayCanonical() {
+        let states: [CoordinatorState] = [
+            .idle, .watching, .validating, .building, .terminating,
+        ]
+        XCTAssertEqual(states.map(\.rawValue), [
+            "idle", "watching", "validating", "building", "terminating",
+        ])
+    }
+}

--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -13,15 +13,15 @@ watch"* (ROADMAP §7).
 
 | Piece | Current behavior |
 |-------|------------------|
-| `BorisEngine` (actor) | One `RunHandle` = one `Process?` slot for one-shots. `run()` is **synchronous** (`waitUntilExit`) — serialized by the actor, so one-shot jobs never overlap. `interrupt()` = SIGTERM; `forceKill()` = SIGKILL. |
-| `BorisRunner.run` | stdout/stderr → temp files (no pipe deadlock). `RunHandle.terminate()` = SIGTERM; `forceKill()` = SIGKILL. |
+| `BorisEngine` (actor) | One `RunHandle` = one `Process?` slot for one-shots. `run()` is **async** (`terminationHandler` + continuation) so `interrupt()` / `forceKill()` / `escalate()` stay responsive on a wedged child. One-shots never overlap (actor + one handle). `interrupt()` = SIGTERM; `forceKill()` = SIGKILL. |
+| `BorisRunner.run` | stdout/stderr → temp files (no pipe deadlock). Async wait. `RunHandle.terminate()` = SIGTERM; `forceKill()` = SIGKILL; `escalate()` = SIGTERM → grace → SIGKILL. |
 | `ChildProcessControl` | Shared SIGSTOP / SIGCONT / SIGKILL primitive. |
-| `Coordinator` (MainActor) | `state` (`idle` / `watching` / `validating` / `building` / `terminating`) plus `isRunning` / `verb` / `summary` / `exitCode` / `problems`. Weak watch registry. Tree-writing verbs (`buildIR` / `buildHTML` / `buildThis` / `buildAll` / `publishStandardSite`) SIGSTOP watch, resume on finish. Stop: SIGTERM then SIGKILL after 2s; with no job, Stop tears down preview watch. |
+| `Coordinator` (MainActor) | `state` (`idle` / `watching` / `validating` / `building` / `terminating`) plus `isRunning` / `verb` / `summary` / `exitCode` / `problems`. Weak watch registry. Tree-writing verbs SIGSTOP watch, resume on finish. Stop / hang watchdog: SIGTERM then SIGKILL after 2s. Save-triggered validate: FSEvents on the selected content root, 300 ms debounce, coalescing, skip window. `terminateAll()` on quit. |
 | `WatchServer` | Long-lived `boris watch --serve`. `suspend()` / `resume()` / `forceKill()`. `stop()` continues a frozen child before SIGTERM. |
 | `PreviewSession` | Owns the `WatchServer`; registers/unregisters with the coordinator on start/stop/exit/timeout. |
 
-**Still open:** save-triggered validate + debounce, job hang watchdog
-(timeouts in §5), moving `waitUntilExit` off the engine actor.
+**Landed (this card):** save-triggered validate + debounce, job hang
+watchdog (timeouts in §5), `waitUntilExit` moved off the engine actor.
 
 ## 2. Canonical states
 
@@ -108,10 +108,8 @@ never blocked on watch.
 
 ## 4. Save-triggered validate (debounce)
 
-Greenfield — no file watcher exists today. Add a per-selected-source
-tree watcher (FSEvents or `DispatchSourceFileSystemObject` on the
-content root) owned by the coordinator; every change →
-`coordinator.noteSave()`.
+A per-selected-source FSEvents watcher on the content root is owned
+by the coordinator; every change → `coordinator.noteSave()`.
 
 - **Debounce:** 300 ms from the *last* save before a validate may
   start (rapid typing coalesces into one run). Constant


### PR DESCRIPTION
Closes the remaining #58 implementation hole after #83 (watch pause/resume) and #69 (design).

## What landed

1. **Async one-shots.** `BorisRunner.run` waits on `terminationHandler`, not `waitUntilExit`. The engine actor stays free so Stop can `interrupt()` / `forceKill()` a wedged child. `RunHandle.escalate()` is SIGTERM → 2s → SIGKILL.
2. **Hang watchdog.** 60s for plan/validate/check/impact; 300s for tree-writing jobs. Timeouts surface in the status line and problems list (never swallowed). Machine-local via UserDefaults (D2).
3. **Save-triggered validate.** FSEvents on the selected content root → 300ms debounce, one coalesced run per burst. Queued behind a manual job if the save is still fresh (≤2s). Manual verbs cancel a pending save-validate. 2s skip window after a manual validate. Dropped in `terminating`. Quit calls `terminateAll()`.

## Tests

- Debounce coalescing, queue/freshness, skip window, terminating drop (`SaveValidateGateTests`)
- Interrupt unblocks `/bin/sleep`; escalate kills a child that ignores SIGTERM (`BorisRunnerAsyncTests`)

`SKIP_EMBED_BORIS=1 make build` + `make test` (72) + `make lint` green.

Closes #58.