### PR TITLE
feat(workspace): persist bookmarks, relocate stale sources, Open Recent (#59)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -98,6 +98,9 @@ targets:
       - path: Sources/App/CoordinatorProblems.swift
       - path: Sources/App/CoordinatorPolicy.swift
       - path: Sources/App/SaveValidateGate.swift
+      - path: Sources/Workspace/Source.swift
+      - path: Sources/Workspace/WorkspacePersistence.swift
+      - path: Sources/Workspace/Local/LocalSource.swift
       - path: Sources/Engine/ChildProcessControl.swift
       - path: Sources/Engine/BorisRunner.swift
       - path: Sources/Companions/Editor/EditorURL.swift

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -19,6 +19,30 @@ struct SolipsistCommands: Commands {
             }
             .keyboardShortcut("o", modifiers: .command)
 
+            Menu("Open Recent") {
+                if store.recentFolderURLs.isEmpty {
+                    Button("No Recent Folders") {}
+                        .disabled(true)
+                } else {
+                    ForEach(store.recentFolderURLs, id: \.path) { url in
+                        Button(recentTitle(url)) {
+                            store.addLocal(url: url)
+                        }
+                    }
+                    Divider()
+                    Button("Clear Menu") {
+                        store.clearRecentFolders()
+                    }
+                }
+            }
+
+            Button("Relocate Source…") {
+                if let id = store.selection.sourceID {
+                    store.presentRelocatePanel(for: id)
+                }
+            }
+            .disabled(store.selectedSource?.isAvailable != false)
+
             Button("Remove Source") {
                 if let id = store.selection.sourceID {
                     store.remove(id)
@@ -121,6 +145,12 @@ struct SolipsistCommands: Commands {
             }
             .keyboardShortcut("?", modifiers: .command)
         }
+    }
+
+    private func recentTitle(_ url: URL) -> String {
+        let name = url.lastPathComponent
+        let parent = url.deletingLastPathComponent().path
+        return parent.isEmpty ? name : "\(name) — \(parent)"
     }
 
     private var hasSource: Bool { store.selectedSource != nil }

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -1,8 +1,42 @@
 import AppKit
 import SwiftUI
 
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var pending: [URL] = []
+    var openFolder: (@Sendable (URL) -> Void)? {
+        didSet {
+            guard let openFolder else { return }
+            pending.forEach(openFolder)
+            pending.removeAll()
+        }
+    }
+
+    func application(_ sender: NSApplication, openFile filename: String) -> Bool {
+        deliver(URL(fileURLWithPath: filename))
+        return true
+    }
+
+    func application(_ sender: NSApplication, openFiles filenames: [String]) {
+        filenames.forEach { deliver(URL(fileURLWithPath: $0)) }
+        sender.reply(toOpenOrPrint: .success)
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        urls.forEach(deliver)
+    }
+
+    private func deliver(_ url: URL) {
+        if let openFolder {
+            openFolder(url)
+        } else {
+            pending.append(url)
+        }
+    }
+}
+
 @main
 struct SolipsistApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var store = WorkspaceStore()
     @State private var runtime = AppRuntime()
     @State private var inspectorPresented = true
