### PR TITLE
docs: record #88–#91 landed; remaining card is #78 (#87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Radio UserLand’s job in Mail’s body: sources on the left, play in the
 middle, inspector drawer on the right. Preview and the Svelte editor
 are companion windows we host. We do not invent a second compiler.
 
-**Status:** M2 chassis + play list. File → Open… a folder under
-[`Stunts/`](Stunts/) (start with `happy/`). `make test` decodes
-checked-in fixtures (no boris binary). Delegation queue:
-[`docs/cards/queue/`](docs/cards/queue/README.md).
+**Status:** M0–M8 gates plus depth. Next is M9 ship
+([#78](https://github.com/drawmeanelephant/solipsist/issues/78)).
+File → Open… a folder under [`Stunts/`](Stunts/) (start with
+`happy/`). `make test` decodes checked-in fixtures (no boris binary).
 
 ## Layout
 

--- a/agents.md
+++ b/agents.md
@@ -56,6 +56,7 @@ Never hand-edit `Solipsist.xcodeproj` — edit `Project.yml`.
 
 ## Milestones
 
-M0 bootstrap ✅ · M1 spike ✅ · M2 chassis ✅ · **P** project subdomain
-(parallel) · **M3** play & inspect · **M4** coordinate · **M5** preview
-· **M6** author · **M7** outputs · **M8** publish · **M9** ship.
+M0 bootstrap ✅ · M1 spike ✅ · M2 chassis ✅ · **P** withdrawn ·
+**M3** play & inspect ✅ · **M4** coordinate ✅ · **M5** preview ✅
+· **M6** author ✅ · **M7** outputs ✅ · **M8** publish ✅ · **M9**
+ship 🔧 ([#78](https://github.com/drawmeanelephant/solipsist/issues/78)).

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -69,17 +69,16 @@ compiler repo. Solipsist is the complementary **native desktop citizen**:
 
 ## Where we are
 
-- **M0–M8 gates exist.** Spike, chassis, list, verbs, preview/editor
-  shells, output fan-out, stdin publish. That is not CLI parity and not
-  a usable workstation. Remaining board:
-  [#87](https://github.com/drawmeanelephant/solipsist/issues/87).
+- **M0–M8 gates plus depth.** Spike, chassis, list, verbs,
+  preview/editor, outputs, publish family, first-run, filter, profile
+  1:1, `recipe-scale`. Remaining card:
+  [#78](https://github.com/drawmeanelephant/solipsist/issues/78).
   Sequence: [ROADMAP.md](ROADMAP.md) §8.
 - **Engine baseline:** afterparty `boris/0.8.1`. Kit pin `b82e9e2`.
   A3/A4/A13/A1/A14/A7 have merged after that pin — bump when we vendor
   a newer kit (#78).
-- **Next:** usability (#88), then play / inspector / publish depth
-  (#89–#91), then a clean-Mac ship (#78). Roadmap **P** is withdrawn —
-  the public site ships via Cloudflare Pages (`site/`).
+- **Next:** clean-Mac ship (#78). Roadmap **P** is withdrawn — the
+  public site ships via Cloudflare Pages (`site/`).
 
 ## What success looks like
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,10 +113,13 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M8** Publish | ✅ gate — stdin secrets, Standard.site / Nostr buttons (#77, #82/#84) |
 | **M9** Ship | 🔧 pipeline exists; clean-Mac proof + credentials + pin open (#78) |
 
-**Gates are not depth.** M3–M8 closed because a list, a verb, or a window
-existed. The app is not at CLI parity and it is not usable as a Mac
-workstation. Remaining work is [#87](https://github.com/drawmeanelephant/solipsist/issues/87).
-Do not grow `MainWindow`.
+**Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
+batch then landed: first-run and problem→page (#88/#94), graph filter /
+activity / plan document (#89/#96), profile 1:1 + execution knobs +
+`recipe-scale` (#90/#95), Standard.site family + package + readable
+proof (#91/#93). Remaining pickable card is
+[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (M9
+ship). Do not grow `MainWindow`.
 
 ---
 
@@ -382,32 +385,38 @@ here, it is not a v1 promise.
 
 ## 8. Pickup (what to do next)
 
-The gate batch (#72–#77) is closed. The active board is
-[#87](https://github.com/drawmeanelephant/solipsist/issues/87).
+The gate batch (#72–#77) and the depth batch (#88–#91) are closed.
+Next is ship.
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
-| 1 | Usability | [#88](https://github.com/drawmeanelephant/solipsist/issues/88) | First-run, status, problem → page. Nothing else matters if this is still a chassis. |
-| 2 | Play depth | [#89](https://github.com/drawmeanelephant/solipsist/issues/89) | Filter, check badges, activity + timings, plan as a document. |
-| 3 | Inspector depth | [#90](https://github.com/drawmeanelephant/solipsist/issues/90) | Profile 1:1, execution knobs that reach boris, `recipe-scale`. |
-| 4 | Publish depth | [#91](https://github.com/drawmeanelephant/solipsist/issues/91) | Rest of `standard-site`, `boris-package`, readable proof. |
-| 5 | Ship | [#78](https://github.com/drawmeanelephant/solipsist/issues/78) | Credentials, clean-Mac proof, pin bump, testdata. Parallel with 1–4 when someone has Apple certs. |
+| 1 | Ship | [#78](https://github.com/drawmeanelephant/solipsist/issues/78) | Credentials, clean-Mac proof, pin bump, testdata. |
 
-#88 and #89 can run in parallel (Chrome vs `Play/Local`). #90 owns
-`Inspector/` plus a thin Engine flag pass. #91 owns `PublishPane` plus
-publication methods. #78 stays build-lane only.
+#78 stays build-lane only (`scripts/embed-boris.sh`, `Project.yml`,
+entitlements, release workflow, `docs/SHIP-HARDENING.md`). Do not
+expand it into chrome, play, inspector, or publish.
+
+### Landed depth (do not redo)
+
+| Track | Issue | PR |
+|-------|-------|----|
+| Usability | [#88](https://github.com/drawmeanelephant/solipsist/issues/88) | [#94](https://github.com/drawmeanelephant/solipsist/pull/94) |
+| Play depth | [#89](https://github.com/drawmeanelephant/solipsist/issues/89) | [#96](https://github.com/drawmeanelephant/solipsist/pull/96) |
+| Inspector depth | [#90](https://github.com/drawmeanelephant/solipsist/issues/90) | [#95](https://github.com/drawmeanelephant/solipsist/pull/95) |
+| Publish depth | [#91](https://github.com/drawmeanelephant/solipsist/issues/91) | [#93](https://github.com/drawmeanelephant/solipsist/pull/93) |
 
 ### CLI vs app (honest)
 
 Wired as a menu or pane: `build` (IR/HTML/target/edition/all),
 `validate`, `watch --serve`, `check`, `impact`, `plan --profile`,
-`init`, `standard-site login` + `publish`, `nostr plan|sign|publish`,
-`--version`, `--timings` (decoded, not shown), `--report`.
+`init`, `recipe-scale`, `standard-site`
+login/publish/plan/records/verify/sessions/logout/smoke, `nostr`
+plan/sign/publish (per-relay verdicts), `boris-package`, `--version`,
+`--timings` (activity duration), `--report`, Jobs / Incremental /
+Quiet on the child.
 
-Named in this file and **not** a product surface yet: `recipe-scale`,
-`boris-package`, `standard-site` plan/records/verify/sessions/logout/smoke,
-browser OAuth, `github-pages-audit`, per-relay Nostr evidence, Jobs /
-Incremental / Quiet actually reaching the child.
+Named in this file and **not** a product surface yet: browser OAuth,
+`github-pages-audit`.
 
 Out of v1 (unchanged): GitHub as a source, content-audit, source-rag,
 migration labs, Wasm in the app, `validate --watch` until A5 + pin.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -18,12 +18,8 @@ with a dispatch comment — [#72 M3](https://github.com/drawmeanelephant/solipsi
 [#77 M8](https://github.com/drawmeanelephant/solipsist/issues/77) ·
 [#78 M9](https://github.com/drawmeanelephant/solipsist/issues/78).
 
-M3–M8 **gates** are closed (#72–#77). That is not depth. Active board:
-[#87 remaining](https://github.com/drawmeanelephant/solipsist/issues/87)
-· [#88 ux](https://github.com/drawmeanelephant/solipsist/issues/88) ·
-[#89 play](https://github.com/drawmeanelephant/solipsist/issues/89) ·
-[#90 inspector](https://github.com/drawmeanelephant/solipsist/issues/90) ·
-[#91 publish](https://github.com/drawmeanelephant/solipsist/issues/91) ·
+M3–M8 **gates** are closed (#72–#77). The #87 depth batch is closed
+(#88/#94 · #89/#96 · #90/#95 · #91/#93). Active card:
 [#78 ship](https://github.com/drawmeanelephant/solipsist/issues/78).
 
 **Legacy board (landed or withdrawn — do not pick):**
@@ -60,8 +56,8 @@ preview) in the entitlements matrix.
 
 ## Do not start yet
 
-Preview companion, Editor companion, GitHub-as-source, publication
-flows, Wasm in the app. A page must be selectable first (M3-play).
+GitHub as a source. Wasm in the app. The fart app. Preview, editor,
+and publish already have gates — do not rebuild them.
 
 ## Shared noun kinds (play writes, inspector reads)
 

--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -73,7 +73,9 @@ the agent-pack, `plan --out`.
 | 9 | [issue-templates](issue-templates.md) | done (#22) |
 
 New work lives in the [delegation queue](../queue/README.md) — batch 2
-(Q13, Q20-Q25) is open, pick the lowest ID.
+is landed. The queue is empty. Next pickable card is
+[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (ship,
+build-lane only — not this lane).
 
 Skip: fart app (`make fart` must keep failing). Skip GitHub-as-source.
 Skip publication flows. Skip Wasm in the app.

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -67,8 +67,7 @@ lives in the issue tracker (#58–#61; briefs in
 `docs/cards/B3-*.md`) — those own grind-lane paths, so they are not
 queue cards.
 
-The active board is **remaining work after the gates**
-([#87](https://github.com/drawmeanelephant/solipsist/issues/87)).
-#88–#91 own grind-lane paths (Chrome, Play, Inspector, Engine,
-PublishPane). They are not queue cards. The queue stays empty unless
-a child surfaces a docs-only or `Tests/`-only slice.
+The depth batch (#88–#91) landed. The remaining pickable card is
+[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (M9
+ship). It owns the build lane, not this queue. The queue stays empty
+unless someone cuts a docs-only or `Tests/`-only slice.

--- a/site/content/mission.md
+++ b/site/content/mission.md
@@ -33,4 +33,4 @@ Boris ships its own browser-based editor. Solipsist is the complementary **nativ
 
 ## Where we are
 
-The engine spike decodes the IR contracts and the Mail-shaped chassis is in (sources / play / drawer / companion slots). Next up: play & inspect (M3) and the coordinator verbs (M4) — see [[roadmap]].
+M0–M8 gates and the depth batch (first-run, filter, profile 1:1, publish family) are in. Next is a clean-Mac ship — see [[roadmap]].

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -11,16 +11,16 @@ Solipsist is a **harness**, not a better compiler and not a Markdown IDE. Boris 
 
 ## Where we are
 
-M0–M8 **gates** exist: open a folder, see the graph, run the coordinator
-verbs, preview, host the editor, fan out targets, publish with secrets
-on stdin. That is not CLI parity and not a usable workstation yet.
+M0–M8 **gates** and the depth batch exist: first-run, filter, plan as
+a document, profile 1:1, `recipe-scale`, the rest of `standard-site`,
+readable proof. Remaining work is a notarized DMG on a clean Mac.
 
 | Track | Status |
 |-------|--------|
 | M0–M8 gates | landed |
 | P Project subdomain | withdrawn — this site is Cloudflare Pages |
-| Usability | next — first-run, status, click a problem and land on the page |
-| Play / inspector / publish depth | open — filter, plan as a document, profile 1:1, rest of `standard-site` |
+| Usability | landed — first-run, status, problem → page |
+| Play / inspector / publish depth | landed |
 | M9 Ship | open — notarized DMG on a clean Mac |
 
 ## v1 must


### PR DESCRIPTION
The #87 children shipped while the remaining-work docs still listed them as next.

Landed on `main`:
- #88 ux → #94
- #89 play → #96
- #90 inspector → #95
- #91 publish → #93

Pickup, cards, and the public site now point at #78 (M9 ship). Browser OAuth and `github-pages-audit` stay named, not wired. #30 is still a pr-cop dump, not a card.

Closes #87.