### PR TITLE
feat(ux): first-run and usable chrome (#88)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -95,6 +95,7 @@ targets:
       - path: Sources/Inspector/InspectorProfile.swift
       - path: Sources/Inspector/ThemeCatalog.swift
       - path: Sources/Play/Local/LocalPlayGraph.swift
+      - path: Sources/Play/Local/ProblemResolver.swift
       - path: Sources/App/CoordinatorProblems.swift
       - path: Sources/App/CoordinatorPolicy.swift
       - path: Sources/App/SaveValidateGate.swift

--- a/Sources/App/AppRuntime.swift
+++ b/Sources/App/AppRuntime.swift
@@ -9,6 +9,7 @@ final class AppRuntime {
     let engine: BorisEngine?
     let enginePath: String?
     let engineError: String?
+    private(set) var engineVersion: String
     let coordinator = Coordinator()
     let credentials = PublishCredentialManager()
 
@@ -16,26 +17,48 @@ final class AppRuntime {
         if let url = BorisBinary.locate() {
             enginePath = url.path
             do {
-                engine = try BorisEngine(binaryURL: url)
+                let eng = try BorisEngine(binaryURL: url)
+                engine = eng
                 engineError = nil
+                engineVersion = "boris"
+                Task { [weak self] in
+                    if let v = try? await eng.version() {
+                        await MainActor.run {
+                            self?.engineVersion = v.line
+                        }
+                    }
+                }
             } catch {
                 engine = nil
                 engineError = String(describing: error)
+                engineVersion = "boris not found"
             }
         } else {
             engine = nil
             enginePath = nil
             engineError = BorisEngineError.binaryNotFound.description
+            engineVersion = "boris not found"
         }
     }
 
-    var statusLine: String {
-        let engineBit: String
-        if let enginePath {
-            engineBit = "engine \(URL(fileURLWithPath: enginePath).lastPathComponent)"
+    func statusLine(selectedSourceTitle: String?) -> String {
+        let sourceTitle = selectedSourceTitle ?? "No source"
+        let verbText: String
+        let exitText: String
+        if coordinator.isRunning {
+            verbText = coordinator.verb?.rawValue ?? "running"
+            exitText = "running"
+        } else if let lastVerb = coordinator.lastVerb {
+            verbText = lastVerb.rawValue
+            exitText = coordinator.exitCode.map { "exit \($0)" } ?? "exit 0"
         } else {
-            engineBit = "engine not found"
+            verbText = coordinator.state == .watching ? "watching" : "idle"
+            exitText = coordinator.exitCode.map { "exit \($0)" } ?? "exit 0"
         }
-        return "\(coordinator.summary) · \(engineBit)"
+        return "\(sourceTitle) · \(verbText) · \(exitText) · \(engineVersion)"
+    }
+
+    var statusLine: String {
+        statusLine(selectedSourceTitle: nil)
     }
 }

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -44,9 +44,11 @@ final class Coordinator {
     private(set) var isRunning = false
     private(set) var state: CoordinatorState = .idle
     private(set) var verb: CoordinatorVerb?
+    private(set) var lastVerb: CoordinatorVerb?
     private(set) var summary = "idle"
     private(set) var exitCode: Int32?
     private(set) var problems: [ProblemItem] = []
+    private var jobStartTime: ContinuousClock.Instant?
     private var task: Task<Void, Never>?
     private var reapTask: Task<Void, Never>?
     private var watchdogTask: Task<Void, Never>?
@@ -215,6 +217,8 @@ final class Coordinator {
         isRunning = true
         state = verb.writesTree ? .building : .validating
         self.verb = verb
+        self.lastVerb = verb
+        self.jobStartTime = .now
         jobOrigin = origin
         timedOut = false
         summary = "\(verb.rawValue)…"
@@ -293,6 +297,10 @@ final class Coordinator {
         reapTask = nil
         watchdogTask?.cancel()
         watchdogTask = nil
+
+        let duration = jobStartTime.map { $0.duration(to: .now) } ?? .zero
+        jobStartTime = nil
+        JobNotificationDispatcher.notifyIfBackgrounded(verb: verb, exit: exit, duration: duration)
 
         let origin = jobOrigin
         let wasTimeout = timedOut

--- a/Sources/App/JobNotification.swift
+++ b/Sources/App/JobNotification.swift
@@ -2,6 +2,7 @@ import AppKit
 import Foundation
 import UserNotifications
 
+@MainActor
 enum JobNotificationDispatcher {
     static func notifyIfBackgrounded(
         verb: CoordinatorVerb,

--- a/Sources/App/JobNotification.swift
+++ b/Sources/App/JobNotification.swift
@@ -1,0 +1,28 @@
+import AppKit
+import Foundation
+import UserNotifications
+
+enum JobNotificationDispatcher {
+    static func notifyIfBackgrounded(
+        verb: CoordinatorVerb,
+        exit: Int32?,
+        duration: Duration
+    ) {
+        guard !NSApplication.shared.isActive else { return }
+
+        let center = UNUserNotificationCenter.current()
+        let content = UNMutableNotificationContent()
+        content.title = "Solipsist"
+        let exitStr = exit.map { "exit \($0)" } ?? "exit 0"
+        content.body = "\(verb.rawValue.capitalized) finished · \(exitStr)"
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "solipsist-job-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+
+        center.add(request) { _ in }
+    }
+}

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UserNotifications
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var pending: [URL] = []
@@ -47,6 +48,7 @@ struct SolipsistApp: App {
                 .environment(store)
                 .environment(runtime)
                 .onAppear {
+                    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
                     appDelegate.openFolder = { url in
                         Task { @MainActor in
                             store.openFromSystem(url)

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// The one window: sources | play | inspector drawer.
 ///
@@ -75,6 +76,21 @@ struct MainWindow: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             statusBar
         }
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            var handled = false
+            for provider in providers {
+                if provider.canLoadObject(ofClass: URL.self) {
+                    _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                        guard let url else { return }
+                        Task { @MainActor in
+                            store.openFromSystem(url)
+                        }
+                    }
+                    handled = true
+                }
+            }
+            return handled
+        }
         .alert("Workspace", isPresented: errorPresented) {
             Button("OK", role: .cancel) { store.lastError = nil }
         } message: {
@@ -85,19 +101,8 @@ struct MainWindow: View {
 
     private var statusBar: some View {
         HStack(spacing: 8) {
-            if let source = store.selectedSource {
-                Image(systemName: source.symbolName)
-                Text(source.title)
-                if let detail = source.detailLine {
-                    Text("·")
-                    Text(detail)
-                        .truncationMode(.middle)
-                }
-            } else {
-                Text("No source")
-            }
+            Text(runtime.statusLine(selectedSourceTitle: store.selectedSource?.title))
             Spacer()
-            Text(runtime.statusLine)
         }
         .font(.caption)
         .foregroundStyle(.secondary)

--- a/Sources/Chrome/PlayHost.swift
+++ b/Sources/Chrome/PlayHost.swift
@@ -12,11 +12,19 @@ struct PlayHost: View {
                 case .local(let source):
                     LocalPlay(source: source)
                 }
+            } else if store.sources.isEmpty {
+                EmptyStateView(
+                    title: "No Sources",
+                    systemImage: "folder.badge.plus",
+                    message: "Open a folder with boris.json (e.g. Stunts/happy) to begin.",
+                    actionTitle: "Open…",
+                    action: { store.presentOpenPanel() }
+                )
             } else {
                 EmptyStateView(
-                    title: "No Source",
-                    systemImage: "tray",
-                    message: "Open a local folder to begin."
+                    title: "No Source Selected",
+                    systemImage: "sidebar.left",
+                    message: "Select a source from the sidebar to view its publication."
                 )
             }
         }

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -30,8 +30,8 @@ struct SourceSidebar: View {
             if store.sources.isEmpty {
                 EmptyStateView(
                     title: "No Sources",
-                    systemImage: "tray",
-                    message: "Open a local folder to add a source.",
+                    systemImage: "folder.badge.plus",
+                    message: "Open a folder with boris.json (e.g. Stunts/happy) to get started.",
                     actionTitle: "Open…",
                     action: { store.presentOpenPanel() }
                 )

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -68,13 +68,20 @@ struct LocalPlay: PlaySurface {
             ContentUnavailableView {
                 Label(source.title, systemImage: "folder")
             } description: {
-                Text("This folder is no longer reachable. Remove it from the sidebar or reopen it.")
+                Text("This folder is unreachable. Relocate it or remove it from the sidebar.")
+            } actions: {
+                Button("Relocate…") {
+                    store.presentRelocatePanel(for: source.id)
+                }
+                Button("Remove", role: .destructive) {
+                    store.remove(source.id)
+                }
             }
         case .empty:
             ContentUnavailableView {
                 Label("No Pages", systemImage: "doc.text")
             } description: {
-                Text("The graph for this folder has no pages.")
+                Text("The graph for this folder has no pages. Open a folder with boris.json (e.g. Stunts/happy) to view pages.")
             }
         case .failed(let message):
             ContentUnavailableView {

--- a/Sources/Play/Local/ProblemResolver.swift
+++ b/Sources/Play/Local/ProblemResolver.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum ProblemResolution: Equatable, Sendable {
+    case page(id: String, title: String)
+    case revealFile(url: URL)
+}
+
+enum ProblemResolver {
+    static func resolve(
+        path: String,
+        source: LocalSource?,
+        graph: Graph?
+    ) -> ProblemResolution? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if let graph, let node = findMatchingNode(in: graph, forPath: trimmed) {
+            return .page(id: node.id, title: node.title)
+        }
+
+        if let url = resolveFileURL(path: trimmed, source: source) {
+            return .revealFile(url: url)
+        }
+
+        return nil
+    }
+
+    static func findMatchingNode(in graph: Graph, forPath path: String) -> GraphNode? {
+        let normalized = path.trimmingCharacters(in: CharacterSet(charactersIn: "/."))
+        return graph.nodes.first { node in
+            if node.sourcePath == path || node.sourcePath == normalized {
+                return true
+            }
+            let nodeNorm = node.sourcePath.trimmingCharacters(in: CharacterSet(charactersIn: "/."))
+            if nodeNorm == normalized {
+                return true
+            }
+            if path.hasSuffix("/" + node.sourcePath) || path.hasSuffix("/" + nodeNorm) {
+                return true
+            }
+            return false
+        }
+    }
+
+    static func resolveFileURL(path: String, source: LocalSource?) -> URL? {
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path)
+        }
+        guard let source else { return nil }
+        if let contentRoot = try? source.contentRoot() {
+            return contentRoot.appendingPathComponent(path)
+        }
+        if let root = try? source.resolve().url {
+            return root.appendingPathComponent(path)
+        }
+        return nil
+    }
+}

--- a/Sources/Play/Local/ProblemsPane.swift
+++ b/Sources/Play/Local/ProblemsPane.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Activity / problems under the graph list. Reads the coordinator only.
@@ -45,8 +46,34 @@ struct ProblemsPane: View {
                     let item = runtime.coordinator.problems.first(where: { $0.id == id }),
                     let path = item.path
                 else { return }
-                let pageID = (path as NSString).deletingPathExtension
-                store.select(noun: WorkspaceNoun(kind: "page", id: pageID, title: pageID))
+
+                let localSource: LocalSource?
+                if case .local(let src) = store.selectedSource {
+                    localSource = src
+                } else {
+                    localSource = nil
+                }
+
+                var graph: Graph?
+                if let localSource, let root = try? localSource.resolve().url {
+                    let graphURL = root
+                        .appendingPathComponent(".boris", isDirectory: true)
+                        .appendingPathComponent("graph.json")
+                    if let data = try? Data(contentsOf: graphURL) {
+                        graph = try? JSONDecoder().decode(Graph.self, from: data)
+                    }
+                }
+
+                guard let resolution = ProblemResolver.resolve(path: path, source: localSource, graph: graph) else {
+                    return
+                }
+
+                switch resolution {
+                case .page(let pageID, let pageTitle):
+                    store.select(noun: WorkspaceNoun(kind: "page", id: pageID, title: pageTitle))
+                case .revealFile(let url):
+                    NSWorkspace.shared.activateFileViewerSelecting([url])
+                }
             }
         )
     }

--- a/Tests/ContractTests/ProblemResolverTests.swift
+++ b/Tests/ContractTests/ProblemResolverTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+final class ProblemResolverTests: XCTestCase {
+    private var sampleGraph: Graph {
+        Graph(
+            schemaVersion: "0.4.0",
+            frozen: true,
+            nodes: [
+                GraphNode(
+                    index: 0,
+                    id: "index",
+                    sourcePath: "index.md",
+                    role: .trunk,
+                    parent: nil,
+                    parentIndex: nil,
+                    title: "Home",
+                    status: "published",
+                    tags: nil
+                ),
+                GraphNode(
+                    index: 1,
+                    id: "about-team",
+                    sourcePath: "about/team.md",
+                    role: .satellite,
+                    parent: "index",
+                    parentIndex: 0,
+                    title: "Our Team",
+                    status: "draft",
+                    tags: nil
+                )
+            ],
+            edges: [],
+            reverseIndex: [],
+            nav: []
+        )
+    }
+
+    func testExactMatchResolvesToPage() {
+        let resolution = ProblemResolver.resolve(
+            path: "index.md",
+            source: nil,
+            graph: sampleGraph
+        )
+        XCTAssertEqual(resolution, .page(id: "index", title: "Home"))
+    }
+
+    func testNestedPathResolvesToPage() {
+        let resolution = ProblemResolver.resolve(
+            path: "about/team.md",
+            source: nil,
+            graph: sampleGraph
+        )
+        XCTAssertEqual(resolution, .page(id: "about-team", title: "Our Team"))
+    }
+
+    func testPathWithLeadingSlashResolvesToPage() {
+        let resolution = ProblemResolver.resolve(
+            path: "/about/team.md",
+            source: nil,
+            graph: sampleGraph
+        )
+        XCTAssertEqual(resolution, .page(id: "about-team", title: "Our Team"))
+    }
+
+    func testNonGraphFileResolvesToRevealFileWithoutInventingId() {
+        let resolution = ProblemResolver.resolve(
+            path: "/path/to/project/boris.json",
+            source: nil,
+            graph: sampleGraph
+        )
+        XCTAssertEqual(
+            resolution,
+            .revealFile(url: URL(fileURLWithPath: "/path/to/project/boris.json"))
+        )
+    }
+
+    func testUnknownRelativePathWithoutSourceFallsBackGracefully() {
+        let resolution = ProblemResolver.resolve(
+            path: "unknown.md",
+            source: nil,
+            graph: sampleGraph
+        )
+        XCTAssertNil(resolution)
+    }
+
+    func testEmptyPathResolvesToNil() {
+        let resolution = ProblemResolver.resolve(
+            path: "   ",
+            source: nil,
+            graph: sampleGraph
+        )
+        XCTAssertNil(resolution)
+    }
+}


### PR DESCRIPTION
Closes #88

- First-run guidance for new users
- Clean status bar formatting
- Problem diagnostic resolution to real graph page or Reveal in Finder
- Drag-and-drop local folder support
- Background job completion notifications
- Unavailable source Relocate/Remove UX