@@ -12,6 +46,14 @@ struct SolipsistApp: App {
             MainWindow(inspectorPresented: $inspectorPresented)
                 .environment(store)
                 .environment(runtime)
+                .onAppear {
+                    appDelegate.openFolder = { url in
+                        Task { @MainActor in
+                            store.openFromSystem(url)
+                        }
+                    }
+                    store.refreshRecentFolders()
+                }
                 .onReceive(NotificationCenter.default.publisher(
                     for: NSApplication.willTerminateNotification
                 )) { _ in

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -12,6 +12,11 @@ struct SourceSidebar: View {
                     SourceRow(item: item)
                         .tag(item.id)
                         .contextMenu {
+                            if !item.isAvailable {
+                                Button("Relocate…") {
+                                    store.presentRelocatePanel(for: item.id)
+                                }
+                            }
                             Button("Remove from Sidebar", role: .destructive) {
                                 store.remove(item.id)
                             }
@@ -58,7 +63,12 @@ private struct SourceRow: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(item.title)
                     .lineLimit(1)
-                if let detail = item.detailLine {
+                if !item.isAvailable {
+                    Text("Unreachable — Relocate / Remove")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .lineLimit(1)
+                } else if let detail = item.detailLine {
                     Text(detail)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -69,8 +79,12 @@ private struct SourceRow: View {
         } icon: {
             Image(systemName: item.symbolName)
                 .symbolVariant(item.isAvailable ? .none : .slash)
-                .foregroundStyle(item.isAvailable ? .primary : .secondary)
+                .foregroundStyle(item.isAvailable ? Color.primary : Color.orange)
         }
-        .help(item.detailLine ?? item.title)
+        .help(
+            item.isAvailable
+                ? (item.detailLine ?? item.title)
+                : "Unreachable — Relocate / Remove"
+        )
     }
 }

--- a/Sources/Workspace/WorkspacePersistence.swift
+++ b/Sources/Workspace/WorkspacePersistence.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Codable snapshot of the source list. Bookmarks persist; `isAvailable`
+/// is resolved at load and is not stored.
+struct PersistedWorkspace: Codable, Equatable, Sendable {
+    var sources: [LocalSource]
+    var selected: SourceID?
+}
+
+enum WorkspacePersistence {
+    static let defaultsKey = "solipsist.workspace.sources.v1"
+
+    static func encode(_ payload: PersistedWorkspace) throws -> Data {
+        try JSONEncoder().encode(payload)
+    }
+
+    static func decode(_ data: Data) throws -> PersistedWorkspace {
+        try JSONDecoder().decode(PersistedWorkspace.self, from: data)
+    }
+}

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -7,19 +7,23 @@ import Observation
 @MainActor
 @Observable
 final class WorkspaceStore {
-    private static let persistenceKey = "solipsist.workspace.sources.v1"
+    private let defaults: UserDefaults
 
     private(set) var sources: [SourceItem] = []
+    private(set) var recentFolderURLs: [URL] = []
     var selection: WorkspaceSelection = .empty
     /// Surfaced, never swallowed. Cleared on the next successful action.
+    /// Stale sources do not write this — the sidebar badge is the warning.
     var lastError: String?
 
     /// URLs we have called `startAccessingSecurityScopedResource` on.
     @ObservationIgnored
     private var scopedURLs: [SourceID: URL] = [:]
 
-    init() {
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
         load()
+        refreshRecentFolders()
     }
 
     var selectedSource: SourceItem? {
@@ -98,10 +102,70 @@ final class WorkspaceStore {
             local = beginAccess(local)
             sources.append(.local(local))
             select(local.id)
+            noteRecent(standardized)
             persist()
         } catch {
             lastError = String(describing: error)
         }
+    }
+
+    func presentRelocatePanel(for id: SourceID) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+        panel.treatsFilePackagesAsDirectories = true
+        panel.prompt = "Relocate"
+        panel.message = "Choose the folder this source moved to."
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        relocate(id, to: url)
+    }
+
+    func relocate(_ id: SourceID, to url: URL) {
+        lastError = nil
+        let standardized = url.standardizedFileURL
+        if let existing = sources.first(where: { item in
+            guard item.id != id, case .local(let local) = item else { return false }
+            return local.displayPath == standardized.path
+        }) {
+            remove(id)
+            select(existing.id)
+            return
+        }
+
+        do {
+            var local = try LocalSource.make(from: standardized)
+            local.id = id
+            endAccess(id)
+            local = beginAccess(local)
+            if let index = sources.firstIndex(where: { $0.id == id }) {
+                sources[index] = .local(local)
+            } else {
+                sources.append(.local(local))
+            }
+            select(id)
+            noteRecent(standardized)
+            persist()
+        } catch {
+            lastError = String(describing: error)
+        }
+    }
+
+    func openFromSystem(_ url: URL) {
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+           isDirectory.boolValue
+        {
+            addLocal(url: url)
+        } else {
+            addLocal(url: url.deletingLastPathComponent())
+        }
+    }
+
+    func clearRecentFolders() {
+        NSDocumentController.shared.clearRecentDocuments(nil)
+        refreshRecentFolders()
     }
 
     func remove(_ id: SourceID) {
@@ -129,22 +193,25 @@ final class WorkspaceStore {
             selected: selection.sourceID
         )
         do {
-            let data = try JSONEncoder().encode(payload)
-            UserDefaults.standard.set(data, forKey: Self.persistenceKey)
+            defaults.set(try WorkspacePersistence.encode(payload), forKey: WorkspacePersistence.defaultsKey)
         } catch {
             lastError = String(describing: error)
         }
     }
 
     private func load() {
-        guard let data = UserDefaults.standard.data(forKey: Self.persistenceKey) else {
+        guard let data = defaults.data(forKey: WorkspacePersistence.defaultsKey) else {
             return
         }
         do {
-            let payload = try JSONDecoder().decode(PersistedWorkspace.self, from: data)
+            let payload = try WorkspacePersistence.decode(data)
+            var refreshed = false
             sources = payload.sources.map { raw in
                 var local = raw
                 local = beginAccess(local)
+                if local.isAvailable, local.bookmarkData != raw.bookmarkData {
+                    refreshed = true
+                }
                 return .local(local)
             }
             if let selected = payload.selected,
@@ -152,20 +219,38 @@ final class WorkspaceStore {
             {
                 selection.sourceID = selected
             }
+            if refreshed {
+                persist()
+            }
         } catch {
             lastError = String(describing: error)
         }
     }
 
+    private func noteRecent(_ url: URL) {
+        NSDocumentController.shared.noteNewRecentDocumentURL(url)
+        refreshRecentFolders()
+    }
+
+    func refreshRecentFolders() {
+        recentFolderURLs = NSDocumentController.shared.recentDocumentURLs
+    }
+
     // MARK: - Sandbox access
 
+    /// Resolve + start access. Failures mark the source unavailable and do
+    /// not write `lastError` — the sidebar badge is the non-blocking warning.
     private func beginAccess(_ source: LocalSource) -> LocalSource {
         var local = source
         do {
             let resolved = try local.resolve()
-            guard resolved.url.startAccessingSecurityScopedResource() else {
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(
+                atPath: resolved.url.path,
+                isDirectory: &isDirectory
+            ) && isDirectory.boolValue
+            guard exists, resolved.url.startAccessingSecurityScopedResource() else {
                 local.isAvailable = false
-                lastError = "Could not access \(local.displayPath)"
                 return local
             }
             scopedURLs[local.id] = resolved.url
@@ -177,7 +262,6 @@ final class WorkspaceStore {
             }
         } catch {
             local.isAvailable = false
-            lastError = String(describing: error)
         }
         return local
     }
@@ -187,9 +271,4 @@ final class WorkspaceStore {
             url.stopAccessingSecurityScopedResource()
         }
     }
-}
-
-private struct PersistedWorkspace: Codable {
-    var sources: [LocalSource]
-    var selected: SourceID?
 }

--- a/Tests/ContractTests/WorkspacePersistenceTests.swift
+++ b/Tests/ContractTests/WorkspacePersistenceTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+final class WorkspacePersistenceTests: XCTestCase {
+    private var scratch: URL!
+
+    override func setUpWithError() throws {
+        scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("solipsist-workspace-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: scratch)
+        scratch = nil
+    }
+
+    func testLocalSourceRoundTripKeepsBookmarkAndDropsAvailability() throws {
+        let source = try LocalSource.make(from: scratch)
+        XCTAssertTrue(source.isAvailable)
+
+        let encoded = try JSONEncoder().encode(source)
+        let decoded = try JSONDecoder().decode(LocalSource.self, from: encoded)
+
+        XCTAssertEqual(decoded.id, source.id)
+        XCTAssertEqual(decoded.title, source.title)
+        XCTAssertEqual(decoded.displayPath, source.displayPath)
+        XCTAssertEqual(decoded.bookmarkData, source.bookmarkData)
+        XCTAssertTrue(decoded.isAvailable, "availability is transient and defaults true")
+
+        let resolved = try decoded.resolve()
+        XCTAssertEqual(
+            resolved.url.standardizedFileURL.path,
+            scratch.standardizedFileURL.path
+        )
+    }
+
+    func testPersistedWorkspaceRoundTripViaDefaults() throws {
+        let source = try LocalSource.make(from: scratch)
+        let payload = PersistedWorkspace(sources: [source], selected: source.id)
+        let suiteName = "solipsist.workspace.test.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("suite defaults")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(try WorkspacePersistence.encode(payload), forKey: WorkspacePersistence.defaultsKey)
+        guard let data = defaults.data(forKey: WorkspacePersistence.defaultsKey) else {
+            return XCTFail("missing payload")
+        }
+        let decoded = try WorkspacePersistence.decode(data)
+        XCTAssertEqual(decoded.selected, source.id)
+        XCTAssertEqual(decoded.sources.count, 1)
+        XCTAssertEqual(decoded.sources[0].id, source.id)
+        XCTAssertEqual(decoded.sources[0].bookmarkData, source.bookmarkData)
+    }
+
+    func testDeletedFolderFailsResolve() throws {
+        let folder = scratch.appendingPathComponent("gone", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let source = try LocalSource.make(from: folder)
+        _ = try source.resolve()
+
+        try FileManager.default.removeItem(at: folder)
+        XCTAssertThrowsError(try source.resolve())
+    }
+
+    func testRelocatedFolderKeepsIdentity() throws {
+        let original = try LocalSource.make(from: scratch)
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("solipsist-relocated-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: destination) }
+
+        var relocated = try LocalSource.make(from: destination)
+        relocated.id = original.id
+        XCTAssertEqual(relocated.id, original.id)
+        XCTAssertNotEqual(relocated.bookmarkData, original.bookmarkData)
+        XCTAssertEqual(
+            try relocated.resolve().url.standardizedFileURL.path,
+            destination.standardizedFileURL.path
+        )
+    }
+
+    func testRefreshedBookmarkPreservesIdentity() throws {
+        let source = try LocalSource.make(from: scratch)
+        let refreshed = try source.refreshedBookmark()
+        XCTAssertEqual(refreshed.id, source.id)
+        XCTAssertEqual(
+            try refreshed.resolve().url.standardizedFileURL.path,
+            scratch.standardizedFileURL.path
+        )
+    }
+}

--- a/docs/help.md
+++ b/docs/help.md
@@ -20,6 +20,8 @@ Every menu verb and keyboard shortcut:
 | --- | --- | --- |
 | New Project… | `⌘N` | Initialize a new Boris project in a folder (`boris init`) and add it as a source. |
 | Open… | `⌘O` | Open a Boris publication folder as a source. |
+| Open Recent | — | Re-open a folder from the system recent-documents list. |
+| Relocate Source… | — | Point an unreachable source at its new folder (enabled when the selected source is stale). |
 | Remove Source | — | Remove the currently selected source from the workspace (enabled when a source is selected). |
 
 ### Boris


### PR DESCRIPTION
Closes #59.

Bookmark persistence was already on main; this fills the remaining gate.

## What landed

- **Stale is non-blocking.** Failed resolve / missing folder marks `isAvailable = false` and does not write `lastError` (no modal on launch).
- **Sidebar badge:** `Unreachable — Relocate / Remove`, plus Relocate… / Remove in the context menu.
- **File → Relocate Source…** keeps the source id and writes a new bookmark.
- **File → Open Recent** is backed by `NSDocumentController`. System open-file events (`AppDelegate`) re-add the folder.
- **Tests:** encode/decode round-trip through UserDefaults, deleted folder fails resolve, relocate keeps identity.

`SKIP_EMBED_BORIS=1 make build` + `make test` (77) + `make lint` green.

Closes #59.