### PR TITLE
docs: remaining-work board after the M3–M8 gates (#87)

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -69,16 +69,17 @@ compiler repo. Solipsist is the complementary **native desktop citizen**:
 
 ## Where we are
 
-- **M0 / M1 / M2 / M3 / M4 done.** Spike decodes the contracts; chassis is
-  in; play & inspect land the dogfood corpus (45 pages / 7 trunks) with
-  completion-backed drawer fields and profile write; the coordinator verbs
-  (plan / validate / build / check / impact / init) are menu items
-  (#72/#73, PR #80). Full sequence: [ROADMAP.md](ROADMAP.md).
+- **M0–M8 gates exist.** Spike, chassis, list, verbs, preview/editor
+  shells, output fan-out, stdin publish. That is not CLI parity and not
+  a usable workstation. Remaining board:
+  [#87](https://github.com/drawmeanelephant/solipsist/issues/87).
+  Sequence: [ROADMAP.md](ROADMAP.md) §8.
 - **Engine baseline:** afterparty `boris/0.8.1`. Kit pin `b82e9e2`.
-  A3/A4/A13 have merged after that pin.
-- **Next:** M5 preview companion (`watch --serve`), then M7 outputs
-  fan-out and M8 publish. Roadmap **P** (Worker/Wasm subdomain) is
-  withdrawn — the public site ships via Cloudflare Pages (`site/`).
+  A3/A4/A13/A1/A14/A7 have merged after that pin — bump when we vendor
+  a newer kit (#78).
+- **Next:** usability (#88), then play / inspector / publish depth
+  (#89–#91), then a clean-Mac ship (#78). Roadmap **P** is withdrawn —
+  the public site ships via Cloudflare Pages (`site/`).
 
 ## What success looks like
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Solipsist — Roadmap
 
-**Date:** 2026-08-17
+**Date:** 2026-08-18
 **Status:** the goals document. Spatial model:
 [`HARNESS.md`](HARNESS.md). Boris surface:
 [`BORIS-CAPABILITIES.md`](BORIS-CAPABILITIES.md).
@@ -105,18 +105,18 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M1** Engine spike | ✅ `make run-spike` decodes the IR contracts |
 | **M2** Chassis | ✅ sources / play / drawer / companion slots; File → Open… adds a local source |
 | **P** Project subdomain | ⛔ withdrawn — the public site ships via Cloudflare Pages (`site/`) |
-| **M3** Play & inspect | ✅ — dogfood corpus (45 pages / 7 trunks, verified), completion drawer, profile write (#72, #80) |
-| **M4** Coordinate | ✅ — coordinator verbs: plan / validate / build / check / impact / init (#73, #80) |
-| **M5** Preview | next |
-| **M6** Author | — |
-| **M7** Outputs | — |
-| **M8** Publish | — |
-| **M9** Ship | — |
+| **M3** Play & inspect | ✅ gate — list from `graph.json`, drawer fields (#72, #80) |
+| **M4** Coordinate | ✅ gate — menu verbs, exits visible (#73, #80) |
+| **M5** Preview | ✅ gate — `watch --serve` companion (#74, #81) |
+| **M6** Author | ✅ gate — `boris-editor` host + link-out (#75, #81) |
+| **M7** Outputs | ✅ gate — Build this / Build all fan-out (#76, #81) |
+| **M8** Publish | ✅ gate — stdin secrets, Standard.site / Nostr buttons (#77, #82/#84) |
+| **M9** Ship | 🔧 pipeline exists; clean-Mac proof + credentials + pin open (#78) |
 
-Chassis was the serial bottleneck and it has landed. M3/M4 gates closed
-(#72/#73 via PR #80) — the dogfood corpus (`Stunts/dogfood/`, 45 pages /
-7 trunks from `graph.json`) proves the play gate against the pinned
-engine. Do not grow `MainWindow`.
+**Gates are not depth.** M3–M8 closed because a list, a verb, or a window
+existed. The app is not at CLI parity and it is not usable as a Mac
+workstation. Remaining work is [#87](https://github.com/drawmeanelephant/solipsist/issues/87).
+Do not grow `MainWindow`.
 
 ---
 
@@ -382,25 +382,39 @@ here, it is not a v1 promise.
 
 ## 8. Pickup (what to do next)
 
-The active board is the roadmap batch in the issue tracker — one card per
-milestone gate, each with a dispatch comment:
-[#72 M3](https://github.com/drawmeanelephant/solipsist/issues/72) (done) ·
-[#73 M4](https://github.com/drawmeanelephant/solipsist/issues/73) (done) ·
-[#74 M5](https://github.com/drawmeanelephant/solipsist/issues/74) (preview)
-· [#75 M6](https://github.com/drawmeanelephant/solipsist/issues/75) (author)
-· [#76 M7](https://github.com/drawmeanelephant/solipsist/issues/76) (outputs)
-· [#77 M8](https://github.com/drawmeanelephant/solipsist/issues/77) (publish)
-· [#78 M9](https://github.com/drawmeanelephant/solipsist/issues/78) (ship).
+The gate batch (#72–#77) is closed. The active board is
+[#87](https://github.com/drawmeanelephant/solipsist/issues/87).
 
-1. **M5 Preview** — `watch --serve` companion window (#74)
-2. **M7 Outputs** — target/edition fan-out (#76; contract probes in
-   [`ENGINE-CONTRACTS.md`](ENGINE-CONTRACTS.md) §5–§7)
-3. **M8 Publish** — Standard.site / Nostr / Proof Pack (#77)
-4. **M9 Ship** — release pipeline is fixed (#78 gaps 1–3); credentials +
-   clean-Mac proof + pin bump remain
+| Order | Track | Issue | Why this next |
+|------:|-------|-------|----------------|
+| 1 | Usability | [#88](https://github.com/drawmeanelephant/solipsist/issues/88) | First-run, status, problem → page. Nothing else matters if this is still a chassis. |
+| 2 | Play depth | [#89](https://github.com/drawmeanelephant/solipsist/issues/89) | Filter, check badges, activity + timings, plan as a document. |
+| 3 | Inspector depth | [#90](https://github.com/drawmeanelephant/solipsist/issues/90) | Profile 1:1, execution knobs that reach boris, `recipe-scale`. |
+| 4 | Publish depth | [#91](https://github.com/drawmeanelephant/solipsist/issues/91) | Rest of `standard-site`, `boris-package`, readable proof. |
+| 5 | Ship | [#78](https://github.com/drawmeanelephant/solipsist/issues/78) | Credentials, clean-Mac proof, pin bump, testdata. Parallel with 1–4 when someone has Apple certs. |
 
-Do not start the editor companion or GitHub-as-source until a page in
-play is selectable. Do not put Wasm in the app.
+#88 and #89 can run in parallel (Chrome vs `Play/Local`). #90 owns
+`Inspector/` plus a thin Engine flag pass. #91 owns `PublishPane` plus
+publication methods. #78 stays build-lane only.
+
+### CLI vs app (honest)
+
+Wired as a menu or pane: `build` (IR/HTML/target/edition/all),
+`validate`, `watch --serve`, `check`, `impact`, `plan --profile`,
+`init`, `standard-site login` + `publish`, `nostr plan|sign|publish`,
+`--version`, `--timings` (decoded, not shown), `--report`.
+
+Named in this file and **not** a product surface yet: `recipe-scale`,
+`boris-package`, `standard-site` plan/records/verify/sessions/logout/smoke,
+browser OAuth, `github-pages-audit`, per-relay Nostr evidence, Jobs /
+Incremental / Quiet actually reaching the child.
+
+Out of v1 (unchanged): GitHub as a source, content-audit, source-rag,
+migration labs, Wasm in the app, `validate --watch` until A5 + pin.
+
+#30 is a pr-cop dump, not a card.
+
+Do not put Wasm in the app.
 
 If another doc disagrees with this file about *when* a surface lands,
 this file wins.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -18,7 +18,13 @@ with a dispatch comment — [#72 M3](https://github.com/drawmeanelephant/solipsi
 [#77 M8](https://github.com/drawmeanelephant/solipsist/issues/77) ·
 [#78 M9](https://github.com/drawmeanelephant/solipsist/issues/78).
 
-M3 and M4 are **done** (#72/#73, PR #80). Active: M5–M9.
+M3–M8 **gates** are closed (#72–#77). That is not depth. Active board:
+[#87 remaining](https://github.com/drawmeanelephant/solipsist/issues/87)
+· [#88 ux](https://github.com/drawmeanelephant/solipsist/issues/88) ·
+[#89 play](https://github.com/drawmeanelephant/solipsist/issues/89) ·
+[#90 inspector](https://github.com/drawmeanelephant/solipsist/issues/90) ·
+[#91 publish](https://github.com/drawmeanelephant/solipsist/issues/91) ·
+[#78 ship](https://github.com/drawmeanelephant/solipsist/issues/78).
 
 **Legacy board (landed or withdrawn — do not pick):**
 

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -67,7 +67,8 @@ lives in the issue tracker (#58–#61; briefs in
 `docs/cards/B3-*.md`) — those own grind-lane paths, so they are not
 queue cards.
 
-The active board is the **roadmap batch** (#72–#78, one card per
-milestone gate, dispatch comments on each issue — see
-[`../README.md`](../README.md)). M3/M4 (#72/#73) are done; the queue
-stays empty until M5–M9 surface data-only or docs-only slices.
+The active board is **remaining work after the gates**
+([#87](https://github.com/drawmeanelephant/solipsist/issues/87)).
+#88–#91 own grind-lane paths (Chrome, Play, Inspector, Engine,
+PublishPane). They are not queue cards. The queue stays empty unless
+a child surfaces a docs-only or `Tests/`-only slice.

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -11,19 +11,17 @@ Solipsist is a **harness**, not a better compiler and not a Markdown IDE. Boris 
 
 ## Where we are
 
-| Milestone | Status |
-|-----------|--------|
-| **M0** Bootstrap | ✅ |
-| **M1** Engine spike | ✅ — decodes the IR contracts |
-| **M2** Chassis | ✅ — sources / play / drawer / companion slots |
-| **P** Project subdomain | next (parallel) |
-| **M3** Play & inspect | next |
-| **M4** Coordinate | — |
-| **M5** Preview | — |
-| **M6** Author | — |
-| **M7** Outputs | — |
-| **M8** Publish | — |
-| **M9** Ship | — |
+M0–M8 **gates** exist: open a folder, see the graph, run the coordinator
+verbs, preview, host the editor, fan out targets, publish with secrets
+on stdin. That is not CLI parity and not a usable workstation yet.
+
+| Track | Status |
+|-------|--------|
+| M0–M8 gates | landed |
+| P Project subdomain | withdrawn — this site is Cloudflare Pages |
+| Usability | next — first-run, status, click a problem and land on the page |
+| Play / inspector / publish depth | open — filter, plan as a document, profile 1:1, rest of `standard-site` |
+| M9 Ship | open — notarized DMG on a clean Mac |
 
 ## v1 must
 


### PR DESCRIPTION
The app has gates, not a product. This makes the docs match.

- Tracker: #87
- Pickable: #88 ux · #89 play · #90 inspector · #91 publish
- Ship stays #78

ROADMAP §4 and §8 are honest. Cards and the public site stop saying M5 is next.

Closes nothing. #87 stays open as the parent.