### PR TITLE
feat(play): graph filtering, check badges, activity and plan view (#89)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -95,6 +95,7 @@ targets:
       - path: Sources/Inspector/InspectorProfile.swift
       - path: Sources/Inspector/ThemeCatalog.swift
       - path: Sources/Play/Local/LocalPlayGraph.swift
+      - path: Sources/App/CoordinatorActivity.swift
       - path: Sources/App/CoordinatorProblems.swift
       - path: Sources/App/CoordinatorPolicy.swift
       - path: Sources/App/SaveValidateGate.swift

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -1,43 +1,7 @@
 import Foundation
 import Observation
 
-enum CoordinatorVerb: String, Sendable {
-    case plan
-    case validate
-    case buildIR
-    case buildHTML
-    case buildThis = "build this"
-    case buildAll
-    case check
-    case impact
-    case publishStandardSite = "publish Standard.site"
-    case publishNostr = "publish Nostr"
 
-    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof).
-    var writesTree: Bool {
-        switch self {
-        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr:
-            true
-        case .plan, .validate, .check, .impact:
-            false
-        }
-    }
-
-    var timeout: Duration {
-        writesTree ? CoordinatorPolicy.buildTimeout : CoordinatorPolicy.oneShotTimeout
-    }
-
-    var secretTarget: String? {
-        switch self {
-        case .publishNostr: PublishTargets.nostr
-        case .publishStandardSite: PublishTargets.standardSite
-        default: nil
-        }
-    }
-}
-
-/// Menu verbs against `BorisEngine`. One job at a time. Play and the
-/// status bar read this; they do not spawn `boris`.
 @MainActor
 @Observable
 final class Coordinator {
@@ -47,6 +11,10 @@ final class Coordinator {
     private(set) var summary = "idle"
     private(set) var exitCode: Int32?
     private(set) var problems: [ProblemItem] = []
+    private(set) var activityHistory: [CoordinatorActivity] = []
+    private(set) var latestPlan: PublicationPlan?
+    private(set) var latestCheckReport: AnalysisReport?
+    private(set) var checkFindings: [AnalysisFinding] = []
     private var task: Task<Void, Never>?
     private var reapTask: Task<Void, Never>?
     private var watchdogTask: Task<Void, Never>?
@@ -67,6 +35,10 @@ final class Coordinator {
     private enum JobOrigin {
         case manual
         case save
+    }
+
+    func clearActivity() {
+        activityHistory.removeAll()
     }
 
     var canRunVerb: Bool { state == .idle || state == .watching }
@@ -231,6 +203,7 @@ final class Coordinator {
             self.handleTimeout(runtime: runtime)
         }
 
+        let startTime = ContinuousClock.now
         let noun = store.selection.noun
         task = Task {
             let result = await Self.perform(
@@ -240,15 +213,29 @@ final class Coordinator {
                 engine: engine,
                 secret: secret
             )
+            let elapsed = startTime.duration(to: .now)
+            let (secs, attos) = elapsed.components
+            let elapsedNs = Int(secs * 1_000_000_000) + Int(attos / 1_000_000_000)
+            let durationNs = result.timings?.totalNs ?? result.totalDurationNs ?? elapsedNs
+
             guard !Task.isCancelled else {
-                self.finish(verb: verb, exit: result.exit, summary: "cancelled", problems: result.problems)
+                self.finish(
+                    verb: verb,
+                    exit: result.exit,
+                    summary: "cancelled",
+                    problems: result.problems,
+                    result: result,
+                    durationNs: durationNs
+                )
                 return
             }
             self.finish(
                 verb: verb,
                 exit: result.exit,
                 summary: result.summary,
-                problems: result.problems
+                problems: result.problems,
+                result: result,
+                durationNs: durationNs
             )
         }
     }
@@ -284,7 +271,9 @@ final class Coordinator {
         verb: CoordinatorVerb,
         exit: Int32?,
         summary: String,
-        problems: [ProblemItem]
+        problems: [ProblemItem],
+        result: JobResult? = nil,
+        durationNs: Int? = nil
     ) {
         if verb.writesTree {
             endTreeWrite()
@@ -313,6 +302,28 @@ final class Coordinator {
             self.summary = summary
             self.problems = problems
         }
+        if let plan = result?.plan {
+            self.latestPlan = plan
+        }
+        if let checkReport = result?.checkReport {
+            self.latestCheckReport = checkReport
+            self.checkFindings = checkReport.findings
+        }
+
+        let activity = CoordinatorActivity(
+            verb: verb,
+            exitCode: exit,
+            summary: self.summary,
+            timestamp: Date(),
+            durationNs: durationNs,
+            timings: result?.timings,
+            problemsCount: self.problems.count
+        )
+        activityHistory.insert(activity, at: 0)
+        if activityHistory.count > 50 {
+            activityHistory.removeLast(activityHistory.count - 50)
+        }
+
         task = nil
         state = (activeWatch?.isRunning == true) ? .watching : .idle
 
@@ -347,6 +358,10 @@ final class Coordinator {
         var exit: Int32?
         var summary: String
         var problems: [ProblemItem]
+        var plan: PublicationPlan? = nil
+        var checkReport: AnalysisReport? = nil
+        var timings: TimingsReport? = nil
+        var totalDurationNs: Int? = nil
     }
 
     private static func takeOrPromptSecret(
@@ -401,7 +416,7 @@ final class Coordinator {
                 } else {
                     problems = []
                 }
-                return JobResult(exit: result.exitCode, summary: summary, problems: problems)
+                return JobResult(exit: result.exitCode, summary: summary, problems: problems, plan: result.plan)
 
             case .validate:
                 let reportURL = FileManager.default.temporaryDirectory
@@ -446,7 +461,9 @@ final class Coordinator {
                 return JobResult(
                     exit: result.exitCode,
                     summary: "IR exit \(result.exitCode) · \(pages) · \(result.report.errorCount ?? items.count) error(s)",
-                    problems: items
+                    problems: items,
+                    timings: result.timings,
+                    totalDurationNs: result.timings?.totalNs
                 )
 
             case .buildHTML:
@@ -510,7 +527,7 @@ final class Coordinator {
                 let exit = result.isSuccess ? 0 : (result.results.last?.exitCode ?? 1)
                 let dur = result.totalDurationNs.map { "(\($0 / 1_000_000)ms)" } ?? ""
                 let summary = "Build all \(result.isSuccess ? "succeeded" : "failed") · \(result.results.count) entry(s) \(dur)"
-                return JobResult(exit: exit, summary: summary, problems: items)
+                return JobResult(exit: exit, summary: summary, problems: items, totalDurationNs: result.totalDurationNs)
 
             case .check:
                 let result = try await engine.check(
@@ -528,7 +545,8 @@ final class Coordinator {
                 return JobResult(
                     exit: result.exitCode,
                     summary: "check exit \(result.exitCode) · \(s.pages) pages · \(s.unreferencedPages) unreferenced",
-                    problems: items
+                    problems: items,
+                    checkReport: result.report
                 )
 
             case .impact:
@@ -637,7 +655,9 @@ final class Coordinator {
             return JobResult(
                 exit: result.exitCode,
                 summary: "\(target.name) exit \(result.exitCode) · \(items.count) problem(s)",
-                problems: items
+                problems: items,
+                timings: result.timings,
+                totalDurationNs: result.timings?.totalNs
             )
 
         case "edition":
@@ -670,7 +690,9 @@ final class Coordinator {
             return JobResult(
                 exit: result.exitCode,
                 summary: "\(spec.kind) exit \(result.exitCode) · \(items.count) problem(s)",
-                problems: items
+                problems: items,
+                timings: result.timings,
+                totalDurationNs: result.timings?.totalNs
             )
 
         default:

--- a/Sources/App/CoordinatorActivity.swift
+++ b/Sources/App/CoordinatorActivity.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+enum CoordinatorVerb: String, Sendable {
+    case plan
+    case validate
+    case buildIR
+    case buildHTML
+    case buildThis = "build this"
+    case buildAll
+    case check
+    case impact
+    case publishStandardSite = "publish Standard.site"
+    case publishNostr = "publish Nostr"
+
+    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof).
+    var writesTree: Bool {
+        switch self {
+        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr:
+            true
+        case .plan, .validate, .check, .impact:
+            false
+        }
+    }
+
+    var timeout: Duration {
+        writesTree ? CoordinatorPolicy.buildTimeout : CoordinatorPolicy.oneShotTimeout
+    }
+
+    var secretTarget: String? {
+        switch self {
+        case .publishNostr: PublishTargets.nostr
+        case .publishStandardSite: PublishTargets.standardSite
+        default: nil
+        }
+    }
+}
+
+/// An execution record in the Coordinator activity history.
+struct CoordinatorActivity: Identifiable, Sendable {
+    let id: UUID
+    let verb: CoordinatorVerb
+    let exitCode: Int32?
+    let summary: String
+    let timestamp: Date
+    let durationNs: Int?
+    let timings: TimingsReport?
+    let problemsCount: Int
+
+    init(
+        id: UUID = UUID(),
+        verb: CoordinatorVerb,
+        exitCode: Int32?,
+        summary: String,
+        timestamp: Date = Date(),
+        durationNs: Int? = nil,
+        timings: TimingsReport? = nil,
+        problemsCount: Int = 0
+    ) {
+        self.id = id
+        self.verb = verb
+        self.exitCode = exitCode
+        self.summary = summary
+        self.timestamp = timestamp
+        self.durationNs = durationNs
+        self.timings = timings
+        self.problemsCount = problemsCount
+    }
+
+    var isSuccess: Bool {
+        exitCode == 0
+    }
+}

--- a/Sources/Play/Local/ActivityPane.swift
+++ b/Sources/Play/Local/ActivityPane.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+/// Activity pane (M3 / #89): shows execution history for the last N coordinator jobs,
+/// tracking verb, exit code, execution timings duration, problem counts, and diagnostics.
+struct ActivityPane: View {
+    @Environment(AppRuntime.self) private var runtime
+
+    var body: some View {
+        Group {
+            if runtime.coordinator.activityHistory.isEmpty {
+                ContentUnavailableView {
+                    Label("No Activity", systemImage: "clock")
+                } description: {
+                    Text("Jobs run by the coordinator will appear here.")
+                }
+            } else {
+                activityList
+            }
+        }
+    }
+
+    private var activityList: some View {
+        List {
+            Section {
+                ForEach(runtime.coordinator.activityHistory) { item in
+                    ActivityRow(activity: item)
+                }
+            } header: {
+                HStack {
+                    Text("History (\(runtime.coordinator.activityHistory.count))")
+                    Spacer()
+                    Button("Clear") {
+                        runtime.coordinator.clearActivity()
+                    }
+                    .controlSize(.small)
+                }
+            }
+        }
+        .listStyle(.inset(alternatesRowBackgrounds: true))
+    }
+}
+
+private struct ActivityRow: View {
+    let activity: CoordinatorActivity
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 8) {
+                statusIcon
+                Text(activity.verb.rawValue)
+                    .font(.headline)
+                Spacer()
+                if let duration = activity.durationNs {
+                    Text(formatDuration(duration))
+                        .font(.caption.monospacedDigit())
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1.5)
+                        .background(Color.secondary.opacity(0.12))
+                        .clipShape(Capsule())
+                }
+                if let exit = activity.exitCode {
+                    Text("exit \(exit)")
+                        .font(.caption.weight(.medium).monospacedDigit())
+                        .foregroundStyle(exit == 0 ? Color.secondary : Color.red)
+                }
+                Text(activity.timestamp.formatted(date: .omitted, time: .standard))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(activity.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+
+            if activity.timings != nil {
+                DisclosureGroup("Timings breakdown", isExpanded: $isExpanded) {
+                    if let timings = activity.timings {
+                        VStack(alignment: .leading, spacing: 4) {
+                            if let mode = timings.mode {
+                                LabeledContent("Mode", value: mode)
+                                    .font(.caption)
+                            }
+                            if let totalNs = timings.totalNs {
+                                LabeledContent("Reported Total", value: formatDuration(totalNs))
+                                    .font(.caption)
+                            }
+                            if let phases = timings.phases, !phases.isEmpty {
+                                Text("Phases:")
+                                    .font(.caption.weight(.medium))
+                                    .padding(.top, 2)
+                                ForEach(phases.keys.sorted(), id: \.self) { phase in
+                                    if let durationNs = phases[phase] {
+                                        LabeledContent(phase, value: formatDuration(durationNs))
+                                            .font(.caption2.monospacedDigit())
+                                    }
+                                }
+                            }
+                            if let counters = timings.counters {
+                                Text("Counters:")
+                                    .font(.caption.weight(.medium))
+                                    .padding(.top, 2)
+                                if let reads = counters.page_reads {
+                                    LabeledContent("Page Reads", value: "\(reads)")
+                                        .font(.caption2.monospacedDigit())
+                                }
+                                if let inc = counters.include_reads {
+                                    LabeledContent("Include Reads", value: "\(inc)")
+                                        .font(.caption2.monospacedDigit())
+                                }
+                                if let fast = counters.fast_path_hits {
+                                    LabeledContent("Fast Path Hits", value: "\(fast)")
+                                        .font(.caption2.monospacedDigit())
+                                }
+                                if let bytes = counters.hash_bytes {
+                                    LabeledContent("Hash Bytes", value: "\(bytes)")
+                                        .font(.caption2.monospacedDigit())
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        if activity.isSuccess {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .imageScale(.medium)
+        } else {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+                .imageScale(.medium)
+        }
+    }
+
+    private func formatDuration(_ ns: Int) -> String {
+        if ns < 1_000 {
+            return "\(ns) ns"
+        } else if ns < 1_000_000 {
+            return "\(ns / 1_000) µs"
+        } else if ns < 1_000_000_000 {
+            return "\(ns / 1_000_000) ms"
+        } else {
+            let seconds = Double(ns) / 1_000_000_000.0
+            return String(format: "%.2f s", seconds)
+        }
+    }
+}

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -10,16 +10,20 @@ struct LocalPlay: PlaySurface {
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
+
     enum PlayTab: String, CaseIterable, Identifiable {
         case pages = "Pages"
         case outputs = "Outputs"
         case publish = "Publish"
+        case plan = "Plan"
+        case activity = "Activity"
 
         var id: String { rawValue }
     }
 
     @State private var selectedTab: PlayTab = .pages
     @State private var state: LoadState = .idle
+    @State private var searchText = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -41,6 +45,10 @@ struct LocalPlay: PlaySurface {
                 OutputsPane(source: source)
             case .publish:
                 PublishPane(source: source)
+            case .plan:
+                PlanPane(source: source)
+            case .activity:
+                ActivityPane()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -48,13 +56,20 @@ struct LocalPlay: PlaySurface {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
                 Divider()
-                ProblemsPane()
+                ProblemsPane(pages: loadedPages)
                     .frame(minHeight: 88, idealHeight: 148, maxHeight: 220)
             }
         }
         .task(id: source.id) {
             await load()
         }
+    }
+
+    private var loadedPages: [PlayPage] {
+        if case .ready(let pages) = state {
+            return pages
+        }
+        return []
     }
 
     @ViewBuilder
@@ -92,11 +107,19 @@ struct LocalPlay: PlaySurface {
     // MARK: - List
 
     private func pageList(_ pages: [PlayPage]) -> some View {
-        List(pages, selection: selectedPageID) { page in
-            PageRow(page: page)
-                .tag(page.id)
+        let filtered = LocalPlayGraph.filter(pages: pages, query: searchText)
+        return Group {
+            if filtered.isEmpty, !searchText.isEmpty {
+                ContentUnavailableView.search(text: searchText)
+            } else {
+                List(filtered, selection: selectedPageID) { page in
+                    PageRow(page: page, findings: runtime.coordinator.checkFindings)
+                        .tag(page.id)
+                }
+                .listStyle(.inset(alternatesRowBackgrounds: true))
+            }
         }
-        .listStyle(.inset(alternatesRowBackgrounds: true))
+        .searchable(text: $searchText, prompt: "Filter by title, id, tag, or status…")
     }
 
     private var selectedPageID: Binding<String?> {
@@ -236,6 +259,7 @@ struct LocalPlay: PlaySurface {
 
 private struct PageRow: View {
     let page: PlayPage
+    let findings: [AnalysisFinding]
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -254,11 +278,46 @@ private struct PageRow: View {
                     .lineLimit(1)
             }
             Spacer(minLength: 8)
-            Text(page.status)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
+
+            ForEach(pageFindings, id: \.code) { finding in
+                FindingBadge(finding: finding)
+            }
+
+            if !page.status.isEmpty {
+                Text(page.status)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
         }
         .help("\(page.title) · \(page.status) · \(page.id)")
+    }
+
+    private var pageFindings: [AnalysisFinding] {
+        findings.filter { $0.type == "page" && $0.value == page.id }
+    }
+}
+
+private struct FindingBadge: View {
+    let finding: AnalysisFinding
+
+    var body: some View {
+        Text(badgeLabel)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.orange.opacity(0.15))
+            .foregroundStyle(.orange)
+            .clipShape(Capsule())
+            .help("\(finding.code): \(finding.value) (count \(finding.count))")
+    }
+
+    private var badgeLabel: String {
+        switch finding.code {
+        case "WUNREFERENCED":
+            return "unreferenced"
+        default:
+            return finding.code
+        }
     }
 }

--- a/Sources/Play/Local/LocalPlayGraph.swift
+++ b/Sources/Play/Local/LocalPlayGraph.swift
@@ -9,6 +9,26 @@ struct PlayPage: Identifiable, Hashable, Sendable {
     let status: String
     let role: PageRole
     let depth: Int
+    let tags: [String]
+    let sourcePath: String
+
+    init(
+        id: String,
+        title: String,
+        status: String = "",
+        role: PageRole = .trunk,
+        depth: Int = 0,
+        tags: [String] = [],
+        sourcePath: String = ""
+    ) {
+        self.id = id
+        self.title = title
+        self.status = status
+        self.role = role
+        self.depth = depth
+        self.tags = tags
+        self.sourcePath = sourcePath
+    }
 }
 
 enum LocalPlayGraph {
@@ -34,7 +54,9 @@ enum LocalPlayGraph {
                     title: node.title,
                     status: node.status ?? "",
                     role: node.role,
-                    depth: depth
+                    depth: depth,
+                    tags: node.tags ?? [],
+                    sourcePath: node.sourcePath
                 )
             )
             for child in children[node.id] ?? [] {
@@ -50,5 +72,74 @@ enum LocalPlayGraph {
             emit(node, depth: 0)
         }
         return rows
+    }
+
+    /// Filter pages by query string matching title, id, tag, or status.
+    /// Supports prefixes: `tag:`, `status:`, `id:`, `title:`.
+    static func filter(pages: [PlayPage], query: String) -> [PlayPage] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return pages }
+        let tokens = trimmed.split(separator: " ").map { String($0) }
+        return pages.filter { page in
+            tokens.allSatisfy { token in
+                pageMatches(page: page, token: token)
+            }
+        }
+    }
+
+    private static func pageMatches(page: PlayPage, token: String) -> Bool {
+        let lower = token.lowercased()
+        if lower.hasPrefix("tag:") {
+            let val = String(lower.dropFirst(4))
+            return page.tags.contains { $0.lowercased().contains(val) }
+        }
+        if lower.hasPrefix("status:") {
+            let val = String(lower.dropFirst(7))
+            return page.status.lowercased().contains(val)
+        }
+        if lower.hasPrefix("id:") {
+            let val = String(lower.dropFirst(3))
+            return page.id.lowercased().contains(val)
+        }
+        if lower.hasPrefix("title:") {
+            let val = String(lower.dropFirst(6))
+            return page.title.lowercased().contains(val)
+        }
+        return page.title.localizedCaseInsensitiveContains(token)
+            || page.id.localizedCaseInsensitiveContains(token)
+            || page.status.localizedCaseInsensitiveContains(token)
+            || page.tags.contains { $0.localizedCaseInsensitiveContains(token) }
+    }
+
+    /// Resolves a diagnostic source path (e.g. "guides/getting-started.md" or "index.md")
+    /// against known pages to find the corresponding page.
+    static func resolvePage(forSourcePath path: String, in pages: [PlayPage]) -> PlayPage? {
+        let normalized = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+
+        // 1. Exact match on sourcePath
+        if let match = pages.first(where: { $0.sourcePath == normalized }) {
+            return match
+        }
+
+        // 2. Exact match on id
+        if let match = pages.first(where: { $0.id == normalized }) {
+            return match
+        }
+
+        // 3. Match without path extension
+        let withoutExt = (normalized as NSString).deletingPathExtension
+        if let match = pages.first(where: { $0.id == withoutExt || $0.sourcePath == withoutExt }) {
+            return match
+        }
+
+        // 4. Suffix match
+        if let match = pages.first(where: {
+            $0.sourcePath.hasSuffix("/" + normalized) || normalized.hasSuffix("/" + $0.sourcePath)
+        }) {
+            return match
+        }
+
+        return nil
     }
 }

--- a/Sources/Play/Local/PlanPane.swift
+++ b/Sources/Play/Local/PlanPane.swift
@@ -78,18 +78,22 @@ struct PlanPane: View {
             if let pub = plan.publication {
                 Section("Publication Declaration") {
                     LabeledContent("Target", value: pub.target)
-                    LabeledContent("Base URL", value: pub.base_url)
-                    LabeledContent("Origin", value: pub.origin)
+                    if !pub.base_url.isEmpty {
+                        LabeledContent("Base URL", value: pub.base_url)
+                    }
+                    if !pub.origin.isEmpty {
+                        LabeledContent("Origin", value: pub.origin)
+                    }
                     if !pub.base_path.isEmpty {
                         LabeledContent("Base Path", value: pub.base_path)
                     }
-                    if let did = pub.did {
+                    if let did = pub.did, !did.isEmpty {
                         LabeledContent("DID", value: did)
                     }
-                    if let name = pub.name {
+                    if let name = pub.name, !name.isEmpty {
                         LabeledContent("Site Name", value: name)
                     }
-                    if let siteKind = pub.site_kind {
+                    if let siteKind = pub.site_kind, !siteKind.isEmpty {
                         LabeledContent("Site Kind", value: siteKind)
                     }
                     if let includes = pub.include, !includes.isEmpty {

--- a/Sources/Play/Local/PlanPane.swift
+++ b/Sources/Play/Local/PlanPane.swift
@@ -78,14 +78,14 @@ struct PlanPane: View {
             if let pub = plan.publication {
                 Section("Publication Declaration") {
                     LabeledContent("Target", value: pub.target)
-                    if !pub.base_url.isEmpty {
-                        LabeledContent("Base URL", value: pub.base_url)
+                    if let baseUrl = pub.base_url, !baseUrl.isEmpty {
+                        LabeledContent("Base URL", value: baseUrl)
                     }
-                    if !pub.origin.isEmpty {
-                        LabeledContent("Origin", value: pub.origin)
+                    if let origin = pub.origin, !origin.isEmpty {
+                        LabeledContent("Origin", value: origin)
                     }
-                    if !pub.base_path.isEmpty {
-                        LabeledContent("Base Path", value: pub.base_path)
+                    if let basePath = pub.base_path, !basePath.isEmpty {
+                        LabeledContent("Base Path", value: basePath)
                     }
                     if let did = pub.did, !did.isEmpty {
                         LabeledContent("DID", value: did)

--- a/Sources/Play/Local/PlanPane.swift
+++ b/Sources/Play/Local/PlanPane.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+
+/// Read-only document view for a decoded PublicationPlan (M8 / #89).
+/// Shows declared targets, projections, inputs, site metadata, and editions.
+struct PlanPane: View {
+    let source: LocalSource
+
+    @Environment(WorkspaceStore.self) private var store
+    @Environment(AppRuntime.self) private var runtime
+    @State private var plan: PublicationPlan?
+
+    var body: some View {
+        Group {
+            if let plan = activePlan {
+                planDocument(plan)
+            } else {
+                ContentUnavailableView {
+                    Label("No Publication Plan", systemImage: "doc.plaintext")
+                } description: {
+                    Text("No publication plan has been computed yet. Run plan to inspect declared outputs.")
+                } actions: {
+                    Button("Plan Publication") {
+                        runtime.coordinator.run(.plan, store: store, runtime: runtime)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!runtime.coordinator.canRunVerb)
+                }
+            }
+        }
+        .task(id: source.id) {
+            loadIfPossible()
+        }
+    }
+
+    private var activePlan: PublicationPlan? {
+        runtime.coordinator.latestPlan ?? plan
+    }
+
+    private func planDocument(_ plan: PublicationPlan) -> some View {
+        List {
+            Section {
+                LabeledContent("Format", value: plan.format)
+                if let version = plan.schema_version {
+                    LabeledContent("Schema Version", value: "\(version)")
+                }
+                if let input = plan.input {
+                    LabeledContent("Input Root", value: input)
+                }
+                if let format = plan.input_format {
+                    LabeledContent("Input Format", value: format)
+                }
+            } header: {
+                HStack {
+                    Text("Publication Plan Overview")
+                    Spacer()
+                    Button("Re-plan") {
+                        runtime.coordinator.run(.plan, store: store, runtime: runtime)
+                    }
+                    .controlSize(.small)
+                    .disabled(!runtime.coordinator.canRunVerb)
+                }
+            }
+
+            if let site = plan.site {
+                Section("Site Metadata") {
+                    if let title = site.title {
+                        LabeledContent("Title", value: title)
+                    }
+                    if let url = site.url {
+                        LabeledContent("URL", value: url)
+                    }
+                    if let desc = site.description {
+                        LabeledContent("Description", value: desc)
+                    }
+                }
+            }
+
+            if let pub = plan.publication {
+                Section("Publication Declaration") {
+                    LabeledContent("Target", value: pub.target)
+                    LabeledContent("Base URL", value: pub.base_url)
+                    LabeledContent("Origin", value: pub.origin)
+                    if !pub.base_path.isEmpty {
+                        LabeledContent("Base Path", value: pub.base_path)
+                    }
+                    if let did = pub.did {
+                        LabeledContent("DID", value: did)
+                    }
+                    if let name = pub.name {
+                        LabeledContent("Site Name", value: name)
+                    }
+                    if let siteKind = pub.site_kind {
+                        LabeledContent("Site Kind", value: siteKind)
+                    }
+                    if let includes = pub.include, !includes.isEmpty {
+                        LabeledContent("Include", value: includes.joined(separator: ", "))
+                    }
+                    if let excludes = pub.exclude, !excludes.isEmpty {
+                        LabeledContent("Exclude", value: excludes.joined(separator: ", "))
+                    }
+                }
+            }
+
+            if let targets = plan.targets, !targets.isEmpty {
+                Section("Declared Targets (\(targets.count))") {
+                    ForEach(targets, id: \.name) { target in
+                        PlanTargetRow(target: target)
+                    }
+                }
+            }
+
+            if let editions = plan.editions {
+                Section("Declared Editions") {
+                    if let ir = editions.ir {
+                        LabeledContent("IR", value: ir.output)
+                    }
+                    if let rag = editions.rag {
+                        VStack(alignment: .leading, spacing: 4) {
+                            LabeledContent("RAG Output", value: rag.output)
+                            if let scope = rag.scope {
+                                LabeledContent("Scope", value: scope)
+                            }
+                            if let split = rag.split_size {
+                                LabeledContent("Split Size", value: "\(split) bytes")
+                            }
+                        }
+                    }
+                    if let context = editions.context {
+                        VStack(alignment: .leading, spacing: 4) {
+                            LabeledContent("Context Output", value: context.output)
+                            if let scope = context.scope {
+                                LabeledContent("Scope", value: scope)
+                            }
+                            if let split = context.split_size {
+                                LabeledContent("Split Size", value: "\(split) bytes")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.inset(alternatesRowBackgrounds: true))
+    }
+
+    private func loadIfPossible() {
+        if runtime.coordinator.latestPlan == nil,
+           runtime.coordinator.canRunVerb,
+           source.profileURL() != nil {
+            runtime.coordinator.run(.plan, store: store, runtime: runtime)
+        }
+    }
+}
+
+private struct PlanTargetRow: View {
+    let target: PublicationPlanTarget
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(target.name)
+                    .font(.headline)
+                Spacer()
+                Text(target.public == true ? "Public" : "Internal")
+                    .font(.caption2.weight(.medium))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.15))
+                    .clipShape(Capsule())
+            }
+
+            LabeledContent("Output Path", value: target.output)
+                .font(.caption)
+
+            if let theme = target.theme {
+                LabeledContent("Theme", value: theme)
+                    .font(.caption)
+            }
+
+            if let layout = target.layout {
+                LabeledContent("Layout", value: layout)
+                    .font(.caption)
+            }
+
+            if let projections = target.projections {
+                HStack(spacing: 6) {
+                    Text("Projections:")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if projections.html == true {
+                        ProjectionChip(title: "HTML")
+                    }
+                    if let sitemap = projections.sitemap {
+                        ProjectionChip(title: "Sitemap: \(sitemap.path)")
+                    }
+                    if let rss = projections.rss {
+                        ProjectionChip(title: "RSS: \(rss.path)")
+                    }
+                    if let llms = projections.llms {
+                        ProjectionChip(title: "LLMs: \(llms.path)")
+                    }
+                }
+                .padding(.top, 2)
+            }
+
+            if let rules = target.layout_rules, !rules.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Layout Rules:")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    ForEach(rules, id: \.selector) { rule in
+                        HStack {
+                            Text(rule.selector)
+                                .font(.caption.monospaced())
+                            Image(systemName: "arrow.right")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text(rule.layout)
+                                .font(.caption)
+                        }
+                    }
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct ProjectionChip: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1.5)
+            .background(Color.accentColor.opacity(0.12))
+            .foregroundStyle(Color.accentColor)
+            .clipShape(Capsule())
+    }
+}

--- a/Sources/Play/Local/ProblemsPane.swift
+++ b/Sources/Play/Local/ProblemsPane.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// Activity / problems under the graph list. Reads the coordinator only.
 struct ProblemsPane: View {
+    var pages: [PlayPage] = []
+
     @Environment(AppRuntime.self) private var runtime
     @Environment(WorkspaceStore.self) private var store
 
@@ -45,8 +47,12 @@ struct ProblemsPane: View {
                     let item = runtime.coordinator.problems.first(where: { $0.id == id }),
                     let path = item.path
                 else { return }
-                let pageID = (path as NSString).deletingPathExtension
-                store.select(noun: WorkspaceNoun(kind: "page", id: pageID, title: pageID))
+                if let page = LocalPlayGraph.resolvePage(forSourcePath: path, in: pages) {
+                    store.select(noun: WorkspaceNoun(kind: "page", id: page.id, title: page.title))
+                } else {
+                    let pageID = (path as NSString).deletingPathExtension
+                    store.select(noun: WorkspaceNoun(kind: "page", id: pageID, title: pageID))
+                }
             }
         )
     }

--- a/Tests/ContractTests/PlayGraphActivityPlanTests.swift
+++ b/Tests/ContractTests/PlayGraphActivityPlanTests.swift
@@ -1,0 +1,244 @@
+import XCTest
+
+final class PlayGraphActivityPlanTests: XCTestCase {
+    func testLocalPlayGraphPagesExtraction() {
+        let node1 = GraphNode(
+            index: 0,
+            id: "index",
+            sourcePath: "index.md",
+            role: .trunk,
+            parent: nil,
+            parentIndex: nil,
+            title: "Home",
+            status: "published",
+            tags: ["home", "main"]
+        )
+        let node2 = GraphNode(
+            index: 1,
+            id: "guides/intro",
+            sourcePath: "guides/intro.md",
+            role: .satellite,
+            parent: "index",
+            parentIndex: 0,
+            title: "Introduction",
+            status: "draft",
+            tags: ["guides", "starter"]
+        )
+        let graph = Graph(
+            schemaVersion: "0.3.0",
+            frozen: true,
+            nodes: [node1, node2],
+            edges: [],
+            reverseIndex: [],
+            nav: []
+        )
+
+        let pages = LocalPlayGraph.pages(from: graph)
+        XCTAssertEqual(pages.count, 2)
+        XCTAssertEqual(pages[0].id, "index")
+        XCTAssertEqual(pages[0].title, "Home")
+        XCTAssertEqual(pages[0].depth, 0)
+        XCTAssertEqual(pages[0].tags, ["home", "main"])
+        XCTAssertEqual(pages[0].sourcePath, "index.md")
+
+        XCTAssertEqual(pages[1].id, "guides/intro")
+        XCTAssertEqual(pages[1].title, "Introduction")
+        XCTAssertEqual(pages[1].depth, 1)
+        XCTAssertEqual(pages[1].tags, ["guides", "starter"])
+        XCTAssertEqual(pages[1].sourcePath, "guides/intro.md")
+    }
+
+    func testLocalPlayGraphFilterByTitleAndId() {
+        let pages = [
+            PlayPage(id: "index", title: "Home Page", status: "published", role: .trunk, depth: 0, tags: ["site"], sourcePath: "index.md"),
+            PlayPage(id: "guides/getting-started", title: "Getting Started", status: "published", role: .satellite, depth: 1, tags: ["guide"], sourcePath: "guides/getting-started.md"),
+            PlayPage(id: "guides/advanced", title: "Advanced Topics", status: "draft", role: .satellite, depth: 1, tags: ["guide", "deep-dive"], sourcePath: "guides/advanced.md"),
+            PlayPage(id: "reference/api", title: "API Reference", status: "draft", role: .satellite, depth: 1, tags: ["reference"], sourcePath: "reference/api.md")
+        ]
+
+        // Empty query returns all
+        XCTAssertEqual(LocalPlayGraph.filter(pages: pages, query: "").count, 4)
+        XCTAssertEqual(LocalPlayGraph.filter(pages: pages, query: "   ").count, 4)
+
+        // Filter by title substring
+        let titleMatches = LocalPlayGraph.filter(pages: pages, query: "getting")
+        XCTAssertEqual(titleMatches.map(\.id), ["guides/getting-started"])
+
+        // Filter by id substring
+        let idMatches = LocalPlayGraph.filter(pages: pages, query: "reference")
+        XCTAssertEqual(idMatches.map(\.id), ["reference/api"])
+
+        // Filter with prefix id:
+        let idPrefixMatches = LocalPlayGraph.filter(pages: pages, query: "id:guides")
+        XCTAssertEqual(idPrefixMatches.map(\.id), ["guides/getting-started", "guides/advanced"])
+    }
+
+    func testLocalPlayGraphFilterByTagAndStatus() {
+        let pages = [
+            PlayPage(id: "index", title: "Home Page", status: "published", role: .trunk, depth: 0, tags: ["site"], sourcePath: "index.md"),
+            PlayPage(id: "guides/getting-started", title: "Getting Started", status: "published", role: .satellite, depth: 1, tags: ["guide", "beginner"], sourcePath: "guides/getting-started.md"),
+            PlayPage(id: "guides/advanced", title: "Advanced Topics", status: "draft", role: .satellite, depth: 1, tags: ["guide", "deep-dive"], sourcePath: "guides/advanced.md"),
+            PlayPage(id: "reference/api", title: "API Reference", status: "draft", role: .satellite, depth: 1, tags: ["reference"], sourcePath: "reference/api.md")
+        ]
+
+        // Tag query (plain)
+        let tagMatches = LocalPlayGraph.filter(pages: pages, query: "deep-dive")
+        XCTAssertEqual(tagMatches.map(\.id), ["guides/advanced"])
+
+        // Tag query (prefix)
+        let tagPrefixMatches = LocalPlayGraph.filter(pages: pages, query: "tag:guide")
+        XCTAssertEqual(tagPrefixMatches.map(\.id), ["guides/getting-started", "guides/advanced"])
+
+        // Status query (plain)
+        let statusMatches = LocalPlayGraph.filter(pages: pages, query: "draft")
+        XCTAssertEqual(statusMatches.map(\.id), ["guides/advanced", "reference/api"])
+
+        // Status query (prefix)
+        let statusPrefixMatches = LocalPlayGraph.filter(pages: pages, query: "status:published")
+        XCTAssertEqual(statusPrefixMatches.map(\.id), ["index", "guides/getting-started"])
+
+        // Multi-token: tag:guide draft
+        let multiMatches = LocalPlayGraph.filter(pages: pages, query: "tag:guide draft")
+        XCTAssertEqual(multiMatches.map(\.id), ["guides/advanced"])
+    }
+
+    func testLocalPlayGraphSourcePathResolution() {
+        let pages = [
+            PlayPage(id: "index", title: "Home", status: "published", role: .trunk, depth: 0, tags: [], sourcePath: "index.md"),
+            PlayPage(id: "guides/getting-started", title: "Getting Started", status: "published", role: .satellite, depth: 1, tags: [], sourcePath: "guides/getting-started.md"),
+            PlayPage(id: "recipe/soup", title: "Hot Soup", status: "published", role: .satellite, depth: 1, tags: [], sourcePath: "recipes/soup.cook")
+        ]
+
+        // Exact sourcePath match
+        let match1 = LocalPlayGraph.resolvePage(forSourcePath: "guides/getting-started.md", in: pages)
+        XCTAssertEqual(match1?.id, "guides/getting-started")
+        XCTAssertEqual(match1?.title, "Getting Started")
+
+        // Cooklang sourcePath match
+        let match2 = LocalPlayGraph.resolvePage(forSourcePath: "recipes/soup.cook", in: pages)
+        XCTAssertEqual(match2?.id, "recipe/soup")
+        XCTAssertEqual(match2?.title, "Hot Soup")
+
+        // Exact ID match
+        let match3 = LocalPlayGraph.resolvePage(forSourcePath: "guides/getting-started", in: pages)
+        XCTAssertEqual(match3?.id, "guides/getting-started")
+
+        // Path without extension
+        let match4 = LocalPlayGraph.resolvePage(forSourcePath: "guides/getting-started", in: pages)
+        XCTAssertEqual(match4?.id, "guides/getting-started")
+
+        // Suffix match (e.g. workspace-relative path /content/index.md)
+        let match5 = LocalPlayGraph.resolvePage(forSourcePath: "content/index.md", in: pages)
+        XCTAssertEqual(match5?.id, "index")
+
+        // Unknown path returns nil
+        let fallback = LocalPlayGraph.resolvePage(forSourcePath: "unknown/orphan.md", in: pages)
+        XCTAssertNil(fallback)
+    }
+
+    func testCoordinatorActivityModel() {
+        let timings = TimingsReport(
+            format: "boris-timings",
+            schemaVersion: "1",
+            mode: "ir",
+            phases: ["scan": 1_500_000, "parse": 3_200_000],
+            counters: TimingsCounters(page_reads: 5, include_reads: 1, hash_bytes: 512, link_resolutions: 2, fast_path_hits: 1),
+            totalNs: 4_700_000
+        )
+
+        let activity = CoordinatorActivity(
+            verb: .buildIR,
+            exitCode: 0,
+            summary: "IR exit 0 · 5 pages",
+            timestamp: Date(),
+            durationNs: 4_700_000,
+            timings: timings,
+            problemsCount: 0
+        )
+
+        XCTAssertEqual(activity.verb, .buildIR)
+        XCTAssertEqual(activity.exitCode, 0)
+        XCTAssertTrue(activity.isSuccess)
+        XCTAssertEqual(activity.durationNs, 4_700_000)
+        XCTAssertEqual(activity.timings?.phases?["scan"], 1_500_000)
+        XCTAssertEqual(activity.timings?.counters?.page_reads, 5)
+
+        let failedActivity = CoordinatorActivity(
+            verb: .validate,
+            exitCode: 1,
+            summary: "validate exit 1 · 2 error(s)",
+            problemsCount: 2
+        )
+        XCTAssertFalse(failedActivity.isSuccess)
+    }
+
+    func testPublicationPlanDecoding() throws {
+        let json = """
+        {
+          "format": "boris-publication-plan",
+          "schema_version": 1,
+          "input": "content",
+          "input_format": "markdown",
+          "site": {
+            "url": "https://example.com",
+            "title": "Example Site",
+            "description": "A demo site"
+          },
+          "publication": {
+            "target": "standard-site",
+            "base_url": "https://example.com",
+            "origin": "https://example.com",
+            "base_path": "",
+            "did": "did:plc:12345",
+            "name": "Example"
+          },
+          "targets": [
+            {
+              "name": "public",
+              "output": "dist",
+              "public": true,
+              "theme": "themes/boris",
+              "layout": "default",
+              "layout_rules": [
+                { "selector": "id:index", "layout": "themes/boris/layouts/home.html" }
+              ],
+              "projections": {
+                "html": true,
+                "sitemap": { "path": "sitemap.xml", "limit": null },
+                "rss": { "path": "rss.xml", "limit": 20 },
+                "llms": { "path": "llms.txt", "limit": null }
+              }
+            }
+          ],
+          "editions": {
+            "ir": { "output": ".boris" },
+            "rag": { "output": "rag", "scope": "all", "split_size": 4096 },
+            "context": { "output": "context", "scope": "all", "split_size": 2048 }
+          }
+        }
+        """
+
+        let plan = try JSONDecoder().decode(PublicationPlan.self, from: Data(json.utf8))
+        XCTAssertEqual(plan.format, "boris-publication-plan")
+        XCTAssertEqual(plan.schema_version, 1)
+        XCTAssertEqual(plan.site?.title, "Example Site")
+        XCTAssertEqual(plan.publication?.target, "standard-site")
+        XCTAssertEqual(plan.targets?.count, 1)
+
+        let target = try XCTUnwrap(plan.targets?.first)
+        XCTAssertEqual(target.name, "public")
+        XCTAssertEqual(target.output, "dist")
+        XCTAssertEqual(target.public, true)
+        XCTAssertEqual(target.theme, "themes/boris")
+        XCTAssertEqual(target.layout_rules?.first?.selector, "id:index")
+        XCTAssertEqual(target.projections?.html, true)
+        XCTAssertEqual(target.projections?.sitemap?.path, "sitemap.xml")
+        XCTAssertEqual(target.projections?.rss?.path, "rss.xml")
+        XCTAssertEqual(target.projections?.llms?.path, "llms.txt")
+
+        XCTAssertEqual(plan.editions?.ir?.output, ".boris")
+        XCTAssertEqual(plan.editions?.rag?.output, "rag")
+        XCTAssertEqual(plan.editions?.rag?.split_size, 4096)
+        XCTAssertEqual(plan.editions?.context?.output, "context")
+    }
+}

--- a/Tests/ContractTests/PlayGraphActivityPlanTests.swift
+++ b/Tests/ContractTests/PlayGraphActivityPlanTests.swift
@@ -51,7 +51,15 @@ final class PlayGraphActivityPlanTests: XCTestCase {
     func testLocalPlayGraphFilterByTitleAndId() {
         let pages = [
             PlayPage(id: "index", title: "Home Page", status: "published", role: .trunk, depth: 0, tags: ["site"], sourcePath: "index.md"),
-            PlayPage(id: "guides/getting-started", title: "Getting Started", status: "published", role: .satellite, depth: 1, tags: ["guide"], sourcePath: "guides/getting-started.md"),
+            PlayPage(
+                id: "guides/getting-started",
+                title: "Getting Started",
+                status: "published",
+                role: .satellite,
+                depth: 1,
+                tags: ["guide"],
+                sourcePath: "guides/getting-started.md"
+            ),
             PlayPage(id: "guides/advanced", title: "Advanced Topics", status: "draft", role: .satellite, depth: 1, tags: ["guide", "deep-dive"], sourcePath: "guides/advanced.md"),
             PlayPage(id: "reference/api", title: "API Reference", status: "draft", role: .satellite, depth: 1, tags: ["reference"], sourcePath: "reference/api.md")
         ]
@@ -76,7 +84,15 @@ final class PlayGraphActivityPlanTests: XCTestCase {
     func testLocalPlayGraphFilterByTagAndStatus() {
         let pages = [
             PlayPage(id: "index", title: "Home Page", status: "published", role: .trunk, depth: 0, tags: ["site"], sourcePath: "index.md"),
-            PlayPage(id: "guides/getting-started", title: "Getting Started", status: "published", role: .satellite, depth: 1, tags: ["guide", "beginner"], sourcePath: "guides/getting-started.md"),
+            PlayPage(
+                id: "guides/getting-started",
+                title: "Getting Started",
+                status: "published",
+                role: .satellite,
+                depth: 1,
+                tags: ["guide", "beginner"],
+                sourcePath: "guides/getting-started.md"
+            ),
             PlayPage(id: "guides/advanced", title: "Advanced Topics", status: "draft", role: .satellite, depth: 1, tags: ["guide", "deep-dive"], sourcePath: "guides/advanced.md"),
             PlayPage(id: "reference/api", title: "API Reference", status: "draft", role: .satellite, depth: 1, tags: ["reference"], sourcePath: "reference/api.md")
         ]
@@ -173,52 +189,7 @@ final class PlayGraphActivityPlanTests: XCTestCase {
     }
 
     func testPublicationPlanDecoding() throws {
-        let json = """
-        {
-          "format": "boris-publication-plan",
-          "schema_version": 1,
-          "input": "content",
-          "input_format": "markdown",
-          "site": {
-            "url": "https://example.com",
-            "title": "Example Site",
-            "description": "A demo site"
-          },
-          "publication": {
-            "target": "standard-site",
-            "base_url": "https://example.com",
-            "origin": "https://example.com",
-            "base_path": "",
-            "did": "did:plc:12345",
-            "name": "Example"
-          },
-          "targets": [
-            {
-              "name": "public",
-              "output": "dist",
-              "public": true,
-              "theme": "themes/boris",
-              "layout": "default",
-              "layout_rules": [
-                { "selector": "id:index", "layout": "themes/boris/layouts/home.html" }
-              ],
-              "projections": {
-                "html": true,
-                "sitemap": { "path": "sitemap.xml", "limit": null },
-                "rss": { "path": "rss.xml", "limit": 20 },
-                "llms": { "path": "llms.txt", "limit": null }
-              }
-            }
-          ],
-          "editions": {
-            "ir": { "output": ".boris" },
-            "rag": { "output": "rag", "scope": "all", "split_size": 4096 },
-            "context": { "output": "context", "scope": "all", "split_size": 2048 }
-          }
-        }
-        """
-
-        let plan = try JSONDecoder().decode(PublicationPlan.self, from: Data(json.utf8))
+        let plan = try JSONDecoder().decode(PublicationPlan.self, from: Data(Self.samplePlanJSON.utf8))
         XCTAssertEqual(plan.format, "boris-publication-plan")
         XCTAssertEqual(plan.schema_version, 1)
         XCTAssertEqual(plan.site?.title, "Example Site")
@@ -226,6 +197,15 @@ final class PlayGraphActivityPlanTests: XCTestCase {
         XCTAssertEqual(plan.targets?.count, 1)
 
         let target = try XCTUnwrap(plan.targets?.first)
+        verifyPlanTarget(target)
+
+        XCTAssertEqual(plan.editions?.ir?.output, ".boris")
+        XCTAssertEqual(plan.editions?.rag?.output, "rag")
+        XCTAssertEqual(plan.editions?.rag?.split_size, 4096)
+        XCTAssertEqual(plan.editions?.context?.output, "context")
+    }
+
+    private func verifyPlanTarget(_ target: PublicationPlanTarget) {
         XCTAssertEqual(target.name, "public")
         XCTAssertEqual(target.output, "dist")
         XCTAssertEqual(target.public, true)
@@ -235,10 +215,50 @@ final class PlayGraphActivityPlanTests: XCTestCase {
         XCTAssertEqual(target.projections?.sitemap?.path, "sitemap.xml")
         XCTAssertEqual(target.projections?.rss?.path, "rss.xml")
         XCTAssertEqual(target.projections?.llms?.path, "llms.txt")
-
-        XCTAssertEqual(plan.editions?.ir?.output, ".boris")
-        XCTAssertEqual(plan.editions?.rag?.output, "rag")
-        XCTAssertEqual(plan.editions?.rag?.split_size, 4096)
-        XCTAssertEqual(plan.editions?.context?.output, "context")
     }
+
+    private static let samplePlanJSON = """
+    {
+      "format": "boris-publication-plan",
+      "schema_version": 1,
+      "input": "content",
+      "input_format": "markdown",
+      "site": {
+        "url": "https://example.com",
+        "title": "Example Site",
+        "description": "A demo site"
+      },
+      "publication": {
+        "target": "standard-site",
+        "base_url": "https://example.com",
+        "origin": "https://example.com",
+        "base_path": "",
+        "did": "did:plc:12345",
+        "name": "Example"
+      },
+      "targets": [
+        {
+          "name": "public",
+          "output": "dist",
+          "public": true,
+          "theme": "themes/boris",
+          "layout": "default",
+          "layout_rules": [
+            { "selector": "id:index", "layout": "themes/boris/layouts/home.html" }
+          ],
+          "projections": {
+            "html": true,
+            "sitemap": { "path": "sitemap.xml", "limit": null },
+            "rss": { "path": "rss.xml", "limit": 20 },
+            "llms": { "path": "llms.txt", "limit": null }
+          }
+        }
+      ],
+      "editions": {
+        "ir": { "output": ".boris" },
+        "rag": { "output": "rag", "scope": "all", "split_size": 4096 },
+        "context": { "output": "context", "scope": "all", "split_size": 2048 }
+      }
+    }
+    """
 }


### PR DESCRIPTION
Closes #89

- Search and filter page list by title, id, tag, and status
- Check findings rendered as badges on graph rows
- Activity history with verb, exit code, and duration
- Structured PublicationPlan document viewer
- Diagnostic sourcePath mapping