### PR TITLE
feat(publish): Standard.site family, package, and readable proof (#91)

### DIFF
--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -106,8 +106,42 @@ struct SolipsistCommands: Commands {
             }
             .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
+            Button("Verify Standard.site") {
+                runtime.coordinator.run(.standardSiteVerify, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
+            Button("Standard.site Records") {
+                runtime.coordinator.run(.standardSiteRecords, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
+            Button("Standard.site Sessions") {
+                runtime.coordinator.run(.standardSiteSessions, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
+            Button("Standard.site Smoke Test") {
+                runtime.coordinator.run(.standardSiteSmoke, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
+            Button("Logout Standard.site") {
+                runtime.coordinator.run(.standardSiteLogout, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
+            Divider()
+
             Button("Publish to Nostr…") {
                 runtime.coordinator.run(.publishNostr, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
+            Divider()
+
+            Button("Package Archive") {
+                runtime.coordinator.run(.package, store: store, runtime: runtime)
             }
             .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -1,40 +1,6 @@
 import Foundation
 import Observation
 
-enum CoordinatorVerb: String, Sendable {
-    case plan
-    case validate
-    case buildIR
-    case buildHTML
-    case buildThis = "build this"
-    case buildAll
-    case check
-    case impact
-    case publishStandardSite = "publish Standard.site"
-    case publishNostr = "publish Nostr"
-
-    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof).
-    var writesTree: Bool {
-        switch self {
-        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr:
-            true
-        case .plan, .validate, .check, .impact:
-            false
-        }
-    }
-
-    var timeout: Duration {
-        writesTree ? CoordinatorPolicy.buildTimeout : CoordinatorPolicy.oneShotTimeout
-    }
-
-    var secretTarget: String? {
-        switch self {
-        case .publishNostr: PublishTargets.nostr
-        case .publishStandardSite: PublishTargets.standardSite
-        default: nil
-        }
-    }
-}
 
 /// Menu verbs against `BorisEngine`. One job at a time. Play and the
 /// status bar read this; they do not spawn `boris`.
@@ -559,8 +525,110 @@ final class Coordinator {
             case .publishStandardSite:
                 return try await publishStandardSite(source: source, engine: engine, secret: secret)
 
+            case .standardSiteVerify:
+                guard let profileURL = source.profileURL() else {
+                    return JobResult(
+                        exit: 3,
+                        summary: "verify: no boris.json",
+                        problems: CoordinatorProblems.fromFailure(code: "standard-site", message: "no boris.json")
+                    )
+                }
+                let result = try await engine.standardSiteVerify(profileURL: profileURL)
+                let items = CoordinatorProblems.fromCommand(
+                    code: "standard-site",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Standard.site verify ok" : "Standard.site verify exit \(result.exitCode)",
+                    problems: items
+                )
+
+            case .standardSiteRecords:
+                guard let profileURL = source.profileURL() else {
+                    return JobResult(
+                        exit: 3,
+                        summary: "records: no boris.json",
+                        problems: CoordinatorProblems.fromFailure(code: "standard-site", message: "no boris.json")
+                    )
+                }
+                let result = try await engine.standardSiteRecords(profileURL: profileURL)
+                let items = CoordinatorProblems.fromCommand(
+                    code: "standard-site",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Standard.site records ok" : "Standard.site records exit \(result.exitCode)",
+                    problems: items
+                )
+
+            case .standardSiteSessions:
+                let result = try await engine.standardSiteSessions(
+                    workingDirectory: try source.workspaceRoot()
+                )
+                let items = CoordinatorProblems.fromCommand(
+                    code: "standard-site",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Standard.site sessions ok" : "Standard.site sessions exit \(result.exitCode)",
+                    problems: items
+                )
+
+            case .standardSiteLogout:
+                let result = try await engine.standardSiteLogout(
+                    workingDirectory: try source.workspaceRoot()
+                )
+                let items = CoordinatorProblems.fromCommand(
+                    code: "standard-site",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Standard.site logout ok" : "Standard.site logout exit \(result.exitCode)",
+                    problems: items
+                )
+
+            case .standardSiteSmoke:
+                let result = try await engine.standardSiteSmoke(
+                    profileURL: source.profileURL(),
+                    workingDirectory: try source.workspaceRoot()
+                )
+                let items = CoordinatorProblems.fromCommand(
+                    code: "standard-site",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Standard.site smoke ok" : "Standard.site smoke exit \(result.exitCode)",
+                    problems: items
+                )
+
             case .publishNostr:
                 return try await publishNostr(source: source, engine: engine, secret: secret)
+
+            case .package:
+                let result = try await engine.package(
+                    contentRoot: try source.contentRoot(),
+                    workingDirectory: try source.workspaceRoot()
+                )
+                let items = CoordinatorProblems.fromCommand(
+                    code: "package",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Package archive ok" : "Package exit \(result.exitCode)",
+                    problems: items
+                )
             }
         } catch {
             let message = String(describing: error)
@@ -815,14 +883,37 @@ final class Coordinator {
         }
 
         let published = try await engine.nostrPublish(bundleURL: bundleURL, reportURL: reportURL)
-        return JobResult(
-            exit: published.exitCode,
-            summary: "Nostr publish exit \(published.exitCode)",
-            problems: CoordinatorProblems.fromCommand(
+        var items: [ProblemItem] = []
+        var summaryText = "Nostr publish exit \(published.exitCode)"
+        let reportData = (try? Data(contentsOf: reportURL)) ?? (published.stdout.isEmpty ? nil : Data(published.stdout.utf8))
+        if let reportData,
+           let report = try? JSONDecoder().decode(NostrPublishReport.self, from: reportData) {
+            if let verdict = report.verdict {
+                summaryText = "Nostr publish \(verdict) (exit \(published.exitCode))"
+            }
+            if let relays = report.relays {
+                for relay in relays {
+                    let isOk = relay.isSuccess
+                    let severity = isOk ? "info" : "error"
+                    items.append(ProblemItem(
+                        severity: severity,
+                        code: "nostr-relay",
+                        message: "\(relay.relayURL): \(relay.displayMessage)"
+                    ))
+                }
+            }
+        }
+        if items.isEmpty, published.exitCode != 0 {
+            items = CoordinatorProblems.fromCommand(
                 code: "nostr",
                 exitCode: published.exitCode,
                 stderr: published.stderr
             )
+        }
+        return JobResult(
+            exit: published.exitCode,
+            summary: summaryText,
+            problems: items
         )
     }
 

--- a/Sources/App/CoordinatorPolicy.swift
+++ b/Sources/App/CoordinatorPolicy.swift
@@ -2,6 +2,47 @@ import Foundation
 
 /// Coordinator states from the #58 state machine. `validating` is any
 /// non-tree-writing one-shot; `building` is any tree-writing one-shot.
+enum CoordinatorVerb: String, Sendable {
+    case plan
+    case validate
+    case buildIR
+    case buildHTML
+    case buildThis = "build this"
+    case buildAll
+    case check
+    case impact
+    case publishStandardSite = "publish Standard.site"
+    case standardSiteVerify = "Standard.site verify"
+    case standardSiteRecords = "Standard.site records"
+    case standardSiteSessions = "Standard.site sessions"
+    case standardSiteLogout = "Standard.site logout"
+    case standardSiteSmoke = "Standard.site smoke"
+    case publishNostr = "publish Nostr"
+    case package
+
+    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof, packages).
+    var writesTree: Bool {
+        switch self {
+        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr, .package:
+            true
+        case .plan, .validate, .check, .impact, .standardSiteVerify, .standardSiteRecords, .standardSiteSessions, .standardSiteLogout, .standardSiteSmoke:
+            false
+        }
+    }
+
+    var timeout: Duration {
+        writesTree ? CoordinatorPolicy.buildTimeout : CoordinatorPolicy.oneShotTimeout
+    }
+
+    var secretTarget: String? {
+        switch self {
+        case .publishNostr: PublishTargets.nostr
+        case .publishStandardSite: PublishTargets.standardSite
+        default: nil
+        }
+    }
+}
+
 enum CoordinatorState: String, Sendable {
     case idle
     case watching

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -697,6 +697,74 @@ public actor BorisEngine {
         return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
     }
 
+    /// Runs `boris standard-site verify --profile PATH`.
+    public func standardSiteVerify(profileURL: URL) async throws -> BorisPublishResult {
+        let out = try await run(
+            arguments: ["standard-site", "verify", "--profile", profileURL.lastPathComponent],
+            workingDirectory: profileURL.deletingLastPathComponent()
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
+    /// Runs `boris standard-site sessions`.
+    public func standardSiteSessions(workingDirectory: URL? = nil) async throws -> BorisPublishResult {
+        let out = try await run(
+            arguments: ["standard-site", "sessions"],
+            workingDirectory: workingDirectory
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
+    /// Runs `boris standard-site logout`.
+    public func standardSiteLogout(workingDirectory: URL? = nil) async throws -> BorisPublishResult {
+        let out = try await run(
+            arguments: ["standard-site", "logout"],
+            workingDirectory: workingDirectory
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
+    /// Runs `boris standard-site smoke` (live opt-in interop test).
+    public func standardSiteSmoke(
+        profileURL: URL? = nil,
+        workingDirectory: URL? = nil
+    ) async throws -> BorisPublishResult {
+        var args = ["standard-site", "smoke"]
+        if let profileURL {
+            args.append(contentsOf: ["--profile", profileURL.lastPathComponent])
+        }
+        let out = try await run(
+            arguments: args,
+            workingDirectory: workingDirectory ?? profileURL?.deletingLastPathComponent()
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
+    /// Runs `boris package`: produces `packages/<archive>` containing `MACHINE-READABLE-VERSION.json`, `SHA256SUMS`, etc.
+    public func package(
+        contentRoot: URL,
+        packagesDir: URL? = nil,
+        archive: String? = nil,
+        withRag: Bool = true,
+        workingDirectory: URL? = nil
+    ) async throws -> BorisPublishResult {
+        var args = ["package", "--input", contentRoot.path]
+        if let packagesDir {
+            args.append(contentsOf: ["--packages-dir", packagesDir.path])
+        }
+        if let archive, !archive.isEmpty {
+            args.append(contentsOf: ["--archive", archive])
+        }
+        args.append(withRag ? "--with-rag" : "--no-rag")
+        args.append("--quiet")
+
+        let out = try await run(
+            arguments: args,
+            workingDirectory: workingDirectory ?? contentRoot.deletingLastPathComponent()
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
     /// Runs `boris nostr plan --profile PATH`.
     public func nostrPlan(profileURL: URL) async throws -> BorisPublishResult {
         let out = try await run(

--- a/Sources/Models/BorisContracts.swift
+++ b/Sources/Models/BorisContracts.swift
@@ -437,6 +437,197 @@ public struct TimingsCounters: Codable, Sendable {
     public var fast_path_hits: Int?
 }
 
+// MARK: - Proof Pack & Evidence Chain (`_boris/proof/`)
+
+/// Decoded from `_boris/proof/proof-pack.json`.
+public struct ProofPackDocument: Codable, Sendable {
+    public var format: String?
+    public var schema_version: Int?
+    public var digest: String?
+    public var model_digest: String?
+    public var generated_at: String?
+    public var timestamp: String?
+    public var claims: [ProofClaim]?
+    public var checks: [ProofCheck]?
+    public var artifacts: [ProofArtifact]?
+    public var limitations: [String]?
+}
+
+/// A structured claim made in the publication proof chain (`claims.json`).
+public struct ProofClaim: Codable, Sendable, Identifiable {
+    public var id: String?
+    public var statement: String?
+    public var claim: String?
+    public var description: String?
+    public var category: String?
+    public var status: String?
+    public var verified: Bool?
+    public var evidence: [String]?
+    public var artifacts: [String]?
+
+    public var displayID: String { id ?? statement ?? "claim" }
+    public var displayText: String { statement ?? claim ?? description ?? id ?? "Unnamed claim" }
+    public var isVerified: Bool {
+        if let verified { return verified }
+        if let status {
+            let s = status.lowercased()
+            return s == "verified" || s == "pass" || s == "ok"
+        }
+        return false
+    }
+}
+
+/// A structured verification check in the proof chain (`checks.json`).
+public struct ProofCheck: Codable, Sendable, Identifiable {
+    public var id: String?
+    public var name: String?
+    public var title: String?
+    public var status: String?
+    public var passed: Bool?
+    public var ok: Bool?
+    public var message: String?
+    public var description: String?
+    public var target: String?
+    public var path: String?
+
+    public var displayID: String { id ?? name ?? title ?? "check" }
+    public var displayTitle: String { name ?? title ?? id ?? "Verification Check" }
+    public var displayMessage: String? { message ?? description }
+    public var isPassed: Bool {
+        if let passed { return passed }
+        if let ok { return ok }
+        if let status {
+            let s = status.lowercased()
+            return s == "passed" || s == "pass" || s == "ok"
+        }
+        return true
+    }
+}
+
+/// A structured artifact entry in `artifacts.json`.
+public struct ProofArtifact: Codable, Sendable, Identifiable {
+    public var id: String { path ?? name ?? sha256 ?? UUID().uuidString }
+    public var path: String?
+    public var name: String?
+    public var size: Int?
+    public var sha256: String?
+    public var media_type: String?
+    public var mime_type: String?
+    public var semantics: String?
+}
+
+/// Decoded from `_boris/proof/claims.json`.
+public struct ProofClaimsDocument: Codable, Sendable {
+    public var format: String?
+    public var schema_version: Int?
+    public var claims: [ProofClaim]?
+    public var limitations: [String]?
+}
+
+/// Decoded from `_boris/proof/checks.json`.
+public struct ProofChecksDocument: Codable, Sendable {
+    public var format: String?
+    public var schema_version: Int?
+    public var checks: [ProofCheck]?
+}
+
+// MARK: - Nostr Publish Report (`_boris/nostr-publish.json`)
+
+/// Decoded from `_boris/nostr-publish.json` or engine stdout.
+public struct NostrPublishReport: Codable, Sendable {
+    public var format: String?
+    public var schema_version: Int?
+    public var verdict: String?
+    public var created_at: String?
+    public var timestamp: String?
+    public var event_id: String?
+    public var relays: [NostrRelayVerdict]?
+}
+
+/// Per-relay publication verdict from a Nostr publish run.
+public struct NostrRelayVerdict: Codable, Sendable, Identifiable {
+    public var id: String { url ?? relay ?? UUID().uuidString }
+    public var url: String?
+    public var relay: String?
+    public var verdict: String?
+    public var status: String?
+    public var ok: Bool?
+    public var message: String?
+    public var error: String?
+    public var event_id: String?
+
+    public var relayURL: String { url ?? relay ?? "unknown" }
+    public var isSuccess: Bool {
+        if let ok { return ok }
+        if let verdict {
+            let v = verdict.lowercased()
+            return v == "complete" || v == "ok" || v == "success" || v == "published"
+        }
+        if let status {
+            let s = status.lowercased()
+            return s == "ok" || s == "success" || s == "complete"
+        }
+        return false
+    }
+    public var displayMessage: String {
+        message ?? error ?? verdict ?? status ?? (isSuccess ? "Published successfully" : "Publish failed")
+    }
+}
+
+// MARK: - Package Metadata (`MACHINE-READABLE-VERSION.json` & `SHA256SUMS`)
+
+/// Decoded from `MACHINE-READABLE-VERSION.json` in packages or project root.
+public struct MachineReadableVersion: Codable, Sendable {
+    public var format: String?
+    public var schema_version: Int?
+    public var version: String?
+    public var commit: String?
+    public var compiler: String?
+    public var compiler_id: String?
+    public var compilerId: String?
+    public var timestamp: String?
+    public var created_at: String?
+    public var platform: String?
+    public var ir_version: String?
+    public var features: [String]?
+    public var sha256: String?
+
+    public var displayVersion: String { version ?? "unknown" }
+    public var displayCommit: String? { commit }
+    public var displayPlatform: String? { platform }
+    public var displayCompiler: String? { compiler ?? compiler_id ?? compilerId }
+}
+
+/// A parsed line from a `SHA256SUMS` file.
+public struct PackageChecksumEntry: Identifiable, Sendable {
+    public var id: String { "\(filename)-\(sha256)" }
+    public let sha256: String
+    public let filename: String
+
+    public init(sha256: String, filename: String) {
+        self.sha256 = sha256
+        self.filename = filename
+    }
+
+    public static func parse(from text: String) -> [PackageChecksumEntry] {
+        var entries: [PackageChecksumEntry] = []
+        for line in text.split(whereSeparator: \.isNewline) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+            let parts = trimmed.split(maxSplits: 1, whereSeparator: { $0.isWhitespace })
+            guard parts.count == 2 else { continue }
+            let hash = String(parts[0])
+            var file = String(parts[1]).trimmingCharacters(in: .whitespaces)
+            if file.hasPrefix("*") {
+                file.removeFirst()
+            }
+            guard hash.count == 64 else { continue }
+            entries.append(PackageChecksumEntry(sha256: hash, filename: file))
+        }
+        return entries
+    }
+}
+
 // MARK: - Schema version policy (D8)
 
 /// D8: unknown/newer `schemaVersion` degrades visibly, never crashes.

--- a/Sources/Play/Local/PublishPane.swift
+++ b/Sources/Play/Local/PublishPane.swift
@@ -1,8 +1,9 @@
+import AppKit
 import SwiftUI
 
-/// Publish pane (M8 / #77): renders publication target details, plan,
-/// evidence chain (`_boris/proof/`), and publish actions. Actions go through
-/// the coordinator — this view never spawns `boris`.
+/// Publish pane (M8 / #77 / #91): renders publication target details, deployment plan,
+/// evidence chain (`_boris/proof/`), Proof Pack claims & checks, Nostr relay verdicts,
+/// package checksums, and publish actions.
 struct PublishPane: View {
     let source: LocalSource
 
@@ -10,6 +11,12 @@ struct PublishPane: View {
     @Environment(AppRuntime.self) private var runtime
     @State private var profile: PublicationProfile?
     @State private var proofFiles: [ProofFileItem] = []
+    @State private var proofPack: ProofPackDocument?
+    @State private var claimsDoc: ProofClaimsDocument?
+    @State private var checksDoc: ProofChecksDocument?
+    @State private var nostrReport: NostrPublishReport?
+    @State private var machineVersion: MachineReadableVersion?
+    @State private var checksumEntries: [PackageChecksumEntry] = []
     @State private var loadError: String?
     @State private var credentialEpoch = 0
 
@@ -22,92 +29,23 @@ struct PublishPane: View {
                 }
             }
 
-            Section("Publication Declaration") {
-                if let pub = profile?.publication {
-                    LabeledContent("Target", value: pub.target)
-                    LabeledContent("Base URL", value: pub.base_url)
-                    LabeledContent("Origin", value: pub.origin)
-                    if !pub.base_path.isEmpty {
-                        LabeledContent("Base Path", value: pub.base_path)
-                    }
-                    if let did = pub.did {
-                        LabeledContent("DID", value: did)
-                    }
-                    if let name = pub.name {
-                        LabeledContent("Site Name", value: name)
-                    }
-                } else {
-                    Text("No `publication` section configured in boris.json.")
-                        .foregroundStyle(.secondary)
-                }
+            publicationSection
+
+            if let target = profile?.publication?.target, target == "github-pages" {
+                githubPagesPlanSection
             }
 
-            Section("Publish Actions") {
-                HStack(spacing: 12) {
-                    Button("Plan Publication") {
-                        runtime.coordinator.run(.plan, store: store, runtime: runtime)
-                    }
-                    .controlSize(.small)
-                    .disabled(!runtime.coordinator.canRunVerb)
+            actionsSection
 
-                    if let target = profile?.publication?.target {
-                        if target == "standard-site" {
-                            Button("Publish to Standard.site") {
-                                runtime.coordinator.run(
-                                    .publishStandardSite,
-                                    store: store,
-                                    runtime: runtime
-                                )
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
-                            .disabled(!runtime.coordinator.canRunVerb)
-                        } else if target == "nostr" {
-                            Button("Publish to Nostr…") {
-                                runtime.coordinator.run(
-                                    .publishNostr,
-                                    store: store,
-                                    runtime: runtime
-                                )
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
-                            .disabled(!runtime.coordinator.canRunVerb)
-                        }
-                    }
-                }
-
-                credentialRow
-
-                Text("Secrets go to boris on stdin. Results land in the problems list.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            if let nostr = nostrReport, let relays = nostr.relays, !relays.isEmpty {
+                nostrVerdictsSection(report: nostr, relays: relays)
             }
 
-            Section("Evidence Chain (_boris/proof/)") {
-                if proofFiles.isEmpty {
-                    Text("No proof files generated yet. Run a build to generate evidence.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(proofFiles) { file in
-                        HStack {
-                            Image(systemName: "checkmark.seal")
-                                .foregroundStyle(.blue)
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text(file.name)
-                                    .font(.body)
-                                Text(file.path)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Text(file.size)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-            }
+            claimsAndChecksSection
+
+            packageEvidenceSection
+
+            evidenceFilesSection
         }
         .listStyle(.inset(alternatesRowBackgrounds: true))
         .task(id: source.id) {
@@ -116,33 +54,389 @@ struct PublishPane: View {
         .onChange(of: runtime.coordinator.isRunning) { wasRunning, isRunning in
             if wasRunning, !isRunning {
                 credentialEpoch += 1
-                if let root = try? source.workspaceRoot() {
-                    scanProofFiles(in: root)
+                load()
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var publicationSection: some View {
+        Section("Publication Declaration") {
+            if let pub = profile?.publication {
+                LabeledContent("Target", value: pub.target)
+                LabeledContent("Base URL", value: pub.base_url)
+                LabeledContent("Origin", value: pub.origin)
+                if !pub.base_path.isEmpty {
+                    LabeledContent("Base Path", value: pub.base_path)
+                }
+                if let did = pub.did {
+                    LabeledContent("DID / Identity", value: did)
+                }
+                if let name = pub.name {
+                    LabeledContent("Site Name", value: name)
+                }
+                if let desc = pub.description, !desc.isEmpty {
+                    LabeledContent("Description", value: desc)
+                }
+                if let discover = pub.show_in_discover {
+                    LabeledContent("Discover Directory", value: discover ? "Visible" : "Hidden")
+                }
+                if let prune = pub.prune {
+                    LabeledContent("Prune Stale Records", value: prune ? "Enabled" : "Disabled")
+                }
+            } else {
+                Text("No `publication` section configured in boris.json.")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var githubPagesPlanSection: some View {
+        Section("GitHub Pages Deployment Plan") {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .foregroundStyle(.blue)
+                    Text("Deterministic Static Build (No Local Secrets)")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+                Text("Boris builds `.nojekyll`, static HTML, and the cryptographic Proof Pack into staging. GitHub Actions deploys the committed artifacts without requiring local personal access tokens.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 2)
+
+            if let pub = profile?.publication {
+                LabeledContent("Public URL", value: pub.base_url)
+                LabeledContent("Staging Output", value: "dist/")
+                LabeledContent("Evidence Root", value: "_boris/proof/")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var actionsSection: some View {
+        Section("Publish Actions") {
+            VStack(alignment: .leading, spacing: 10) {
+                // Top row: Plan + Target-specific actions
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        Button("Plan") {
+                            runtime.coordinator.run(.plan, store: store, runtime: runtime)
+                        }
+                        .controlSize(.small)
+                        .disabled(!runtime.coordinator.canRunVerb)
+
+                        if let target = profile?.publication?.target {
+                            if target == "standard-site" {
+                                Button("Publish to Standard.site") {
+                                    runtime.coordinator.run(
+                                        .publishStandardSite,
+                                        store: store,
+                                        runtime: runtime
+                                    )
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.small)
+                                .disabled(!runtime.coordinator.canRunVerb)
+
+                                Button("Verify") {
+                                    runtime.coordinator.run(
+                                        .standardSiteVerify,
+                                        store: store,
+                                        runtime: runtime
+                                    )
+                                }
+                                .controlSize(.small)
+                                .disabled(!runtime.coordinator.canRunVerb)
+
+                                Button("Records") {
+                                    runtime.coordinator.run(
+                                        .standardSiteRecords,
+                                        store: store,
+                                        runtime: runtime
+                                    )
+                                }
+                                .controlSize(.small)
+                                .disabled(!runtime.coordinator.canRunVerb)
+
+                                Button("Sessions") {
+                                    runtime.coordinator.run(
+                                        .standardSiteSessions,
+                                        store: store,
+                                        runtime: runtime
+                                    )
+                                }
+                                .controlSize(.small)
+                                .disabled(!runtime.coordinator.canRunVerb)
+
+                                Button("Smoke") {
+                                    runtime.coordinator.run(
+                                        .standardSiteSmoke,
+                                        store: store,
+                                        runtime: runtime
+                                    )
+                                }
+                                .controlSize(.small)
+                                .disabled(!runtime.coordinator.canRunVerb)
+
+                                Button("Logout") {
+                                    runtime.coordinator.run(
+                                        .standardSiteLogout,
+                                        store: store,
+                                        runtime: runtime
+                                    )
+                                }
+                                .controlSize(.small)
+                                .disabled(!runtime.coordinator.canRunVerb)
+                            } else if target == "nostr" {
+                                Button("Publish to Nostr…") {
+                                    runtime.coordinator.run(
+                                        .publishNostr,
+                                        store: store,
+                                        runtime: runtime
+                                    )
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.small)
+                                .disabled(!runtime.coordinator.canRunVerb)
+                            } else if target == "github-pages" {
+                                Button("Build HTML & Proof") {
+                                    runtime.coordinator.run(
+                                        .buildHTML,
+                                        store: store,
+                                        runtime: runtime
+                                    )
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.small)
+                                .disabled(!runtime.coordinator.canRunVerb)
+                            }
+                        }
+
+                        Button("Package Archive") {
+                            runtime.coordinator.run(.package, store: store, runtime: runtime)
+                        }
+                        .controlSize(.small)
+                        .disabled(!runtime.coordinator.canRunVerb)
+                    }
+                }
+
+                credentialRow
+
+                Text("Secrets are never put in argv or logs; they stream to Boris over stdin.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func nostrVerdictsSection(report: NostrPublishReport, relays: [NostrRelayVerdict]) -> some View {
+        Section("Nostr Relay Publication Verdicts") {
+            if let verdict = report.verdict {
+                HStack {
+                    Text("Overall Verdict")
+                    Spacer()
+                    Text(verdict.uppercased())
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(verdict.lowercased() == "complete" || verdict.lowercased() == "ok" ? .green : .orange)
+                }
+            }
+
+            ForEach(relays) { relay in
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: relay.isSuccess ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(relay.isSuccess ? .green : .red)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(relay.relayURL)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Text(relay.displayMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }
     }
 
-    private func load() {
-        guard let root = try? source.workspaceRoot() else {
-            loadError = "Could not resolve workspace root."
-            return
-        }
-        do {
-            if let pair = try InspectorProfile.load(from: root) {
-                do {
-                    profile = try JSONDecoder().decode(PublicationProfile.self, from: pair.data)
-                    loadError = nil
-                } catch {
-                    profile = nil
-                    loadError = error.localizedDescription
+    @ViewBuilder
+    private var claimsAndChecksSection: some View {
+        let allClaims = proofPack?.claims ?? claimsDoc?.claims ?? []
+        let allChecks = proofPack?.checks ?? checksDoc?.checks ?? []
+        let limitations = proofPack?.limitations ?? claimsDoc?.limitations ?? []
+
+        if !allClaims.isEmpty || !allChecks.isEmpty || !limitations.isEmpty {
+            Section("Proof Pack & Verification Claims") {
+                if let digest = proofPack?.digest ?? proofPack?.model_digest {
+                    LabeledContent("Model Digest", value: digest)
+                        .font(.caption)
+                }
+
+                if !allClaims.isEmpty {
+                    Text("Declared Claims")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ForEach(allClaims) { claim in
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: claim.isVerified ? "checkmark.seal.fill" : "seal")
+                                .foregroundStyle(claim.isVerified ? .green : .blue)
+                            VStack(alignment: .leading, spacing: 2) {
+                                HStack {
+                                    Text(claim.displayText)
+                                        .font(.subheadline)
+                                    Spacer()
+                                    if let cat = claim.category {
+                                        Text(cat)
+                                            .font(.caption2)
+                                            .padding(.horizontal, 4)
+                                            .padding(.vertical, 1)
+                                            .background(Color.secondary.opacity(0.15))
+                                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                                    }
+                                }
+                                if let evidence = claim.evidence ?? claim.artifacts, !evidence.isEmpty {
+                                    Text("Evidence: " + evidence.joined(separator: ", "))
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if !allChecks.isEmpty {
+                    Text("Verification Checks")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ForEach(allChecks) { check in
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: check.isPassed ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                                .foregroundStyle(check.isPassed ? .green : .red)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(check.displayTitle)
+                                    .font(.subheadline)
+                                if let msg = check.displayMessage {
+                                    Text(msg)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                if let target = check.target ?? check.path {
+                                    Text(target)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if !limitations.isEmpty {
+                    Text("Declared Limitations")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ForEach(limitations, id: \.self) { limitation in
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: "info.circle")
+                                .foregroundStyle(.orange)
+                            Text(limitation)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
             }
-        } catch {
-            loadError = error.localizedDescription
         }
+    }
 
-        scanProofFiles(in: root)
+    @ViewBuilder
+    private var packageEvidenceSection: some View {
+        if machineVersion != nil || !checksumEntries.isEmpty {
+            Section("Package Evidence & Checksums") {
+                if let ver = machineVersion {
+                    LabeledContent("Engine Version", value: ver.displayVersion)
+                    if let commit = ver.displayCommit {
+                        LabeledContent("Commit", value: commit)
+                    }
+                    if let platform = ver.displayPlatform {
+                        LabeledContent("Platform", value: platform)
+                    }
+                    if let compiler = ver.displayCompiler {
+                        LabeledContent("Compiler ID", value: compiler)
+                    }
+                    if let ir = ver.ir_version {
+                        LabeledContent("IR Version", value: ir)
+                    }
+                }
+
+                if !checksumEntries.isEmpty {
+                    Text("SHA256 Fingerprints")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ForEach(checksumEntries) { entry in
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                Text(entry.filename)
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                Spacer()
+                                Button {
+                                    NSPasteboard.general.clearContents()
+                                    NSPasteboard.general.setString(entry.sha256, forType: .string)
+                                } label: {
+                                    Image(systemName: "doc.on.doc")
+                                        .font(.caption2)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Copy SHA-256")
+                            }
+                            Text(entry.sha256)
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var evidenceFilesSection: some View {
+        Section("Evidence Chain (_boris/proof/)") {
+            if proofFiles.isEmpty {
+                Text("No proof files generated yet. Run a build to generate evidence.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(proofFiles) { file in
+                    HStack {
+                        Image(systemName: "checkmark.seal")
+                            .foregroundStyle(.blue)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(file.name)
+                                .font(.body)
+                            Text(file.path)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(file.size)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
     }
 
     @ViewBuilder
@@ -184,6 +478,31 @@ struct PublishPane: View {
         return "not set"
     }
 
+    private func load() {
+        guard let root = try? source.workspaceRoot() else {
+            loadError = "Could not resolve workspace root."
+            return
+        }
+        do {
+            if let pair = try InspectorProfile.load(from: root) {
+                do {
+                    profile = try JSONDecoder().decode(PublicationProfile.self, from: pair.data)
+                    loadError = nil
+                } catch {
+                    profile = nil
+                    loadError = error.localizedDescription
+                }
+            }
+        } catch {
+            loadError = error.localizedDescription
+        }
+
+        scanProofFiles(in: root)
+        loadProofArtifacts(in: root)
+        loadNostrReport(in: root)
+        loadPackageMetadata(in: root)
+    }
+
     private func scanProofFiles(in root: URL) {
         let proofDir = root.appendingPathComponent("_boris/proof", isDirectory: true)
         guard let contents = try? FileManager.default.contentsOfDirectory(
@@ -206,6 +525,76 @@ struct PublishPane: View {
             ))
         }
         proofFiles = items.sorted(by: { $0.name < $1.name })
+    }
+
+    private func loadProofArtifacts(in root: URL) {
+        let proofDir = root.appendingPathComponent("_boris/proof", isDirectory: true)
+
+        let proofPackURL = proofDir.appendingPathComponent("proof-pack.json")
+        if let data = try? Data(contentsOf: proofPackURL) {
+            proofPack = try? JSONDecoder().decode(ProofPackDocument.self, from: data)
+        } else {
+            proofPack = nil
+        }
+
+        let claimsURL = proofDir.appendingPathComponent("claims.json")
+        if let data = try? Data(contentsOf: claimsURL) {
+            claimsDoc = try? JSONDecoder().decode(ProofClaimsDocument.self, from: data)
+        } else {
+            claimsDoc = nil
+        }
+
+        let checksURL = proofDir.appendingPathComponent("checks.json")
+        if let data = try? Data(contentsOf: checksURL) {
+            checksDoc = try? JSONDecoder().decode(ProofChecksDocument.self, from: data)
+        } else {
+            checksDoc = nil
+        }
+    }
+
+    private func loadNostrReport(in root: URL) {
+        let nostrURL = root.appendingPathComponent("_boris/nostr-publish.json")
+        if let data = try? Data(contentsOf: nostrURL) {
+            nostrReport = try? JSONDecoder().decode(NostrPublishReport.self, from: data)
+        } else {
+            nostrReport = nil
+        }
+    }
+
+    private func loadPackageMetadata(in root: URL) {
+        // Look for MACHINE-READABLE-VERSION.json in packages/ or _boris/ or root
+        let candidates = [
+            root.appendingPathComponent("packages/MACHINE-READABLE-VERSION.json"),
+            root.appendingPathComponent("_boris/MACHINE-READABLE-VERSION.json"),
+            root.appendingPathComponent("MACHINE-READABLE-VERSION.json"),
+            root.appendingPathComponent("vendor/boris-agent-kit/MANIFEST.json"),
+        ]
+        machineVersion = nil
+        for candidate in candidates {
+            if let data = try? Data(contentsOf: candidate),
+               let decoded = try? JSONDecoder().decode(MachineReadableVersion.self, from: data) {
+                machineVersion = decoded
+                break
+            }
+        }
+
+        // Look for SHA256SUMS in packages/ or _boris/ or root
+        let checksumCandidates = [
+            root.appendingPathComponent("packages/SHA256SUMS"),
+            root.appendingPathComponent("_boris/SHA256SUMS"),
+            root.appendingPathComponent("SHA256SUMS"),
+            root.appendingPathComponent("vendor/boris-agent-kit/SHA256SUMS"),
+        ]
+        checksumEntries = []
+        for candidate in checksumCandidates {
+            if let text = try? String(contentsOf: candidate, encoding: .utf8) {
+                let parsed = PackageChecksumEntry.parse(from: text)
+                if !parsed.isEmpty {
+                    checksumEntries = parsed
+                    break
+                }
+            }
+        }
     }
 }
 

--- a/Tests/ContractTests/PublishContractTests.swift
+++ b/Tests/ContractTests/PublishContractTests.swift
@@ -58,4 +58,140 @@ final class PublishContractTests: XCTestCase {
         ]
         XCTAssertEqual(expectedEvidenceFiles.count, 5)
     }
+
+    func testProofPackDocumentDecoding() throws {
+        let json = """
+        {
+          "format": "boris-proof-pack",
+          "schema_version": 1,
+          "digest": "sha256:abcd1234efgh5678",
+          "generated_at": "2026-08-17T20:00:00Z",
+          "claims": [
+            {
+              "id": "claim-deterministic-build",
+              "statement": "Build output is byte-for-byte reproducible.",
+              "category": "integrity",
+              "status": "verified",
+              "evidence": ["artifacts.json", "touches.json"]
+            },
+            {
+              "id": "claim-no-active-svg",
+              "statement": "No active SVG or script elements detected in media.",
+              "category": "security",
+              "verified": true
+            }
+          ],
+          "checks": [
+            {
+              "name": "Check asset checksums",
+              "status": "passed",
+              "message": "All 42 assets match recorded SHA256",
+              "target": "dist/assets"
+            },
+            {
+              "name": "Check link consistency",
+              "passed": true,
+              "target": "dist/"
+            }
+          ],
+          "limitations": [
+            "Search index does not cover external media descriptions."
+          ]
+        }
+        """
+        let doc = try JSONDecoder().decode(ProofPackDocument.self, from: Data(json.utf8))
+        XCTAssertEqual(doc.format, "boris-proof-pack")
+        XCTAssertEqual(doc.digest, "sha256:abcd1234efgh5678")
+        XCTAssertEqual(doc.claims?.count, 2)
+        XCTAssertEqual(doc.claims?[0].isVerified, true)
+        XCTAssertEqual(doc.claims?[0].displayText, "Build output is byte-for-byte reproducible.")
+        XCTAssertEqual(doc.checks?.count, 2)
+        XCTAssertEqual(doc.checks?[0].isPassed, true)
+        XCTAssertEqual(doc.limitations?.count, 1)
+    }
+
+    func testNostrPublishReportWithRelayVerdicts() throws {
+        let json = """
+        {
+          "format": "boris-nostr-publish",
+          "schema_version": 1,
+          "verdict": "complete",
+          "created_at": "2026-08-17T21:00:00Z",
+          "event_id": "note1xyz789",
+          "relays": [
+            {
+              "url": "wss://relay.damus.io",
+              "verdict": "complete",
+              "ok": true,
+              "message": "Saved note1xyz789"
+            },
+            {
+              "url": "wss://nos.lol",
+              "verdict": "failed",
+              "ok": false,
+              "error": "Rate limited"
+            }
+          ]
+        }
+        """
+        let report = try JSONDecoder().decode(NostrPublishReport.self, from: Data(json.utf8))
+        XCTAssertEqual(report.verdict, "complete")
+        let relays = try XCTUnwrap(report.relays)
+        XCTAssertEqual(relays.count, 2)
+        XCTAssertEqual(relays[0].relayURL, "wss://relay.damus.io")
+        XCTAssertEqual(relays[0].isSuccess, true)
+        XCTAssertEqual(relays[1].relayURL, "wss://nos.lol")
+        XCTAssertEqual(relays[1].isSuccess, false)
+        XCTAssertEqual(relays[1].displayMessage, "Rate limited")
+    }
+
+    func testMachineReadableVersionDecoding() throws {
+        let json = """
+        {
+          "format": "boris-machine-readable-version",
+          "schema_version": 1,
+          "version": "0.8.1",
+          "commit": "b82e9e2eace74d9ca61df23dffc1329d2a2fe628",
+          "compiler": "zig-0.16.0",
+          "platform": "Darwin-arm64",
+          "ir_version": "0.4.0",
+          "features": ["nip23", "standard-site", "rag", "proof-pack"]
+        }
+        """
+        let version = try JSONDecoder().decode(MachineReadableVersion.self, from: Data(json.utf8))
+        XCTAssertEqual(version.displayVersion, "0.8.1")
+        XCTAssertEqual(version.displayCommit, "b82e9e2eace74d9ca61df23dffc1329d2a2fe628")
+        XCTAssertEqual(version.displayPlatform, "Darwin-arm64")
+        XCTAssertEqual(version.features?.count, 4)
+    }
+
+    func testSHA256SUMSParsing() {
+        let text = """
+        # Boris release hashes
+        12c8cd450c4fffb47b9cb92e2468071769a6d4c13a28a961231b1b69e1555abd  bin/boris
+        56d8cd450c4fffb47b9cb92e2468071769a6d4c13a28a961231b1b69e1555abc *MACHINE-READABLE-VERSION.json
+        # empty lines below
+
+        """
+        let entries = PackageChecksumEntry.parse(from: text)
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].filename, "bin/boris")
+        XCTAssertEqual(entries[0].sha256, "12c8cd450c4fffb47b9cb92e2468071769a6d4c13a28a961231b1b69e1555abd")
+        XCTAssertEqual(entries[1].filename, "MACHINE-READABLE-VERSION.json")
+        XCTAssertEqual(entries[1].sha256, "56d8cd450c4fffb47b9cb92e2468071769a6d4c13a28a961231b1b69e1555abc")
+    }
+
+    func testCoordinatorVerbsAttributes() {
+        XCTAssertTrue(CoordinatorVerb.package.writesTree)
+        XCTAssertTrue(CoordinatorVerb.publishStandardSite.writesTree)
+        XCTAssertTrue(CoordinatorVerb.publishNostr.writesTree)
+        XCTAssertFalse(CoordinatorVerb.standardSiteVerify.writesTree)
+        XCTAssertFalse(CoordinatorVerb.standardSiteRecords.writesTree)
+        XCTAssertFalse(CoordinatorVerb.standardSiteSessions.writesTree)
+        XCTAssertFalse(CoordinatorVerb.standardSiteLogout.writesTree)
+        XCTAssertFalse(CoordinatorVerb.standardSiteSmoke.writesTree)
+        XCTAssertEqual(CoordinatorVerb.publishStandardSite.secretTarget, PublishTargets.standardSite)
+        XCTAssertEqual(CoordinatorVerb.publishNostr.secretTarget, PublishTargets.nostr)
+        XCTAssertNil(CoordinatorVerb.standardSiteVerify.secretTarget)
+    }
 }


### PR DESCRIPTION
Closes #91

- Extended Standard.site commands (verify, records, sessions, logout, smoke)
- Boris package evidence with checksum verification
- Human-readable Proof Pack claims viewer
- Per-relay Nostr publish verdicts
- GitHub Pages readable deployment plan