### PR TITLE
docs: M10 implementation design and lane recut (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ A native macOS harness for
 [Boris](https://github.com/drawmeanelephant/boris), the deterministic
 Zig graph-native publication compiler.
 
-Radio UserLand’s job in Mail’s body: sources on the left, play in the
-middle, inspector drawer on the right. Preview and the Svelte editor
-are companion windows we host. We do not invent a second compiler.
+Radio UserLand’s job in Mail’s body: sources in Settings, mailboxes
+on the left, a reading place in the middle, inspector drawer on the
+right. Preview and the Svelte editor are companion windows we host.
+We do not invent a second compiler.
 
-**Status:** M0–M8 gates plus depth. Next is M9 ship
+**Status:** M0–M8 gates plus depth. Next ship is M9
 ([#78](https://github.com/drawmeanelephant/solipsist/issues/78)).
+Next product cut is M10 Mail body
+([#98](https://github.com/drawmeanelephant/solipsist/issues/98)).
 File → Open… a folder under [`Stunts/`](Stunts/) (start with
 `happy/`). `make test` decodes checked-in fixtures (no boris binary).
 

--- a/agents.md
+++ b/agents.md
@@ -59,4 +59,7 @@ Never hand-edit `Solipsist.xcodeproj` — edit `Project.yml`.
 M0 bootstrap ✅ · M1 spike ✅ · M2 chassis ✅ · **P** withdrawn ·
 **M3** play & inspect ✅ · **M4** coordinate ✅ · **M5** preview ✅
 · **M6** author ✅ · **M7** outputs ✅ · **M8** publish ✅ · **M9**
-ship 🔧 ([#78](https://github.com/drawmeanelephant/solipsist/issues/78)).
+ship 🔧 ([#78](https://github.com/drawmeanelephant/solipsist/issues/78))
+· **M10** Mail body 📋
+([#98](https://github.com/drawmeanelephant/solipsist/issues/98) —
+Settings / mailboxes / reading — after #78, never inside it).

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -1,11 +1,16 @@
 # Solipsist — Harness & Lanes
 
-**Date:** 2026-08-17
+**Date:** 2026-08-18
 **Status:** locked direction (spatial model + how we split work)
 **Parents:** Radio UserLand × Mail, HIG pedant, contract pedant
 This file is the product chassis and the agent-split. Goals live in
 [`ROADMAP.md`](ROADMAP.md). If they disagree about where a surface
 lives, this file wins.
+
+M2–M8 shipped a flatter cut of this model (source list + tabbed play +
+companions). **M10** is the recut to the Mail body named below. Do not
+expand [#78](https://github.com/drawmeanelephant/solipsist/issues/78)
+(M9 ship) into this chrome. What ships today is recorded in §7.
 
 ---
 
@@ -23,51 +28,111 @@ render its contracts. We never reimplement its semantics.
 
 ## 2. Spatial model
 
-Left to right, one main window. Companion windows for foreign surfaces.
+Left to right, one main window. A Settings scene for the account book.
+Companion windows for foreign surfaces.
 
 ```
+Settings (not a column) — Sources: add / relocate / remove accounts
+
 ┌──────────────────┬─────────────────────────────┬──────────────────┐
-│ SOURCES          │ PLAY                        │ DRAWER           │
+│ MAILBOXES        │ READING                     │ DRAWER           │
 │                  │                             │                  │
-│ Local folder     │ The work, for the selected  │ Options          │
-│ GitHub           │ source. Pages, outputs,     │ Settings         │
-│ (whatever next)  │ activity, reports.          │ Minutiae         │
-│                  │ Noun selected here.         │ of the selection │
+│ Source as        │ Message list of the         │ Options          │
+│ account header;  │ selected mailbox, plus a    │ Profile / page   │
+│ folders under    │ reading pane for the        │ fields / knobs   │
+│ it (Pages,       │ selected message.           │ of the selection │
+│ Outputs, …)      │ Noun selected here.         │                  │
 └──────────────────┴─────────────────────────────┴──────────────────┘
 
 Companion windows (hosted, not authored):
-  • Preview   — boris watch --serve in WKWebView
+  • Preview   — full site; boris watch --serve in WKWebView
   • Editor    — boris-editor (Svelte) at its session-token URL
   • anything else Boris already built that we will not rewrite
 ```
 
-### Left — sources
+Mail, not Finder, not Xcode. Accounts in Preferences. Mailboxes on the
+left. Messages in the middle. The letter you picked, readable. Compose
+is a separate surface (the hosted editor now; a native buffer only when
+we name that later).
 
-Accounts, not a file tree. A **source** is a place content lives or
-publishes: a local folder (security-scoped bookmark), a GitHub repo,
-later whatever earns a provider. The first source type is local. GitHub
-is the second. The sidebar is a source list, Mail-style, not a project
-tree. Trees and mailboxes of a source belong to that source's play
-surface.
+### Settings — the account book
+
+A **source** is a place content lives or publishes: a local folder
+(security-scoped bookmark), a GitHub repo, later whatever earns a
+provider. The first source type is local. GitHub is the second.
+
+Sources are **accounts**. They are added, renamed, relocated, and
+removed in **Settings → Sources**, the way Mail adds accounts. File →
+Open… and Open Recent still add a local source — that is the Mac verb
+for a folder — but they write the same store the Settings pane shows.
+The sidebar plus button is a shortcut to that add, not a second
+inventory.
 
 Do not hardcode "the open folder" as the app model. Hardcode `Source`.
 
-### Middle — play
+Settings is a `Settings` scene, not a column, not a play tab, not the
+drawer. Machine-local app state that is not selection-minutiae may
+grow further panes here. D2 still holds: output-changing controls write
+`boris.json`; machine state writes the plist; Settings and the drawer
+are views, never a third store.
 
-Where work happens for the selected source. For a local Boris project
-that means the coordinator surface: the graph as a workable list,
-outputs (targets / editions), plan/validate/build activity, reports.
-Selecting a noun in the play place is what the drawer and the companion
-windows listen to.
+### Left — mailboxes
 
-Play is **not** the editor, **not** the preview, **not** a settings form.
+A mailbox tree, Mail-style. Each source is an **account header**.
+Under it live that source's mailboxes:
+
+| Mailbox | What it is | Was (M3–M8) |
+|---------|------------|-------------|
+| Pages | `graph.json` nodes as messages | Play → Pages tab |
+| Outputs | profile targets / editions | Play → Outputs tab |
+| Publish | publication console | Play → Publish tab |
+| Plan | `plan --profile` as a document | Play → Plan tab |
+| Activity | timings / job log | Play → Activity tab |
+
+Nested folders under Pages are allowed when they come from the
+**graph** (`parent`, later `status` / tags) — trunks as folders,
+satellites as messages. They are not allowed when they come from
+walking the content directory. This is not a Finder clone. `.boris/`,
+`themes/`, and the rest of the project tree stay off the sidebar
+unless a mailbox contract names them.
+
+Selecting a mailbox is what the reading place listens to. Selecting a
+source header without a mailbox selects that source's default mailbox
+(Pages).
+
+### Middle — reading
+
+The message list of the selected mailbox, plus a **reading pane** for
+the selected message. For Pages that means the graph list (title,
+status, id, check badges) and, under it or beside it, the selected
+page as a letter:
+
+- If `watch --serve` is up, the reading pane loads that page's served
+  URL through the existing preview session. It does not spawn a second
+  watch. It does not use `file://`.
+- If watch is down, the pane shows a contract-backed summary (title,
+  id, status, `sourcePath`, relations from `completion.json`) and the
+  verbs Preview / Edit. It does not render Markdown. It does not parse
+  frontmatter.
+
+Selecting a noun in the reading place is what the drawer and the
+companion windows listen to.
+
+The reading place is **not** the editor, **not** the full-site
+preview, **not** a settings form, **not** a homegrown Markdown
+previewer. Outputs / Publish / Plan / Activity are still *our* chrome
+when those mailboxes are selected; they are no longer tabs stacked on
+top of Pages.
 
 ### Right — drawer
 
-Inspector. Options, settings, minutiae. Collapsible. This is what makes
-the one-window workflow: you should not leave the main window to change
-a profile key, a scope, a theme, a page's frontmatter fields, or
-`jobs` / `incremental` / `quiet`.
+Inspector. Options, profile keys, page fields, execution knobs.
+Collapsible. This is what makes the one-window workflow: you should
+not leave the main window to change a profile key, a scope, a theme, a
+page's frontmatter fields, or `jobs` / `incremental` / `quiet`.
+
+The drawer is minutiae of the **selection**, not the account book.
+Adding a source does not belong here.
 
 Rule still stands (D2): if it changes Boris output, the control writes
 the publication profile. If it is machine-local, it writes the app
@@ -75,14 +140,28 @@ plist. The drawer is a view over those two stores, never a third.
 
 ### Companion windows
 
-Surfaces we host and do not write. Preview. The Svelte editor. Future
-Boris UIs. They open from the main window (and the menu bar) against the
-current selection. They are not columns. They are not tabs in the
-drawer.
+Surfaces we host and do not write. The full-site Preview. The Svelte
+editor. Future Boris UIs. They open from the main window (and the menu
+bar) against the current selection. They are not columns. They are not
+tabs in the drawer.
+
+Edit ▶ / double-click a page / Return on a Pages row opens the editor
+companion against the selected source (and against the selected
+`sourcePath` once that launch contract exists). Link-out remains the
+accepted fallback.
 
 Mail's Activity window is the analog for build/plan/timings if that
-surface ever outgrows the play place. It is still *our* chrome if we
+surface ever outgrows its mailbox. It is still *our* chrome if we
 author it; companions are specifically the things we refuse to author.
+
+### Native editor (named later, not M10)
+
+A from-scratch native buffer is **allowed to be later**. It is not a
+v1 gate and it is not a reason to stop hosting `boris-editor`. If it
+lands, it is a buffer + save + problems surface over `sourcePath`. It
+does not parse frontmatter, does not compile, does not invent graph
+semantics, and does not replace `watch --serve`. Until that card is
+cut, Edit means the hosted companion.
 
 ---
 
@@ -95,12 +174,13 @@ owns a directory.
 ```
 Sources/
   App/            process entry, menu bar, window groups
-  Chrome/         the one window: sidebar slot, play slot, drawer slot
+    Settings/     Settings scene — Sources pane (the account book)
+  Chrome/         the one window: mailbox slot, reading slot, drawer slot
   Workspace/      Source protocol + selection store + providers
     Local/        first provider (bookmark, open/save, recents)
     GitHub/       later
-  Play/           one play surface per source kind
-    Local/        graph list, outputs, activity, reports
+  Play/           one reading surface per source kind
+    Local/        message list + reading pane; mailbox contents
   Inspector/      Inspectable sections, no selection ownership
   Companions/     PreviewWindow, EditorWindow (WKWebView hosts)
   Engine/         existing — the only Process owner
@@ -108,7 +188,9 @@ Sources/
 ```
 
 `ContentView.swift` is gone. Chrome is `MainWindow` and empty slots.
-Do not grow `MainWindow` — fill `Play/`, `Inspector/`, `Companions/`.
+Do not grow `MainWindow` — fill `Play/`, `Inspector/`, `Companions/`,
+`App/Settings/`. Recut `SourceSidebar` into a mailbox tree; do not
+start a second sidebar.
 
 ### Load-bearing types (the seams)
 
@@ -117,18 +199,23 @@ fills them in.
 
 | Seam | Owns | Does not own |
 |------|------|----------------|
-| `Source` | identity, title, kind, how to appear in the sidebar | play UI, inspector UI |
-| `PlaySurface` | the middle view for one source kind | engine process, window chrome |
+| `Source` | identity, title, kind, how to appear as an account header | mailbox contents, inspector UI |
+| `PlaySurface` | the middle view for one source kind + selected mailbox | engine process, window chrome |
 | `Inspectable` | sections the drawer renders for the current selection | the selection itself |
 | `Companion` | a window that hosts a foreign surface | compiler semantics |
-| `WorkspaceSelection` | the single selected source + noun | views |
+| `WorkspaceSelection` | the single selected source + mailbox + noun | views |
 
 Rules:
 
 - Selection is a value type in one observable store. The drawer and the
-  companions **read** it. They never own it.
-- Engine is the only thing that starts a `Process`. Companions ask the
-  actor; they do not spawn `boris`.
+  companions **read** it. They never own it. Chrome writes `sourceID`
+  and `mailbox`; play writes `noun`.
+- `mailbox` is an open string (like `noun.kind`): `pages`, `outputs`,
+  `publish`, `plan`, `activity`, later a trunk id. Do not invent a
+  second vocabulary.
+- Engine is the only thing that starts a `Process`. Companions and the
+  reading pane ask the actor; they do not spawn `boris`. One watch
+  session per selected source — the reading pane reuses it.
 - Models do not import SwiftUI. Play/Inspector do not parse JSON —
   they take decoded contracts.
 - A new source type is a new folder under `Workspace/` + `Play/`. It
@@ -150,7 +237,11 @@ cut wrong — stop and recut.
 | **Inspector** | `Sources/Inspector/` | selection store shape, Engine | Selecting a page/target/profile key shows the matching section |
 | **Preview companion** | `Sources/Companions/Preview/` | editor, play | Preview window loads `watch --serve` and reloads on SSE |
 | **Editor companion** | `Sources/Companions/Editor/` | preview, play | Editor window loads `boris-editor` token URL; link-out fallback |
-| **GitHub source** | `Sources/Workspace/GitHub/`, `Sources/Play/GitHub/` | Local play, Engine | A GitHub source appears in the sidebar and vends its own play |
+| **GitHub source** | `Sources/Workspace/GitHub/`, `Sources/Play/GitHub/` | Local play, Engine | A GitHub source appears as an account header and vends its own mailboxes |
+| **Settings** (M10) | `Sources/App/Settings/`, Settings commands in `Commands.swift` / `SolipsistApp.swift` | Play implementations, mailbox tree internals | Settings → Sources adds/removes/relocates a local source; same store as File → Open… |
+| **Mailboxes** (M10) | `Sources/Chrome/SourceSidebar.swift`, `WorkspaceSelection` mailbox field | Play row rendering, Inspector sections | Sidebar is account headers + mailboxes; selecting one writes `selection.mailbox` |
+| **Reading** (M10) | `Sources/Play/Local/` | Chrome mailbox construction, Engine | Tabs gone; center is message list + reading pane driven by `mailbox` |
+| **Editor wiring** (M10) | `Sources/Companions/Editor/`, Edit menu verb | Native `TextView`, Play list internals | Edit / double-click a page opens the hosted editor; link-out fallback |
 | **Issues** | `docs/issues/` | `Sources/` | Draft fact-checked against afterparty, then filed |
 | **Design** | `docs/*.md` except `issues/` | `Sources/` | Decisions recorded; no silent contradiction with this file |
 
@@ -164,6 +255,11 @@ cut wrong — stop and recut.
 3. **Editor companion and GitHub source** start after Local play is
    something you can select in. They must not block the one-window
    workflow.
+4. **M10 (Mail body) starts after M9 is the remaining ship card, not
+   instead of it.** Settings can run next to Mailboxes. Reading follows
+   Mailboxes (it consumes `selection.mailbox`). Editor wiring follows
+   a selectable page noun — it can overlap Reading if it only keys off
+   `noun.kind == "page"`. Native editor is not in this sequence.
 
 ### Integration rules
 
@@ -175,7 +271,8 @@ cut wrong — stop and recut.
 - If a feature is not in the menu bar, it is not a feature.
 - If you are about to write a Markdown editor, a graph algorithm, a
   frontmatter parser, or an HTTP server — stop. That is Boris's job or
-  a companion host.
+  a companion host. A native buffer is a named later card, not a
+  surprise `TextView` in Play.
 
 ---
 
@@ -210,3 +307,23 @@ Landed. Goals from here: [`ROADMAP.md`](ROADMAP.md) M3+.
 - `ContentView.swift` is gone.
 - `make build` still produces a runnable app; `make run-spike` is
   unchanged (spike does not import Chrome).
+
+---
+
+## 7. What ships today (M2–M8), vs M10
+
+Do not "fix" the shipping chrome back onto this file's destination
+without picking an M10 card. The live app is still the flatter cut:
+
+| Surface | Ships today | M10 destination |
+|---------|-------------|-----------------|
+| Account book | File → Open… / sidebar plus / Remove Source | Settings → Sources (same `WorkspaceStore`) |
+| Left column | Flat source list (`SourceSidebar`) | Account headers + mailboxes |
+| Center | Segmented play tabs (Pages / Outputs / Publish / Plan / Activity) + problems strip | Message list + reading pane, driven by the selected mailbox |
+| Preview | Companion only | Companion (full site) + reading pane (selected page, same watch) |
+| Editor | Companion only; source-scoped, not page-scoped | Companion, opened from the selected page; native buffer later |
+| Selection | `sourceID` + `noun` | `sourceID` + `mailbox` + `noun` |
+
+M10 cards live in [`cards/`](cards/README.md)
+([#98](https://github.com/drawmeanelephant/solipsist/issues/98)).
+#78 stays build-lane only.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -238,10 +238,10 @@ cut wrong — stop and recut.
 | **Preview companion** | `Sources/Companions/Preview/` | editor, play | Preview window loads `watch --serve` and reloads on SSE |
 | **Editor companion** | `Sources/Companions/Editor/` | preview, play | Editor window loads `boris-editor` token URL; link-out fallback |
 | **GitHub source** | `Sources/Workspace/GitHub/`, `Sources/Play/GitHub/` | Local play, Engine | A GitHub source appears as an account header and vends its own mailboxes |
-| **Settings** (M10) | `Sources/App/Settings/`, Settings commands in `Commands.swift` / `SolipsistApp.swift` | Play implementations, mailbox tree internals | Settings → Sources adds/removes/relocates a local source; same store as File → Open… |
-| **Mailboxes** (M10) | `Sources/Chrome/SourceSidebar.swift`, `WorkspaceSelection` mailbox field | Play row rendering, Inspector sections | Sidebar is account headers + mailboxes; selecting one writes `selection.mailbox` |
-| **Reading** (M10) | `Sources/Play/Local/` | Chrome mailbox construction, Engine | Tabs gone; center is message list + reading pane driven by `mailbox` |
-| **Editor wiring** (M10) | `Sources/Companions/Editor/`, Edit menu verb | Native `TextView`, Play list internals | Edit / double-click a page opens the hosted editor; link-out fallback |
+| **Settings** (M10) | `Sources/App/Settings/`, Settings scene in `SolipsistApp.swift` | `Commands.swift`, Play, mailbox tree, `Project.yml` | Settings → Sources adds/removes/relocates a local source; same store as File → Open… |
+| **Mailboxes** (M10) | `SourceSidebar.swift`; `WorkspaceSelection` / `WorkspaceStore` / `WorkspacePersistence`; sole `MainWindow.swift` | Settings scene, `Commands.swift`, Play row rendering, Inspector, `Project.yml` | Sidebar is account headers + mailboxes; selecting one writes `selection.mailbox` |
+| **Reading** (M10) | `Sources/Play/Local/`; named recut: `PlayHost` binder, `AppRuntime.previewSession`, `Companions/Preview/` session share + `PreviewURL` helpers | Chrome mailbox construction, `MainWindow.swift`, Engine | Tabs gone; center is message list + reading pane driven by `mailbox` |
+| **Editor wiring** (M10) | `Sources/Companions/Editor/`, File → Edit Page in `Commands.swift` | Native `TextView`, Play list internals, `MainWindow.swift` | File → Edit Page; header shows title + `sourcePath`; merge after Reading |
 | **Issues** | `docs/issues/` | `Sources/` | Draft fact-checked against afterparty, then filed |
 | **Design** | `docs/*.md` except `issues/` | `Sources/` | Decisions recorded; no silent contradiction with this file |
 
@@ -257,9 +257,9 @@ cut wrong — stop and recut.
    workflow.
 4. **M10 (Mail body) starts after M9 is the remaining ship card, not
    instead of it.** Settings can run next to Mailboxes. Reading follows
-   Mailboxes (it consumes `selection.mailbox`). Editor wiring follows
-   a selectable page noun — it can overlap Reading if it only keys off
-   `noun.kind == "page"`. Native editor is not in this sequence.
+   Mailboxes (it consumes `selection.mailbox`). Editor wiring **merges
+   after Reading** (it reads `noun.sourcePath` that Reading writes).
+   Native editor is not in this sequence.
 
 ### Integration rules
 

--- a/docs/M10-DESIGN.md
+++ b/docs/M10-DESIGN.md
@@ -1,0 +1,1450 @@
+# M10 Mail Body — Implementation Design
+
+| Field | Value |
+|-------|--------|
+| **Title** | M10 Mail Body — Implementation Design |
+| **Author** | Solipsist design lane |
+| **Date** | 2026-08-18 |
+| **Status** | Accepted |
+| **Repo** | [drawmeanelephant/solipsist](https://github.com/drawmeanelephant/solipsist) |
+| **Parent issue** | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) |
+| **Children** | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) Settings · [#100](https://github.com/drawmeanelephant/solipsist/issues/100) Mailboxes · [#101](https://github.com/drawmeanelephant/solipsist/issues/101) Reading · [#102](https://github.com/drawmeanelephant/solipsist/issues/102) Editor |
+| **Parents** | [`HARNESS.md`](HARNESS.md) §2 (spatial) · [`ROADMAP.md`](ROADMAP.md) §5 M10 · [`Agents.md`](../Agents.md) |
+
+This is the extra planning [#98](https://github.com/drawmeanelephant/solipsist/issues/98) asked for. It is not a restatement of the cards. The four child cards, **HARNESS §4**, and the parent sequence are patched to match this file — **HARNESS wins on where a surface lives; the cards plus this design execute it.**
+
+Implementation stays on new feature branches off `main`, one per card.
+
+---
+
+## Overview
+
+M2–M8 shipped a flatter chassis: a flat `SourceSidebar`, a segmented `PlayTab` picker inside `LocalPlay`, Preview/Editor as source-scoped companions, and no Settings scene. HARNESS §2 is now the destination: Settings holds the account book, the left column is account headers plus mailboxes, the center is a message list plus a reading pane, Edit opens hosted `boris-editor` from the selected page.
+
+The code already has the seams this recut fills. `WorkspaceStore` is the one observable inventory. `WorkspaceSelection` is a value the drawer and companions only read. The Preview companion’s `PreviewSession` (`@State` on `PreviewWindow` today) owns that window’s `WatchServer`; after M10-3 it is lifted and bound to the selected source. `EditorSession` already owns the one `boris-editor` host. None of those need a second process, a second store, or a Swift Markdown renderer.
+
+What is missing is the Mail body: a `mailbox` field on selection, a Settings scene over the same store, a recut sidebar, a reading pane that *observes* the existing watch, and an Edit verb that surfaces `sourcePath` because `boris-editor` has no fact-checked file-open deep link.
+
+---
+
+## Background & Motivation
+
+### What ships today
+
+| Surface | File | Behavior |
+|---------|------|----------|
+| Selection | `Sources/Workspace/WorkspaceSelection.swift` | `sourceID` + `noun`. No mailbox. |
+| Persistence | `Sources/Workspace/WorkspacePersistence.swift` | `PersistedWorkspace { sources, selected }` at UserDefaults key `solipsist.workspace.sources.v1`. Noun is not stored. `select(_:)` itself does not persist — only `addLocal` / `relocate` / `remove` call `persist()`. |
+| Sidebar | `Sources/Chrome/SourceSidebar.swift` | `List(selection: Binding<SourceID?>)` of flat sources. Relocate context item only when `!item.isAvailable`. |
+| Center | `Sources/Play/Local/LocalPlay.swift` | `@State selectedTab: PlayTab` segmented control. Tabs are view-local; they are not selection. |
+| Preview | `Sources/Companions/Preview/PreviewWindow.swift` | `@State private var session = PreviewSession()`. `onDisappear` calls `session.stop()`. Window-local; Play cannot see it. |
+| Editor | `Sources/Companions/Editor/EditorWindow.swift` | Source-scoped `EditorSession`. Header shows source title + folder path. `EditorURL` requires `#token=<hex>` and nothing else. |
+| App | `Sources/App/SolipsistApp.swift` | `@State private var store = WorkspaceStore()` injected into `WindowGroup`s. No `Settings` scene. `Sources/App/Settings/` does not exist. |
+| Toolbar / menu | `MainWindow.swift`, `Commands.swift` | Editor and Preview enabled whenever `selectedSource != nil`. Inspector `PageSection.openEditor()` already calls `openWindow(id: CompanionID.editor)`. |
+
+### Pain
+
+The window is Mail-shaped and behaves like a tabbed workbench. Clicking a source does not pick a mailbox. The letter is a companion window, not the selected message. Edit opens the project, not the page. Sources are added by a sidebar plus button, not an account book.
+
+### Locked destination (do not reopen)
+
+```
+Settings → Sources (the account book; not a column)
+
+┌──────────────────┬─────────────────────────────┬──────────────────┐
+│ MAILBOXES        │ READING                     │ DRAWER           │
+│ Source as        │ Message list + reading      │ Profile, page    │
+│ account header;  │ pane for the selected       │ fields, options  │
+│ folders under it │ message                     │                  │
+└──────────────────┴─────────────────────────────┴──────────────────┘
+Companions: Preview (full site) · Editor (boris-editor)
+Native buffer: named Later, not this milestone.
+```
+
+Mail, not Finder, not Xcode. Nested folders under Pages come from `graph.json` `parent` only — and **not in this milestone** (see Key Decisions).
+
+---
+
+## Goals & Non-Goals
+
+### Goals
+
+1. Settings → Sources adds / relocates / removes local sources against the same `WorkspaceStore` as File → Open….
+2. Left column is account headers + five mailboxes. Chrome writes `sourceID` + `mailbox`.
+3. Center switches on `selection.mailbox`. Pages is a graph list plus a reading pane. Other mailboxes are the existing full-height panes.
+4. Reading pane loads the selected page's served URL when watch is up; otherwise a contract-backed summary. No `file://`. No Swift Markdown. No second `Process`.
+5. File → Edit Page / toolbar / double-click / Return open the hosted editor and surface title + `sourcePath`. No invented deep link.
+6. Every PR: `SKIP_EMBED_BORIS=1 make build` + `make test` green. One card = one worktree = one PR.
+
+### Non-Goals
+
+- M9 ship (#78): `scripts/embed-boris.sh`, **all of** `Project.yml` (entitlements *and* target membership), release paths.
+- Native `NSTextView` / `TextEditor` buffer.
+- GitHub as a source.
+- Walking `content/` as a Finder tree; showing `.boris/`, `themes/`, `dist/` as mailboxes.
+- Nested Pages trunk folders in the sidebar (later; see §Mailbox sidebar).
+- Reimplementing coordinator verbs, publish, or contracts.
+- Pin bump / A1 `--watch-json` as a reading-pane dependency.
+- An app-side HTTP server.
+- Growing `MainWindow` with views. #100 is the sole M10 owner of that file (column width + Editor toolbar enablement). #102 does not edit it.
+
+### Hard constraints (repeat so implementers cannot miss them)
+
+1. Never touch the `boris` repo. Never reimplement Boris semantics in Swift.
+2. Never silently ignore diagnostics or exit codes.
+3. Never mutate the user’s content tree except on an explicit save.
+4. One `Process?` slot in `BorisEngine`. Cancel = `Process.terminationReason == .uncaughtSignal`.
+5. Do not grow `MainWindow`. Fill `Play/`, `Inspector/`, `Companions/`, `App/Settings/`. Recut `SourceSidebar`; do not start a second sidebar.
+6. D2: output-changing settings write `boris.json`; machine state writes the plist; Settings and the drawer are views, never a third store.
+7. Unknown/newer `schemaVersion` degrades, never crashes (D8).
+8. Menus first. If it is not in the menu bar, it is not a feature.
+
+---
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D-S1 | `WorkspaceSelection` grows `mailbox: String? = nil`. The five M10 tokens live as `WorkspaceMailbox` static strings (`pages` · `outputs` · `publish` · `plan` · `activity`), not a closed Swift enum. **M10 UI admits only those five**; unknown → Pages *display* without writing `pages` back. Persist the **raw** string. | Cards and HARNESS: open string. A later trunk card must stop treating unknown as Pages *before* it persists a trunk id. M10 will not round-trip trunks; that is explicit, not future-proofing. |
+| D-S2 | `WorkspaceNoun` grows `sourcePath: String? = nil`. | Play already has `PlayPage.sourcePath`. Editor and the reading summary need it. Noun is not persisted. M10-2 lands the field; M10-3 is the only writer (list, problems jump, graph reload); M10-4 reads it. **#102 merges after #101.** |
+| D-S3 | Mailbox **does** persist across relaunch, on `PersistedWorkspace.mailbox: String? = nil`, same UserDefaults key `solipsist.workspace.sources.v1`. Noun does **not**. No per-source mailbox map. | Machine state (D2). Missing key decodes as `nil`. Switching source writes `pages` (card gate). Do **not** canonicalize on load — a future trunk id must survive an M10 binary that later `persist()`s. |
+| D-S4 | `select` persists only when the in-memory selection actually changed. Today's `select(_:)` does not write defaults — a sidebar click is lost on quit. Persist-on-select rewrites the **full** payload, including `LocalSource.bookmarkData`. | Behavior change for `selected`, not only mailbox. Extract `WorkspaceSelectionRules` so ContractTests do not compile `WorkspaceStore`. Never edit `Project.yml`. |
+| D-S5 | Source change or mailbox change clears `noun`. Graph reload that no longer contains `noun.id` clears `noun`; if the id remains, rewrite title + `sourcePath`. Header click writes `sourceID` + `pages`. | Card gate + Mail "leaving the folder drops the message." Same-id path refresh keeps Edit caption honest. |
+| D-S6 | Sidebar is `List` + `Section` per source, five tagged child rows. Selection type is `MailboxRowID` (`sourceID` + `mailbox`). **Not** `OutlineGroup` / `DisclosureGroup`. Nested trunks **out of M10**. Expansion is not persisted. Header tap is best-effort; Pages row is the accessible control. | Chrome must not decode `graph.json`. macOS `Section` header + `onTapGesture` is flaky. |
+| D-S7 | Settings scene in `SolipsistApp` gets the same `@State store` via `.environment(store)`. No singleton. **#99 does not edit `Commands.swift` or `Project.yml`.** | System Settings… is the menu. Filed card M10-1 is patched to match. |
+| D-S8 | Lift `PreviewSession` onto `AppRuntime`. Named recut: #101 may substitute the session owner, expose `boundRootPath`, add `PreviewURL` helpers, and bind the session from `PlayHost`. It may not change `WatchServer` argv or add a second session. `PlayHost` (always alive) retargets or stops on `sourceID` change **even when the companion is closed**. Reading pane observes and treats a root mismatch as idle. | Window-local `@State` cannot follow the sidebar. HARNESS §3: one watch per selected source. Do not grow `MainWindow`. |
+| D-S9 | Page URL = loopback origin of the helper URL + `/{graph node id}.html`. **Not** `sourcePath` with the extension swapped. Mapping is a Solipsist rule, not a probed watch field. | `GraphNode` has no permalink. ENGINE-CONTRACTS §1 says `GET /<page>.html` without defining `<page>`. Id-vs-stem was not live-probed; hand-gate if a cook corpus is available. |
+| D-S10 | Center split is **stacked** (`VSplitView`: list above letter). Other mailboxes are full-height existing panes. | The center is already the `NavigationSplitView` detail; a further H-split plus inspector is too tight at `minWidth: 800`. |
+| D-S11 | Reading pane does **not** subscribe to SSE. It loads the page URL and reloads when `serveURL` changes **or** the user re-selects the row. 404 / load failure is in-pane summary, via `WKNavigationDelegate`. | Helper page owns EventSource. `WKWebView` reports many 404s as successful navigations — detect status explicitly. |
+| D-S12 | `boris-editor` has **no** file-open query/fragment. Do not invent one. Do not file `docs/issues/boris-A*-editor-open-file.md` in this milestone. Companion header shows title + `sourcePath`. | A14 + `EditorURL` + `docs/issues/README.md`. |
+| D-S13 | Recut M10-4 off `LocalPlay.swift` **and** `MainWindow.swift`. M10-3 lands double-click / Return. M10-4 owns File → Edit Page and `EditorWindow` header. `#102` **merges after `#101`.** | HARNESS §4. After the recut, only #101 writes `noun.sourcePath`; merging #102 first fails the header gate. |
+| D-S14 | Merge order: #99 ∥ #100, then #101, then #102. #102 *development* may start after #100 (type has `sourcePath`); #102 *merge* after #101. #100 is the sole `MainWindow` owner. | Settings is disjoint if it stays off Commands / Project.yml / SourceSidebar. |
+| D-S15 | Durable copy: `docs/M10-DESIGN.md`. **Design-lane patches HARNESS §4 (four M10 rows + sequence) and the four child cards’ Owns / Do-not-touch / Gate** (not one-line pointers). | HARNESS says it wins when docs disagree. An unpatched §4 re-opens the file collisions. |
+| D-S16 | Do not add `WorkspaceStore.swift` to ContractTests. Do not edit `Project.yml`. Test selection rules via `WorkspaceSelectionRules` in `WorkspaceSelection.swift` (already in the test target). | `WorkspaceStore` pulls `AppRuntime` → `Coordinator` → AppKit / `NSDocumentController`. `Project.yml` is a #78 path. |
+
+---
+
+## Proposed Design
+
+### 1. Selection model
+
+#### Shape after M10
+
+`Sources/Workspace/WorkspaceSelection.swift`:
+
+```swift
+/// M10 mailbox tokens. Open vocabulary — not a closed enum.
+/// M10 UI admits only `all`; unknown values display as Pages
+/// without being rewritten to `pages` in the plist.
+enum WorkspaceMailbox {
+    static let pages = "pages"
+    static let outputs = "outputs"
+    static let publish = "publish"
+    static let plan = "plan"
+    static let activity = "activity"
+
+    static let all: [String] = [pages, outputs, publish, plan, activity]
+    static let defaultMailbox = pages
+
+    static func isKnown(_ raw: String?) -> Bool {
+        guard let raw else { return false }
+        return all.contains(raw)
+    }
+
+    /// M10 display/switch value. Does **not** write back.
+    /// A later trunk card must stop using this for persist.
+    static func display(_ raw: String?) -> String {
+        guard let raw, isKnown(raw) else { return defaultMailbox }
+        return raw
+    }
+
+    static func displayName(_ raw: String) -> String { /* Pages / Outputs / … / raw */ }
+    static func symbolName(_ raw: String) -> String { /* doc.text / … / folder */ }
+}
+
+struct WorkspaceSelection: Hashable, Sendable, Codable {
+    var sourceID: SourceID?
+    /// Open string. Persist raw. Nil when no source is selected.
+    var mailbox: String? = nil
+    var noun: WorkspaceNoun?
+
+    var canEditPage: Bool { noun?.kind == "page" }
+
+    static let empty = WorkspaceSelection(sourceID: nil, mailbox: nil, noun: nil)
+}
+
+struct WorkspaceNoun: Hashable, Sendable, Codable {
+    var kind: String
+    var id: String
+    var title: String
+    /// Content-root-relative path from `GraphNode.sourcePath`. Page nouns only.
+    var sourcePath: String? = nil
+}
+
+/// Pure selection transitions. `WorkspaceStore` calls these, then
+/// `persist()` if the value changed. ContractTests compile this file
+/// already — do not add `WorkspaceStore.swift` to the test target.
+enum WorkspaceSelectionRules {
+    static func selectSource(_ current: WorkspaceSelection, id: SourceID?) -> WorkspaceSelection {
+        var next = current
+        let changed = current.sourceID != id
+        next.sourceID = id
+        if id == nil {
+            next.mailbox = nil
+            next.noun = nil
+        } else if changed {
+            next.mailbox = WorkspaceMailbox.defaultMailbox
+            next.noun = nil
+        }
+        return next
+    }
+
+    static func selectMailbox(_ current: WorkspaceSelection, mailbox: String) -> WorkspaceSelection {
+        guard current.sourceID != nil else { return current }
+        // Store what chrome wrote (one of `all` in M10). Do not coerce unknown → pages.
+        guard current.mailbox != mailbox else { return current }
+        var next = current
+        next.mailbox = mailbox
+        next.noun = nil
+        return next
+    }
+
+    static func select(_ current: WorkspaceSelection, id: SourceID, mailbox: String) -> WorkspaceSelection {
+        var next = current
+        let sourceChanged = current.sourceID != id
+        let mailboxChanged = current.mailbox != mailbox
+        next.sourceID = id
+        next.mailbox = mailbox
+        if sourceChanged || mailboxChanged {
+            next.noun = nil
+        }
+        return next
+    }
+
+    static func restore(selected: SourceID?, mailbox: String?, available: Set<SourceID>) -> WorkspaceSelection {
+        guard let selected, available.contains(selected) else {
+            return .empty
+        }
+        // Raw mailbox. Do not run `display` here.
+        return WorkspaceSelection(sourceID: selected, mailbox: mailbox, noun: nil)
+    }
+}
+```
+
+Synthesized `Codable` keys (do not add a custom `CodingKeys` unless a rename is required):
+
+| Type | Keys |
+|------|------|
+| `WorkspaceSelection` | `sourceID`, `mailbox`, `noun` |
+| `WorkspaceNoun` | `kind`, `id`, `title`, `sourcePath` |
+
+`sourcePath` is optional; a payload without it decodes as `nil`. `WorkspaceSelection` is Codable today but is **not** the persisted payload — `PersistedWorkspace` is. Noun stays session-only.
+
+#### Persistence
+
+`Sources/Workspace/WorkspacePersistence.swift`:
+
+```swift
+struct PersistedWorkspace: Codable, Equatable, Sendable {
+    var sources: [LocalSource]
+    var selected: SourceID?
+    var mailbox: String? = nil    // default so existing memberwise call sites compile
+}
+```
+
+Keep the same key. `mailbox` defaults to `nil` so `PersistedWorkspace(sources:selected:)` in today's `persist()` and `WorkspacePersistenceTests.testPersistedWorkspaceRoundTripViaDefaults` still compile. `LocalSource` keeps its explicit `CodingKeys` (`id`, `title`, `bookmarkData`, `displayPath`) — `isAvailable` stays transient. `PersistedWorkspace` / `WorkspaceSelection` keep **synthesized** keys (`sources`, `selected`, `mailbox`).
+
+Do not bump the key. Do not persist `noun`. Do not persist a `[SourceID: String]` map.
+
+Exact `persist()` / `load()` in `WorkspaceStore` (today lines 186–228):
+
+```swift
+private func persist() {
+    let locals: [LocalSource] = sources.compactMap { item in
+        if case .local(let local) = item { return local }
+        return nil
+    }
+    let payload = PersistedWorkspace(
+        sources: locals,
+        selected: selection.sourceID,
+        mailbox: selection.mailbox      // raw; do not run display()
+    )
+    do {
+        defaults.set(try WorkspacePersistence.encode(payload), forKey: WorkspacePersistence.defaultsKey)
+    } catch {
+        lastError = String(describing: error)
+    }
+}
+
+private func load() {
+    guard let data = defaults.data(forKey: WorkspacePersistence.defaultsKey) else { return }
+    do {
+        let payload = try WorkspacePersistence.decode(data)
+        var refreshed = false
+        sources = payload.sources.map { /* beginAccess, same as today */ }
+        let available = Set(sources.map(\.id))
+        selection = WorkspaceSelectionRules.restore(
+            selected: payload.selected,
+            mailbox: payload.mailbox,    // raw
+            available: available
+        )
+        if refreshed { persist() }
+    } catch {
+        lastError = String(describing: error)
+    }
+}
+```
+
+**Migration tests** (on `PersistedWorkspace`, no `WorkspaceStore`):
+
+| Direction | Payload | Expect |
+|-----------|---------|--------|
+| Backward | v1 JSON without `mailbox` | `mailbox == nil` |
+| Forward | JSON with `"mailbox":"outputs"` decoded by a type that only has `sources`/`selected` (or `JSONSerialization` ignoring extras) | no throw; old fields intact |
+| Round-trip | `"mailbox":"guides/overview"` (future trunk) | string preserved; **not** rewritten to `pages` |
+
+`JSONDecoder` ignores unknown keys by default, so an old binary can read a new plist. A new binary reads an old plist as `mailbox == nil`. UI then `display(nil)` → Pages.
+
+#### Store API
+
+`Sources/Workspace/WorkspaceStore.swift`. All mutations stay `@MainActor`. Views never assign `selection.mailbox` except through these methods.
+
+```swift
+func select(_ id: SourceID?) {
+    let next = WorkspaceSelectionRules.selectSource(selection, id: id)
+    guard next != selection else { return }
+    selection = next
+    persist()
+}
+
+func select(mailbox: String) {
+    let next = WorkspaceSelectionRules.selectMailbox(selection, mailbox: mailbox)
+    guard next != selection else { return }
+    selection = next
+    persist()
+}
+
+/// Sidebar write path. Header click passes `mailbox: WorkspaceMailbox.pages`.
+func select(_ id: SourceID, mailbox: String) {
+    let next = WorkspaceSelectionRules.select(selection, id: id, mailbox: mailbox)
+    guard next != selection else { return }
+    selection = next
+    persist()
+}
+```
+
+`select(noun:)` stays as today — no persist, no mailbox touch.
+
+Persist-on-select is **not** a mailbox-only change. Today's `selected` is only written from `addLocal` / `relocate` / `remove`. After this, every *changed* sidebar click rewrites the full `PersistedWorkspace`, including every `LocalSource.bookmarkData` (binary). That is accepted: same encode path as add/remove, now on selection change. Failed `defaults.set` still leaves in-memory selection mutated (same as today's add/remove). Early-return when unchanged avoids rewriting bookmarks on a no-op click.
+
+`addLocal` / `relocate` already call `select(id)` then `persist()`. After the guard, a no-op `select` does not double-write; a real change persists once inside `select`, and the trailing `persist()` is a second full write — leave the existing call sites as they are (idempotent, matches today's relocate/add).
+
+`remove`: if the removed id was selected, today's code sets `selection = .empty` then `select(first.id)`. That path writes `mailbox = pages`. Good.
+
+#### Defaults
+
+| Event | `sourceID` | `mailbox` | `noun` |
+|-------|------------|-----------|--------|
+| First launch, no sources | `nil` | `nil` | `nil` |
+| `addLocal` / Open… / Open Recent / Settings Add Local | new id | `pages` | `nil` |
+| Sidebar header click | that id | `pages` | `nil` if source or mailbox changed; kept if already on that source's Pages |
+| Sidebar child click | that id | that mailbox | `nil` if source or mailbox changed |
+| Source switch (any path) | new id | `pages` | `nil` |
+| Same-source mailbox change | unchanged | new mailbox | `nil` |
+| Play row click | unchanged | unchanged | written by play |
+| Graph reload missing `noun.id` | unchanged | unchanged | `nil` |
+| Graph reload, same `noun.id` | unchanged | unchanged | rewritten (title + `sourcePath`) |
+| Relaunch | persisted selected | persisted raw mailbox (`nil` → UI Pages) | `nil` |
+
+#### Who writes what
+
+```mermaid
+flowchart LR
+    subgraph chrome [Chrome]
+        Sidebar[SourceSidebar]
+    end
+    subgraph play [Play]
+        LocalPlay[LocalPlay]
+        Problems[ProblemsPane]
+        Outputs[OutputsPane]
+    end
+    Store[WorkspaceStore.selection]
+    subgraph readers [Read only]
+        Drawer[InspectorDrawer]
+        Preview[PreviewWindow]
+        Editor[EditorWindow]
+        Settings[SourcesSettingsPane]
+    end
+    Sidebar -->|sourceID + mailbox| Store
+    LocalPlay -->|noun| Store
+    Problems -->|noun; mailbox pages on jump| Store
+    Outputs -->|noun target/edition| Store
+    Store --> Drawer
+    Store --> Preview
+    Store --> Editor
+    Settings -->|add/remove/relocate + select| Store
+```
+
+**Exception (documented):** `ProblemsPane` may call `store.select(mailbox: WorkspaceMailbox.pages)` before writing a page noun **with `sourcePath`**. Resolve the path the same way the list writer does: `LocalPlayGraph.resolvePage(forSourcePath:in:)` / the in-memory `[PlayPage]`. A jump that left you on Outputs would otherwise select a page you cannot see, and Edit would show an empty caption. Play does not otherwise write mailbox.
+
+---
+
+### 2. Mailbox sidebar construction
+
+File: `Sources/Chrome/SourceSidebar.swift` (recut in place). Do not add a second sidebar file.
+
+#### SwiftUI structure: `List` + `Section`
+
+Not `OutlineGroup` (no recursive tree in M10). Not `DisclosureGroup` (five rows are always visible).
+
+```swift
+struct SourceSidebar: View {
+    @Environment(WorkspaceStore.self) private var store
+
+    var body: some View {
+        List(selection: selectedRow) {
+            ForEach(store.sources) { item in
+                Section {
+                    ForEach(WorkspaceMailbox.all, id: \.self) { box in
+                        Label(WorkspaceMailbox.displayName(box),
+                              systemImage: WorkspaceMailbox.symbolName(box))
+                            .tag(MailboxRowID(sourceID: item.id, mailbox: box))
+                    }
+                } header: {
+                    SourceAccountHeader(item: item)
+                        .contentShape(Rectangle())
+                        .onTapGesture { store.select(item.id, mailbox: WorkspaceMailbox.pages) }
+                        .contextMenu { sourceMenu(item) }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("Mailboxes")
+        .overlay { /* existing No Sources empty state */ }
+        .toolbar { /* existing plus → presentOpenPanel() */ }
+    }
+
+    private var selectedRow: Binding<MailboxRowID?> {
+        Binding(
+            get: {
+                guard let id = store.selection.sourceID else { return nil }
+                return MailboxRowID(
+                    sourceID: id,
+                    mailbox: WorkspaceMailbox.display(store.selection.mailbox)
+                )
+            },
+            set: { row in
+                guard let row else {
+                    store.select(nil)
+                    return
+                }
+                store.select(row.sourceID, mailbox: row.mailbox)
+            }
+        )
+    }
+}
+
+struct MailboxRowID: Hashable, Sendable {
+    var sourceID: SourceID
+    var mailbox: String
+}
+```
+
+`MailboxRowID` lives in `WorkspaceSelection.swift` (next to the mailbox strings) so tests can construct it without importing SwiftUI.
+
+#### Header click vs child click
+
+| Click | Store write | List highlight |
+|-------|-------------|----------------|
+| Section header | `select(id, mailbox: pages)` | Pages child (same `MailboxRowID`) |
+| Pages row | `select(id, mailbox: pages)` | Pages child |
+| Outputs / Publish / Plan / Activity | `select(id, mailbox: that)` | that child |
+
+The header is not a tagged row, so it never fights the child for highlight. Header tap and Pages tap are the same selection. That is Mail (account header → inbox).
+
+**Header tap is best-effort.** macOS sidebar `Section` headers plus `.onTapGesture` are flaky (hit testing, VoiceOver). Iterate in #100; do not block the card on a perfect header. The **Pages row is the accessible control**. #100 hand-gate: click header → Pages highlighted + play on Pages, *if* the tap registers; always verify clicking the Pages child.
+
+Put Relocate / Remove on the header context menu **and** on each child (same actions, keyed by `item.id`). Relocate stays enabled only when `!item.isAvailable`, matching today's `SourceRow` and File → Relocate (`Commands.swift` line 44: `.disabled(store.selectedSource?.isAvailable != false)`).
+
+Keep the stale caption ("Unreachable — Relocate / Remove") and slashed symbol on the header. Do not badge every mailbox child.
+
+#### Nested trunk folders: **out of M10-2**
+
+Do not show `graph.parent` trunks as sidebar folders in this milestone. Reasons:
+
+- Mailboxes lane does not own `Sources/Play/Local/` or `graph.json` decoding. Putting trunks in the sidebar would force Chrome to read IR.
+- Selection identity for a trunk id is the "later" row in the card table. Half-building it creates mailbox strings Reading does not filter on.
+- Indent in the Pages *message list* already expresses parent (M3 `PlayPage.depth`). That stays.
+
+When a later card adds trunks, `mailbox` becomes the trunk id (open string) and Reading filters `LocalPlayGraph.pages` by that parent. That card **must** stop using `WorkspaceMailbox.display` for persist and must stop treating unknown as Pages in the center switch **before** it writes a trunk id. Do not invent a second field. M10 will not round-trip trunks.
+
+#### Multi-source expand/collapse
+
+Always expanded. No persisted outline state. Five mailboxes × N sources is small (a workspace with ten local folders is 50 rows). A collapse control would be a third piece of machine state we do not need.
+
+#### Empty workspace
+
+Keep the existing `EmptyStateView(title: "No Sources", …, action: presentOpenPanel)`. Do not invent a second empty state.
+
+#### `MainWindow` — #100 is the sole M10 owner
+
+HARNESS §4 is path-based. Two PRs must not share `MainWindow.swift`.
+
+`Sources/Chrome/MainWindow.swift` in **#100 only**:
+
+1. Bump `.navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 300)` to `min: 200, ideal: 240, max: 340`.
+2. Sidebar column title stays with `SourceSidebar.navigationTitle("Mailboxes")`.
+3. Editor toolbar button (lines 61–67): `.disabled(!store.selection.canEditPage)`. Preview toolbar stays source-gated. Do not add views.
+
+#102 does **not** edit this file. `canEditPage` lands on `WorkspaceSelection` in #100 (already that PR’s file).
+
+#### M10-2 PlayTab shim
+
+`LocalPlay.swift` today:
+
+```swift
+@State private var selectedTab: PlayTab = .pages
+Picker("View", selection: $selectedTab) { … }
+switch selectedTab { … }
+```
+
+Replace `@State` with a Binding onto the store so the app does not go dark if #101 has not merged:
+
+```swift
+private var selectedTab: Binding<LocalPlay.PlayTab> {
+    Binding(
+        get: { PlayTab(mailbox: store.selection.mailbox) },
+        set: { store.select(mailbox: $0.mailboxKey) }
+    )
+}
+```
+
+```swift
+extension LocalPlay.PlayTab {
+    var mailboxKey: String {
+        switch self {
+        case .pages: return WorkspaceMailbox.pages
+        case .outputs: return WorkspaceMailbox.outputs
+        case .publish: return WorkspaceMailbox.publish
+        case .plan: return WorkspaceMailbox.plan
+        case .activity: return WorkspaceMailbox.activity
+        }
+    }
+
+    init(mailbox: String?) {
+        switch WorkspaceMailbox.display(mailbox) {
+        case WorkspaceMailbox.outputs: self = .outputs
+        case WorkspaceMailbox.publish: self = .publish
+        case WorkspaceMailbox.plan: self = .plan
+        case WorkspaceMailbox.activity: self = .activity
+        default: self = .pages
+        }
+    }
+}
+```
+
+Do not redesign the center list. Do not delete the picker. M10-3 deletes both.
+
+The shim is **sequential**, not parallel: #101 must not start until #100 is on `main` (already the parent-card rule). If that order is broken, drop the shim and let #101 land mailbox switching alone.
+
+---
+
+### 3. Settings → Sources
+
+#### Same store instance
+
+`SolipsistApp` already holds the only `WorkspaceStore`:
+
+```swift
+@State private var store = WorkspaceStore()
+@State private var runtime = AppRuntime()
+```
+
+Add a `Settings` scene next to the existing `WindowGroup`s. Pass the same instance. Do not construct a second store. Do not introduce a singleton. Do not put Settings state on `AppRuntime`.
+
+```swift
+Settings {
+    SettingsRoot()
+        .environment(store)
+        .environment(runtime)
+}
+```
+
+macOS presents **Solipsist → Settings…** automatically for a `Settings` scene. **Do not edit `Commands.swift`.** The filed M10-1 card is patched: Settings commands are *not* this PR. File → Open… / Open Recent / Relocate / Remove stay as they are (#102 is the only M10 owner of `Commands.swift`).
+
+`runtime` is injected so a future Settings pane can show engine identity; M10-1 must not write `boris.json` or call coordinator verbs.
+
+#### Folder and XcodeGen
+
+New files under `Sources/App/Settings/`:
+
+- `SettingsRoot.swift` — `TabView` with one tab, so later panes slot in.
+- `SourcesSettingsPane.swift` — the account book.
+
+`Project.yml` already has `- path: Sources/App` with `createIntermediateGroups: true`. **No `Project.yml` change** for app membership. **Do not touch entitlements.**
+
+#### Pane UI
+
+```
+┌ Settings ─────────────────────────────────────────┐
+│ [Sources]                                          │
+│                                                    │
+│  ┌──────────────────────────────────────────────┐  │
+│  │ 📁 happy          Local                      │  │
+│  │    /Users/…/Stunts/happy                     │  │
+│  │ 📁 dogfood        Local   Unreachable        │  │
+│  │    /old/path                                 │  │
+│  └──────────────────────────────────────────────┘  │
+│                                                    │
+│  [Add Local…]  [Relocate…]  [Remove]               │
+│                                                    │
+│  A source is a folder of Boris content.            │
+└────────────────────────────────────────────────────┘
+```
+
+- Rows: `title`, `kind.displayName` (`"Local"` from `SourceKind`), `detailLine` (path, middle-truncated), stale badge identical to the sidebar caption.
+- Selection in this list **is** `store.selection.sourceID`. Clicking a row calls `store.select(item.id)`. Yes — Settings can change the selected source. Add Local already does (`WorkspaceStore.addLocal` → `select(local.id)`).
+- **If #99 lands before #100:** `select(_:)` still does not persist (today’s code). List *membership* persists via existing `addLocal` (#59). Which row is selected is in-session only until #100. Do not misread the #99 gate as “Settings click survives quit.”
+- **After #100:** the same `select(item.id)` also writes `mailbox = pages` and persists `selected` + `mailbox`.
+- **Add Local…** → `store.presentOpenPanel()`. Always enabled.
+- **Relocate…** → `store.presentRelocatePanel(for:)` on the selected id. Enabled iff `store.selectedSource?.isAvailable == false`. Matches File → Relocate Source….
+- **Remove** → `store.remove(id)`. Enabled iff `store.selection.sourceID != nil`. Confirm with a system `confirmationDialog` ("Remove “happy” from Solipsist? The folder on disk is not deleted."). File menu has no confirm today; Settings is the account book and should ask.
+- Empty state (no sources):
+
+  > **No Sources**
+  >
+  > A source is a folder of Boris content — an account, not a file tree. Add a folder that contains `boris.json` (for example `Stunts/happy`) to get started.
+
+  Action button: **Add Local…**.
+
+- Do not add a GitHub row. Do not auto-open `SUPPORT-NOT-FOR-GITHUB/` or any repo path.
+- D2: this pane writes bookmarks / plist only, through the existing store methods. It does not write `boris.json`. It does not move profile keys or execution knobs here.
+
+#### Gate
+
+Solipsist → Settings… → Sources → Add Local… a folder with `boris.json` → it appears in the sidebar and is selected. Relocate and Remove from Settings match the File-menu verbs. Restart → **the source is still in the list** (#59). Selected-row persistence is #100. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+---
+
+### 4. Reading pane + PreviewSession sharing
+
+#### Lift the session (named recut) and bind it to the selected source
+
+Today the companion’s `PreviewSession` is `@State` on `PreviewWindow` and `.onDisappear { session.stop() }`. Restart on source change is `.task(id: source.id)` **in that window**. `Coordinator.activeWatch` is `private weak` and does not expose `serveURL`. `PreviewSession.rootPath` is private.
+
+If we only lift the object onto `AppRuntime` and leave retarget to the companion `.task`, a **closed** companion will not run that task when the sidebar source changes. The letter would then call `PreviewURL.pageURL` against another folder’s loopback server. That violates HARNESS §3 “one watch session per selected source” without spawning a second `Process`.
+
+**Named recut (card M10-3 is patched):** Reading may (1) park the existing `PreviewSession` on `AppRuntime`, (2) substitute `PreviewWindow` to use it and drop stop-on-disappear, (3) expose `boundRootPath` / `isBound(to:)`, (4) add `PreviewURL` helpers, (5) bind the session from `PlayHost`. It may **not** change `WatchServer` argv, add a second session, or call `BorisEngine.previewStart` except through `PreviewSession.start`.
+
+`AppRuntime` comment today: “the engine identity, not the workspace. Companions … do not spawn `boris`.” Update it:
+
+```swift
+/// Process-wide runtime: engine identity, coordinator, and the one
+/// preview watch session (lifted from the companion so Play can observe
+/// it). Companions and Play ask this type; they do not spawn `boris`.
+@MainActor
+@Observable
+final class AppRuntime {
+    let engine: BorisEngine?
+    // …
+    let coordinator = Coordinator()
+    let credentials = PublishCredentialManager()
+    let previewSession = PreviewSession()
+}
+```
+
+This is still one `WatchServer` `Process`, not a second `BorisEngine` `RunHandle`.
+
+`PreviewSession` additive API (`Sources/Companions/Preview/PreviewSession.swift`):
+
+```swift
+/// Content-root path this session last started, if any.
+var boundRootPath: String? { rootPath }
+
+func isBound(to contentRoot: URL) -> Bool {
+    boundRootPath == contentRoot.standardizedFileURL.path
+}
+```
+
+`PlayHost` (always mounted in `MainWindow`’s detail column — do **not** grow `MainWindow`) is the binder that stays alive when the companion is closed:
+
+```swift
+// PlayHost — #101 named recut, binder only
+@Environment(AppRuntime.self) private var runtime
+
+// on the existing Group:
+.onAppear { syncPreviewSession() }
+.onChange(of: store.selection.sourceID) { syncPreviewSession() }
+
+private func syncPreviewSession() {
+    let session = runtime.previewSession
+    guard
+        case .local(let local) = store.selectedSource,
+        local.isAvailable,
+        let content = try? local.contentRoot(),
+        let project = try? local.workspaceRoot()
+    else {
+        if session.phase != .idle { session.stop() }
+        return
+    }
+    switch session.phase {
+    case .idle, .failed:
+        return // do not auto-start watch
+    case .starting, .serving:
+        if !session.isBound(to: content) {
+            session.start(
+                contentRoot: content,
+                projectRoot: project,
+                engine: runtime.engine,
+                coordinator: runtime.coordinator
+            )
+        }
+    }
+}
+```
+
+`PreviewSession.start` already `stop()`s then starts when the root differs (lines 57–66). PlayHost calls that — not `previewStart` from the letter.
+
+`PreviewWindow`:
+
+- Replace `@State private var session = PreviewSession()` with `runtime.previewSession`.
+- Delete `.onDisappear { session.stop() }`.
+- Keep `.task(id: source.id) { startPreview(for: source) }` so **opening** the companion still starts watch (PlayHost will not auto-start from idle).
+
+Watch lifetime after the lift:
+
+| Event | Effect |
+|-------|--------|
+| Preview companion appears | `start(...)` (existing window task) |
+| Same source, window reopened | reuse running server (`start` idempotent) |
+| Source changes, companion **open** | PlayHost *and* window task retarget via `start` |
+| Source changes, companion **closed**, session was serving/starting | **PlayHost retargets** to the new content root |
+| Source changes, companion closed, session idle/failed | stay idle (letter shows summary) |
+| No usable source (none selected / stale) | PlayHost `stop()`s a live session |
+| Companion window closed | watch stays up **if** still bound to the selected source |
+| Reading-pane Preview button | `openWindow(id: CompanionID.preview)` — starts via the companion task |
+| Boris → Stop with no running job | `Coordinator.stop` SIGTERMs `activeWatch` (`Coordinator.swift` 264–272) |
+| App terminate | `coordinator.terminateAll` force-kills watch |
+
+Reading pane never holds a `WatchServer`, never touches `Sources/Engine/**`.
+
+#### How Play observes watch without owning Engine
+
+```swift
+let session = runtime.previewSession
+let bound: Bool = {
+    guard case .local(let local) = store.selectedSource,
+          let root = try? local.contentRoot()
+    else { return false }
+    return session.isBound(to: root)
+}()
+
+switch (bound, session.phase) {
+case (true, .serving(let helperURL)):
+    // load PreviewURL.pageURL(helper:pageID:)
+case (true, .starting):
+    // ProgressView("Starting preview…")
+case (false, .serving), (false, .starting):
+    // foreign root — treat as idle (summary). PlayHost should already retarget.
+    // Do not load pageURL against this helper.
+case (_, .idle), (_, .failed):
+    // contract summary + Preview / Edit buttons
+}
+```
+
+`PreviewSession.phase` is already `Equatable` and `@Observable`. No new Engine API. The `isBound` check is defense in depth if PlayHost has not yet hopped.
+
+#### URL derivation
+
+Do not invent a permalink field. `GraphNode` has `id` + `sourcePath` and nothing else (`BorisContracts.swift` 129–145). ENGINE-CONTRACTS §1:
+
+| Endpoint | Behavior |
+|----------|----------|
+| `GET /` | `index.html` |
+| `GET /<page>.html` | static page |
+| `GET /__boris/` | helper (iframe + EventSource) |
+| `GET /__boris/events` | SSE `event: reload` |
+
+`WatchServer.onServe` delivers the helper (`http://127.0.0.1:PORT/__boris/`). The published page identity is `GraphNode.id` / `PlayPage.id`, **not** the file stem:
+
+| `id` | `sourcePath` | Served path |
+|------|--------------|-------------|
+| `index` | `index.md` | `/index.html` |
+| `guides/getting-started` | `guides/getting-started.md` | `/guides/getting-started.html` |
+| `recipe/soup` | `recipes/soup.cook` | `/recipe/soup.html` |
+
+Swapping the extension on `sourcePath` would 404 a Cooklang row *if* the engine serves by id. That mapping is a **Solipsist rule**, not a verified watch field: ENGINE-CONTRACTS §1 writes `GET /<page>.html` without defining `<page>`. In-repo IR fixtures have `id` == stem. The `recipe/soup` vs `recipes/soup.cook` pair exists only as a synthetic `PlayPage` in `PlayGraphActivityPlanTests.swift`, not as a probed `watch --serve`. A `Stunts/happy` hand gate will not distinguish id vs stem.
+
+Keep id-based `pageURL`. Do not invent a permalink field. Card #101 is patched so implementers do not follow the old `sourcePath` hint.
+
+**Hand-gate (if a cook / id≠stem corpus is available):** confirm `GET /{id}.html` vs `GET /{stem}.html` before treating a 404 as “not built yet.” If live serve is stem-based, file a follow-up on #101 — do not silently swap extensions in M10.
+
+Add a pure function on the existing `PreviewURL` type (`Sources/Companions/Preview/PreviewURL.swift`):
+
+```swift
+extension PreviewURL {
+    /// Site origin from the helper URL `http://127.0.0.1:PORT/__boris/`.
+    public static func siteOrigin(fromHelper helper: URL) -> URL? {
+        guard isLoopback(helper) else { return nil }
+        var components = URLComponents(url: helper, resolvingAgainstBaseURL: false)
+        let path = components?.path ?? ""
+        if path == "/__boris" || path.hasPrefix("/__boris/") {
+            components?.path = "/"
+        }
+        components?.fragment = nil
+        components?.query = nil
+        return components?.url
+    }
+
+    /// `GET /{pageID}.html` on the served tree. `pageID` is `GraphNode.id`.
+    public static func pageURL(helper: URL, pageID: String) -> URL? {
+        guard let origin = siteOrigin(fromHelper: helper) else { return nil }
+        let trimmed = pageID.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !trimmed.isEmpty else { return nil }
+        return URL(string: trimmed + ".html", relativeTo: origin)?.absoluteURL
+    }
+}
+```
+
+#### WKWebView + 404 / load failure
+
+Do **not** embed `PreviewWindow` or `PreviewWebView` in the center column. Those types own the paste-URL toolbar and `openInBrowser`.
+
+Add in `Sources/Play/Local/`:
+
+- `ReadingPane.swift` — letter **or** in-pane summary + Preview/Edit. Never a second URL (no `file://`, no stem fallback).
+- `ReadingWebModel` (`@Observable`) + `ReadingWebView` (`NSViewRepresentable`).
+- `ReadingWebModel` sets `webView.navigationDelegate` to itself (or a small nested `NSObject` coordinator). `PreviewURL.isAllowed` before every `load`.
+
+**Detecting failure** (`WKNavigationDelegate`):
+
+| Signal | Treat as |
+|--------|----------|
+| `didFail` / `didFailProvisionalNavigation` | load failure → summary + caption |
+| `decidePolicyFor navigationResponse` where `HTTPURLResponse.statusCode` is 404 (or ≥400) | `.cancel` + summary + caption (“This page is not at the served URL yet. Build HTML or wait for watch.”) |
+| `didFinish` with no prior failure | show the web view |
+
+`WKWebView` often reports HTTP 404 as a *successful* navigation; checking `statusCode` is required. Do not infer 404 from title or HTML body.
+
+**Retry:** reload the page URL when (1) `previewSession.serveURL` changes, (2) the user re-selects the Pages row. Because `WorkspaceNoun` is `Equatable`, assigning the same noun may not notify `@Observable`. Increment a local `loadGeneration` in the list `Binding.set` (even when id is unchanged) and `.task(id: loadGeneration)` the letter. Rebuilds that keep the same helper URL do **not** retry (D-S11, no SSE). A 404 from a not-yet-built page waits for re-select or a new `serveURL`.
+
+Two WKWebViews on the same loopback origin is fine. One `Process` (the existing watch).
+
+#### Split: stacked
+
+```swift
+VSplitView {
+    pageList(pages)
+        .frame(minHeight: 120)
+    ReadingPane(page: selectedPlayPage, source: source)
+        .frame(minHeight: 160)
+}
+```
+
+Why stacked, not list-left-of-letter:
+
+- `MainWindow` is already `NavigationSplitView` (sidebar | play) + `.inspector`. A third horizontal split at `minWidth: 800` crushes titles and the indent column (`PlayPage.depth * 16`).
+- The problems strip is already a bottom `safeAreaInset` (`LocalPlay.swift` 56–62). Stacked list-above-letter sits naturally above it.
+- Mail's classic wide layout is list-left; Mail's classic *single-column* message+preview is list-above. Our center column is that single column.
+
+Keep `.searchable` on the list. Keep indent, badges, filter.
+
+#### Watch up / down while a page is showing
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant List as Pages list
+    participant Letter as ReadingPane
+    participant Store as WorkspaceStore
+    participant Session as AppRuntime.previewSession
+    participant Companion as PreviewWindow
+
+    User->>List: click page
+    List->>Store: select(noun: page + sourcePath)
+    Store-->>Letter: noun
+    Letter->>Session: read phase
+    alt phase == idle/failed
+        Letter-->>User: summary + Preview / Edit
+        User->>Letter: Preview
+        Letter->>Companion: openWindow(preview)
+        Companion->>Session: start(...)
+        Session-->>Letter: phase == serving(helper)
+        Letter->>Letter: load pageURL(helper, id)
+    else phase == serving
+        Letter->>Letter: load pageURL(helper, id)
+    end
+    User->>Companion: close window
+    Note over Session: watch stays up
+    Letter-->>User: letter still loaded
+    User->>User: Boris → Stop
+    Session-->>Letter: phase == idle
+    Letter-->>User: summary again
+```
+
+#### SSE
+
+The companion helper at `/__boris/` owns `EventSource('/__boris/events')` and reloads its iframe. The reading pane loads `/{id}.html` directly, so it will **not** auto-reload on rebuild.
+
+M10 choice: **do not subscribe**. Reload the page URL only when `previewSession.serveURL` changes (start / restart / source switch). Live-while-editing remains the Preview companion. A later card may add an EventSource client; that is not a second `Process` and not this milestone.
+
+#### Other mailboxes
+
+```swift
+switch WorkspaceMailbox.display(store.selection.mailbox) {
+case WorkspaceMailbox.outputs:  OutputsPane(source: source)
+case WorkspaceMailbox.publish:  PublishPane(source: source)
+case WorkspaceMailbox.plan:     PlanPane(source: source)
+case WorkspaceMailbox.activity: ActivityPane()
+default:                        pagesMailbox   // pages, nil, or unknown (M10)
+}
+```
+
+`display` is UI-only. It must not write `pages` over an unknown stored mailbox. A later trunk card replaces this `default` with a filter — it must not ship while M10 still maps unknown → Pages **and** persist-on-select is live.
+
+No fake message list. Delete the `Picker`. Delete `PlayTab` (or leave the mapping type file-private and unused — prefer delete). Problems strip stays under all mailboxes.
+
+#### Summary (watch down, or no page)
+
+When `noun?.kind == "page"` and watch is down, render a `Form` / `LabeledContent` stack, not Markdown:
+
+- Title, ID, Status, Role, `sourcePath` from the `PlayPage` / noun.
+- Tags from `PlayPage.tags`.
+- Relations: decode `.boris/completion.json` with the existing `Completion` model (`Sources/Models/BorisContracts.swift`). Do **not** import `InspectorCompletion` (Play must not take a dependency on `Sources/Inspector/`). Same file path `LocalPlay` already uses for `graph.json`. Decode failure → omit relations (D8).
+- Buttons: **Preview** → `openWindow(id: CompanionID.preview)`. **Edit** → `openWindow(id: CompanionID.editor)` (the M10-3 stub; header chrome is M10-4).
+
+When no page is selected: `ContentUnavailableView` "No Page Selected" / "Select a page to read it."
+
+On graph reload inside `apply(_:)` after building `pages`:
+
+- If `noun?.kind == "page"` and no row has that `id` → `store.select(noun: nil)`.
+- If the id still exists → rewrite the noun (`id`, `title`, `sourcePath`) even when the id is unchanged, so a moved file does not leave a stale Edit caption.
+
+Problems jump (#101): after `select(mailbox: pages)`, write `WorkspaceNoun(kind: "page", id:title:sourcePath:)` using `LocalPlayGraph.resolvePage` / the in-memory list — same path as the list writer. Today `ProblemsPane` writes id+title only.
+
+Stale / failed / empty graph states stay `ContentUnavailableView` as today. No monospaced dump.
+
+---
+
+### 5. Editor wiring
+
+#### Finding: no file-open contract
+
+Fact-checked against the tree (not against a live afterparty checkout — we do not touch `boris/`):
+
+| Source | What it pins |
+|--------|----------------|
+| `docs/issues/boris-A14-editor-launch-contract.md` | Launch line `BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=<32 hex>`. Flags: `[DIR] [--boris PATH] [--ui-dir DIR] [--port PORT]`. Token in the **fragment**, not query. Non-goals: no NDJSON, no WKWebView-specific behavior. |
+| `docs/issues/README.md` | "M10 editor wiring (#102) may later need an open-file deep link on `boris-editor`; do not draft it until it is fact-checked against afterparty. Do not invent a query/fragment." |
+| `Sources/Companions/Editor/EditorURL.swift` | Accepts only loopback `http` + `#token=<hex>`. No `file`, `path`, or `sourcePath` parameter. A second fragment key would fail `hasPrefix("token=")`. |
+| `Sources/Engine/EditorServer.swift` | Args: `contentRoot --boris <engine> --port 0`. No file argument. |
+| `docs/cards/parallel/editor-shell.md` | "Do not put the token into query or logs." |
+
+There is no proven query or fragment the Svelte shell honors for a file. **Do not invent one. Do not draft `docs/issues/boris-A*-editor-open-file.md` in M10.** Surface `sourcePath` in chrome and stop.
+
+#### Companion header (M10-4)
+
+`EditorWindow.header(for:)` today shows `source.title` + `source.detailLine` (folder path). After M10-4:
+
+```
+{noun.title}                         // if noun.kind == "page"
+{noun.sourcePath}                    // caption, middle-truncated
+{source.title} · Editor              // otherwise keep today's header
+```
+
+Session stays source-scoped: `EditorSession.start(contentRoot:projectRoot:engine:)` unchanged. Paste-`BORIS_EDITOR_URL=` and Open in Browser stay. SIGTERM on close stays (`EditorSession.stop` → `EditorServer.stop` → `process.terminate()`).
+
+`PageSection.openEditor()` already opens the same window. Leave it (card: do not touch Inspector, or point it at the same verb — pointing is a one-line no-op).
+
+#### Menu, keyboard, gestures
+
+| Affordance | Where | Enablement | Owner |
+|------------|-------|------------|-------|
+| **File → Edit Page** | `Commands.swift` `CommandGroup(replacing: .newItem)` after Remove Source | `store.selection.canEditPage` | **M10-4** |
+| **View → Editor** (⌘⇧E) | existing `CommandGroup(after: .sidebar)` | stays source-gated (`selectedSource != nil`) — open the companion for the project | unchanged |
+| Toolbar **Editor** | `MainWindow.swift` lines 61–67 | `.disabled(!store.selection.canEditPage)` | **M10-2** (sole MainWindow owner) |
+| Double-click / Return on a Pages row | `LocalPlay` page list | same as Edit Page | **M10-3** |
+| Reading-pane **Edit** button | `ReadingPane` | same | M10-3 stub |
+
+Return is **list-local** (`.onKeyPress(.return)` / `onSubmit` on the `List`), not a global menu shortcut. A global Return would steal from Inspector text fields.
+
+```swift
+// M10-3, inside pageList(_:) — openWindow comes from the environment
+.onKeyPress(.return) {
+    guard store.selection.canEditPage else { return .ignored }
+    openWindow(id: CompanionID.editor)
+    return .handled
+}
+```
+
+Double-click: `simultaneousGesture(TapGesture(count: 2).onEnded { … })` on `PageRow`, or `NSTableView` style via `onTapGesture(count: 2)` on the row. One action, not a new list.
+
+No `⌘` shortcut on Edit Page. Do not steal ⌘⇧E.
+
+#### Recut vs the card's `LocalPlay.swift` ownership
+
+Card M10-4 lists `Sources/Play/Local/LocalPlay.swift` (double-click). Card M10-3 owns that file entirely (tabs go away, list + letter). HARNESS §4: if two PRs need the same file, recut.
+
+**Recut (D-S13):** M10-4’s “Do not touch” gains `Sources/Play/Local/**` **and** `Sources/Chrome/MainWindow.swift`. M10-3 lands the list gestures as `openWindow(id: CompanionID.editor)`. M10-4’s gate (“title and `sourcePath` visible”) is satisfied in `EditorWindow` and **requires #101’s noun writer** — merge #102 only after #101 is on `main`. Development of `EditorWindow` / `Commands.swift` may start after #100 (`sourcePath` is on the type).
+
+---
+
+### 6. Lane / file ownership and merge order
+
+#### Conflict matrix
+
+| Path | #99 Settings | #100 Mailboxes | #101 Reading | #102 Editor |
+|------|:---:|:---:|:---:|:---:|
+| `Sources/App/Settings/**` (new) | **owns** | — | — | — |
+| `Sources/App/SolipsistApp.swift` | Settings scene | — | — | — |
+| `Sources/App/AppRuntime.swift` | — | — | `previewSession` + comment | — |
+| `Sources/App/Commands.swift` | **do not touch** | — | — | **owns** File → Edit Page |
+| `Sources/Chrome/SourceSidebar.swift` | — | **owns** | — | — |
+| `Sources/Chrome/MainWindow.swift` | — | **sole owner** (width + Editor toolbar) | — | **do not touch** |
+| `Sources/Chrome/PlayHost.swift` | — | — | **binder only** (named recut) | — |
+| `Sources/Workspace/WorkspaceSelection.swift` | — | **owns** (`mailbox`, `sourcePath`, `MailboxRowID`, `WorkspaceMailbox`, `canEditPage`, `WorkspaceSelectionRules`) | — | — |
+| `Sources/Workspace/WorkspaceStore.swift` | read-only add/remove/relocate | **owns** `select(mailbox:)`, persist-on-select | — | — |
+| `Sources/Workspace/WorkspacePersistence.swift` | — | **owns** `mailbox: String? = nil` | — | — |
+| `Sources/Play/Local/LocalPlay.swift` | — | PlayTab shim; **#101 starts after #100** | **owns** (deletes shim) | **do not touch** |
+| `Sources/Play/Local/ReadingPane.swift` (new) | — | — | **owns** | — |
+| `Sources/Play/Local/ReadingWebView.swift` (new) | — | — | **owns** | — |
+| `Sources/Play/Local/LocalPlayGraph.swift` | — | — | prefer leave | — |
+| `Sources/Play/Local/{Outputs,Publish,Plan,Activity,Problems}Pane.swift` | — | — | Problems jump + `sourcePath`; others untouched | — |
+| `Sources/Companions/Preview/PreviewURL.swift` | — | — | `siteOrigin` / `pageURL` (named recut) | — |
+| `Sources/Companions/Preview/PreviewWindow.swift` | — | — | shared session; no stop-on-disappear | — |
+| `Sources/Companions/Preview/PreviewSession.swift` | — | — | expose `boundRootPath` / `isBound(to:)` | — |
+| `Sources/Companions/Editor/**` | — | — | — | **owns** header |
+| `Sources/Engine/**` | — | — | — | — |
+| `Sources/Inspector/**` | — | — | — | — |
+| `Project.yml` (any) / `scripts/embed-boris.sh` | — | — | — | — |
+| `docs/M10-DESIGN.md` + four child cards + `docs/HARNESS.md` §4 | design lane | — | — | — |
+
+If a PR needs a cell marked for another PR, stop and recut again. Do not "just this once."
+
+#### Shims
+
+**M10-2 → M10-3 (`LocalPlay.swift`).** Sequential only: #101 starts after #100 is on `main`. M10-2’s only legal Play edit is the PlayTab Binding. M10-3 deletes it. If #101 ever starts first, drop the shim.
+
+**M10-3 → M10-4.** Recut: M10-4 does not touch Play or MainWindow. M10-3 writes `sourcePath` and lands gestures. M10-4 fills the header. **Merge #102 after #101.**
+
+#### Recommended merge order
+
+```mermaid
+flowchart TD
+    A["#99 M10-1 Settings<br/>feat/m10-settings-sources"] 
+    B["#100 M10-2 Mailboxes<br/>feat/m10-mailbox-sidebar"]
+    C["#101 M10-3 Reading<br/>feat/m10-reading-pane"]
+    D["#102 M10-4 Editor<br/>feat/m10-editor-wiring"]
+    A --> C
+    B --> C
+    C --> D
+    A -.->|parallel| B
+    B -.->|dev after type exists| D
+```
+
+| Issue | Branch | May start | May merge | "Landed" means |
+|-------|--------|-----------|-----------|----------------|
+| #99 | `feat/m10-settings-sources` | immediately, off `main` | anytime | Settings adds/removes/relocates; list membership persists (#59); tests green |
+| #100 | `feat/m10-mailbox-sidebar` | immediately, off `main` | anytime | Sidebar is account + five mailboxes; `mailbox` written + persisted; PlayTab shim; MainWindow width + toolbar; tests green |
+| #101 | `feat/m10-reading-pane` | after #100 is on `main` | after #100 | Tabs gone; list + letter; session bound to selected source; no `file://`; tests green |
+| #102 | `feat/m10-editor-wiring` | after #100 (`sourcePath` on the type) | **after #101** | File → Edit Page; header shows title + `sourcePath` written by #101; link-out works; tests green |
+
+#99 and #100 are disjoint (no shared files). #102 development may overlap #101 on `EditorWindow` / `Commands` only. #102 **merge** is after #101. #78 stays its own track.
+
+Implementation branches off `main`, not off `docs/m10-mail-body`. That branch is docs-only.
+
+---
+
+### 7. Tests
+
+ContractTests already compiles `WorkspaceSelection`, `WorkspacePersistence`, `LocalSource`, `LocalPlayGraph`, `PreviewURL`, `EditorURL` **without** the bundled boris binary. `WorkspaceStore.swift` is **not** in the test target and **must not** be added. Do not edit `Project.yml`.
+
+`WorkspaceStore` imports AppKit, calls `NSDocumentController` from `init`/`refreshRecentFolders()`, and `presentNewProjectPanel(runtime:)` references `AppRuntime` → `Coordinator` → `ContentTreeWatcher` / `SaveValidateGate`. That is a large App graph, not “add one path.”
+
+#### Extend existing files
+
+| File | Add |
+|------|-----|
+| `Tests/ContractTests/WorkspacePersistenceTests.swift` | `PersistedWorkspace(sources:selected:)` still compiles (`mailbox` defaults `nil`). Payload **without** `mailbox` decodes `nil` (backward). JSON **with** `"mailbox":"outputs"` still yields `sources`/`selected` when extras are ignored (forward). Round-trip `"mailbox":"guides/overview"` preserves the string (not rewritten to `pages`). |
+| `Tests/ContractTests/CompanionURLTests.swift` | `siteOrigin` / `pageURL` for `index`, `guides/getting-started`, **and** `recipe/soup`; reject non-loopback helpers; reject `file://`. |
+| `Tests/ContractTests/PlayGraphActivityPlanTests.swift` | no change required. |
+
+#### New files
+
+| File | Lane | What |
+|------|------|------|
+| `Tests/ContractTests/WorkspaceSelectionTests.swift` | #100 | `WorkspaceMailbox.display` / `isKnown`; `MailboxRowID` hash; `WorkspaceNoun` with and without `sourcePath`; `canEditPage`; `WorkspaceSelectionRules.selectSource` / `selectMailbox` / `select` / `restore` (source change → pages + noun nil; mailbox change clears noun; same-id `selectSource` does not clobber mailbox; restore keeps raw mailbox including unknown). |
+
+No `WorkspaceStoreSelectionTests`. No `EditorEnablementTests` — `canEditPage` is covered in `WorkspaceSelectionTests` (#100). #102 has no new test file.
+
+#### What cannot be unit-tested without boris (and is not required)
+
+- `PreviewSession.start` actually binding a port.
+- `EditorSession` launching `boris-editor`.
+- WKWebView navigation / 404 fallback.
+- SwiftUI `List` highlight of `MailboxRowID`.
+
+Those are the card gates, exercised by hand on `Stunts/happy`.
+
+`SKIP_EMBED_BORIS=1 make build` + `make test` remains the merge gate for every PR. The new tests must not require `SOLIPSIST_BORIS_BIN`.
+
+---
+
+### 8. Docs / issue hygiene
+
+| Destination | Write |
+|-------------|--------|
+| Durable copy | `docs/M10-DESIGN.md` on `docs/m10-mail-body` (design lane). This file. |
+| **`docs/HARNESS.md` §4** | **Required.** Four M10 lane rows + sequence item 4: Settings = `App/Settings/` + `SolipsistApp` only; Mailboxes = sidebar + selection/persist + sole `MainWindow`; Reading = `Play/Local/` + named Preview/`PlayHost`/`AppRuntime` recut; Editor wiring = `Companions/Editor/` + `Commands.swift`, merge after Reading. HARNESS wins if a card and this file ever drift. |
+| **Child cards** | **Patch Owns / Do-not-touch / Gate** on `M10-settings-sources.md`, `M10-mailbox-sidebar.md`, `M10-reading-pane.md`, `M10-editor-wiring.md`, plus sequence on `M10-mail-body.md` and `cards/README.md`. Required, not optional pointers. |
+| #98 (tracker) | Comment: pointer to `docs/M10-DESIGN.md`; Key Decisions; merge #102 after #101; recuts; PlayHost binder; no `Project.yml`. |
+| #99 | Same `@State store`; **do not edit `Commands.swift` or `Project.yml`**; list membership persists (#59); selected-row persistence is #100; after #100, Settings `select(id)` resets mailbox to `pages`. |
+| #100 | Selection + persist rules; sole `MainWindow` owner; `WorkspaceSelectionRules`; no `Project.yml`; no `WorkspaceStore` in ContractTests; header tap best-effort. |
+| #101 | After #100; named Preview/`PlayHost`/`AppRuntime` recut; bind session to selected source; URL from `id`; stacked; no SSE; gestures; Problems + graph reload write `sourcePath`. |
+| #102 | **Merge after #101.** No `LocalPlay`, no `MainWindow`. File → Edit Page. Header reads `noun.sourcePath`. No boris issue. |
+| `docs/help.md` | Design-lane follow-up after #101. |
+| `docs/issues/` | Nothing in M10. |
+
+---
+
+## API / Interface Changes
+
+### `WorkspaceSelection` / `WorkspaceNoun`
+
+Before:
+
+```swift
+struct WorkspaceSelection: Hashable, Sendable, Codable {
+    var sourceID: SourceID?
+    var noun: WorkspaceNoun?
+    static let empty = WorkspaceSelection(sourceID: nil, noun: nil)
+}
+struct WorkspaceNoun: Hashable, Sendable, Codable {
+    var kind: String
+    var id: String
+    var title: String
+}
+```
+
+After: add `mailbox: String? = nil` (default so `WorkspaceSelection(sourceID:noun:)` still compiles) and `WorkspaceNoun.sourcePath: String? = nil`. M10-3 is the only writer of `sourcePath`:
+
+```swift
+store.select(noun: WorkspaceNoun(
+    kind: "page",
+    id: page.id,
+    title: page.title,
+    sourcePath: page.sourcePath
+))
+```
+
+`OutputsPane` target/edition nouns leave `sourcePath` nil.
+
+### `WorkspaceStore`
+
+| Method | Change |
+|--------|--------|
+| `select(_ id: SourceID?)` | Rules + persist **if changed**. Source change → mailbox `pages`, noun nil. |
+| `select(mailbox:)` | **New.** Raw string. Persist if changed. |
+| `select(_ id: SourceID, mailbox: String)` | **New.** Sidebar write path. Persist if changed. |
+| `select(noun:)` | Unchanged (no persist). |
+| `persist()` | Writes `mailbox: selection.mailbox` (raw). Rewrites bookmarks. |
+| `load()` | `WorkspaceSelectionRules.restore` — raw mailbox. |
+
+### `PersistedWorkspace`
+
+```swift
+var mailbox: String? = nil
+```
+
+Key unchanged: `solipsist.workspace.sources.v1`.
+
+### `AppRuntime`
+
+```swift
+let previewSession = PreviewSession()
+```
+
+Comment updated: runtime also owns the one preview watch session.
+
+### `PreviewSession`
+
+```swift
+var boundRootPath: String? { rootPath }
+func isBound(to contentRoot: URL) -> Bool
+```
+
+### `PreviewURL`
+
+```swift
+static func siteOrigin(fromHelper helper: URL) -> URL?
+static func pageURL(helper: URL, pageID: String) -> URL?
+```
+
+### `PreviewWindow`
+
+Uses `runtime.previewSession`. No `stop()` on disappear.
+
+### `PlayHost`
+
+`syncPreviewSession()` on appear and `sourceID` change.
+
+### `Settings` scene
+
+New. System Settings menu. No `Commands.swift` change.
+
+### `Commands` (M10-4 only)
+
+```swift
+Button("Edit Page") {
+    openWindow(id: CompanionID.editor)
+}
+.disabled(!store.selection.canEditPage)
+```
+
+### `MainWindow` (M10-2 only)
+
+Column width + Editor toolbar `.disabled(!store.selection.canEditPage)`.
+
+### Not changed
+
+- `BorisEngine.previewStart` / `editorStart`
+- `WatchServer` / `EditorServer` argv
+- `EditorURL.parse`
+- `PlaySurface` protocol
+- `Source` / `LocalSource` / bookmark format
+- Entitlements
+
+---
+
+## Data Model Changes
+
+No IR / `boris.json` / completion schema change. App plist only.
+
+| Store | Key / field | Migration |
+|-------|-------------|-----------|
+| UserDefaults | `solipsist.workspace.sources.v1` | Additive `mailbox: String? = nil`. Old payloads decode. No bump. Persist-on-select rewrites `selected` + all `bookmarkData`. |
+| `WorkspaceSelection` | `mailbox` | Session + plist (raw). |
+| `WorkspaceNoun` | `sourcePath` | Session only. |
+
+Rollback: `JSONDecoder` ignores unknown keys (old binary + new plist). New binary + old plist → `mailbox == nil` → UI Pages.
+
+Storage: each *changed* sidebar click re-encodes every source bookmark (binary, not “a few hundred bytes”). Same cost as today’s add/remove, now more frequent.
+
+---
+
+## Alternatives Considered
+
+### 1. Sidebar selection stays `SourceID?`; mailboxes are a second control
+
+A `Picker` under the source list, or the existing `PlayTab` picker, would avoid `MailboxRowID`. Rejected: HARNESS §2 puts mailboxes in the left column. A second control is the tabbed workbench we are leaving. `SourceID` alone cannot highlight Pages vs Outputs.
+
+### 2. Closed `enum Mailbox: String` instead of an open string
+
+Safer Codable. Rejected: cards require an open string. M10 still *displays* only five values; that is a milestone limit, not a type-level close. A later trunk card changes `display` / the Play switch — not the stored type.
+
+### 3. Do not persist mailbox
+
+Simpler `PersistedWorkspace`. Rejected: a user who lives in Outputs would bounce back to Pages on every launch. The key already exists; an optional field is the cheap path. We still do not persist noun (a message is more ephemeral than a folder).
+
+### 4. Keep `PreviewSession` as `@State` in `PreviewWindow`; reading pane starts its own watch
+
+Violates "one watch session per selected source", "do not spawn a second watch", and the one-`Process` rule once a job is running. Rejected.
+
+### 5. Reading pane loads `/__boris/` (the helper) instead of `/{id}.html`
+
+Free SSE reload, zero URL derivation. Rejected: the letter would be the full site, not the selected message. That is the companion's job.
+
+### 6. Reading pane injects EventSource or a second helper page
+
+Would give live reload on the letter. Rejected for M10 as scope: it is a small client of an existing endpoint, but it is a new protocol client we do not need for the gate. Named as a later add-on under D-S11.
+
+### 7. Side-by-side list \| letter inside the center column
+
+Closer to wide Mail. Rejected for M10: three horizontal bands + inspector at 800 pt minimum. Stacked is the honest fit for the current `NavigationSplitView`. A later width-adaptive split is allowed if someone measures it; do not build both.
+
+### 8. Invent `?file=` / `#path=` on `BORIS_EDITOR_URL`
+
+Would make Edit actually open the file. Rejected: no fact-checked contract; `EditorURL.parse` would reject a second fragment; `docs/issues/README.md` forbids drafting the boris issue until afterparty is checked. Header chrome is the honest M10 surface.
+
+### 9. Settings constructs its own `WorkspaceStore`
+
+Would desync the sidebar. Rejected. The `@State` on `SolipsistApp` is the one instance.
+
+### 10. Add `WorkspaceStore.swift` to ContractTests / edit `Project.yml`
+
+Would compile `AppRuntime` → `Coordinator` and touch a #78 path. Rejected. `WorkspaceSelectionRules` is already in the test target.
+
+### 11. Auto-start watch from `PlayHost` whenever a source is selected
+
+Would spawn `watch --serve` without the user opening Preview. Rejected. PlayHost **retargets or stops** a live session; it does not start from idle. Companion appear remains the start path.
+
+### 12. Two PRs share `MainWindow.swift` by “only touching different hunks”
+
+HARNESS §4 is path-based. Rejected. #100 owns the file.
+
+---
+
+## Security & Privacy Considerations
+
+| Threat | Mitigation |
+|--------|------------|
+| Reading pane loads a non-loopback URL | `PreviewURL.pageURL` requires `isLoopback`; `ReadingWebView` refuses anything `PreviewURL.isAllowed` rejects. Same rule as `PreviewWebModel.load`. |
+| `file://` preview of `dist/` | Forbidden. 404 on the served URL falls back to the summary, not to disk HTML. |
+| Settings / Open panel escape from the sandbox | Reuse `presentOpenPanel` / `presentRelocatePanel` / security-scoped bookmarks. No new entitlement. |
+| Second `watch --serve` binds another port | One `PreviewSession` on `AppRuntime`. PlayHost retargets via `start` (stop-then-start). Letter never calls `previewStart`. |
+| Letter loads a foreign source’s helper | `isBound(to:)` + PlayHost sync on every `sourceID` change, companion open or closed. |
+| Editor token in logs / query | Unchanged. Do not put `sourcePath` into the token URL. Header text is not the token. |
+| Stale source still selected from Settings | Relocate/Remove only; `isAvailable` is resolved at load, never persisted (existing). |
+| Plist growth / selected-path leak | Same payload as today plus a mailbox string. Paths already live in `LocalSource.displayPath`. |
+
+Auth: none. No network except existing loopback watch/editor. No third store.
+
+---
+
+## Observability
+
+No new metric backend. Use the surfaces that already exist:
+
+| Signal | Where |
+|--------|-------|
+| Selected source · verb · exit · engine version | `AppRuntime.statusLine` (status bar) |
+| Watch up / down | `previewSession.phase` / `coordinator.state == .watching` (status bar already says `watching`) |
+| Graph load failure | existing `ContentUnavailableView` + `LoadState.failed` |
+| Page URL 404 | reading-pane caption; do not swallow |
+| Persist failure | existing `WorkspaceStore.lastError` alert |
+| Engine / editor missing | existing `PreviewSession` / `EditorSession` failed phase strings |
+
+Do not add `os_log` noise for every mailbox click. If a persist or decode fails, it already sets `lastError`.
+
+Alerting: n/a (single-user Mac app).
+
+---
+
+## Rollout Plan
+
+- No feature flags. Each child PR is the flag: `main` stays the flatter chassis until that PR merges.
+- Stage 1: #99 and #100 can ship independently. Users get Settings and/or a mailbox sidebar with the old tabbed center still driven by the shim.
+- Stage 2: #101 removes the tabs. The shim dies.
+- Stage 3: #102 **merges after #101** — File → Edit Page + header `sourcePath`.
+- Rollback: revert the child PR. `mailbox` is optional. Persist-on-select (`selected`) reverts with #100.
+- Do not ship M10 inside #78. Do not edit `Project.yml`.
+
+Latency / load: one extra WKWebView when a page is selected and watch is up. Watch process count stays 0 or 1. Each *changed* selection re-encodes all bookmarks.
+
+---
+
+## Open Questions
+
+Resolved by this document (do not relitigate in a child PR):
+
+- Nested trunks in the sidebar? **Out of M10.**
+- Persist mailbox? **Yes, one string on `PersistedWorkspace`.**
+- Persist outline expansion? **No outline.**
+- Stacked vs side-by-side? **Stacked.**
+- SSE in the reading pane? **No.**
+- Editor deep link? **None. Do not file.**
+- Settings vs workspace selection? **Same `sourceID`.**
+- Who lands double-click? **M10-3.**
+- Who owns `MainWindow`? **#100 only.**
+- #102 merge order? **After #101.**
+- `Project.yml` / `WorkspaceStore` in tests? **Neither.**
+
+Still open, but **not blocking** M10 (decide in the child PR or a later card):
+
+1. Width-adaptive list-left-of-letter when the center column is very wide. Default remains stacked.
+2. Whether File → Edit Page should eventually grow a ⌘ shortcut once a native buffer exists. Not now.
+3. Whether a later EventSource client on the reading pane is worth a card after users feel the stale-letter gap.
+4. `docs/help.md` refresh timing — design-lane follow-up after #101.
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Companion-close no longer stops watch; users think Preview is "off" | Medium | Status bar shows `watching`. Stop (⌘.) tears it down. PlayHost still binds to the selected source. |
+| Letter would load a foreign helper after source switch | **High** if binder is skipped | PlayHost `syncPreviewSession` + `isBound(to:)` treat mismatch as idle. |
+| `/{id}.html` is not a probed serve mapping | Medium | Id-based rule + `recipe/soup` unit test + hand-gate if a cook corpus exists. 404 → summary, not `file://`. |
+| #100 and #101 both edit `LocalPlay.swift` | Medium | Sequential: #101 starts after #100. Shim then delete. |
+| Persist-on-select rewrites all bookmarks | Low | Same encode path as add/remove; skip persist when selection unchanged. |
+| Settings Remove confirms, File menu does not | Low | Accept; Settings is the account book. |
+| Two WKWebViews hold the loopback document | Low | Distinct instances; one server. |
+
+---
+
+## References
+
+- [`HARNESS.md`](HARNESS.md) §2 spatial model, §4 lanes
+- [`ROADMAP.md`](ROADMAP.md) §5 M10
+- [`ENGINE-CONTRACTS.md`](ENGINE-CONTRACTS.md) §1 `watch --serve` endpoints
+- [`COORDINATOR.md`](COORDINATOR.md) §3 watch vs build (SIGSTOP, registerWatch)
+- [`issues/boris-A14-editor-launch-contract.md`](issues/boris-A14-editor-launch-contract.md)
+- [`issues/README.md`](issues/README.md) — do not invent a query/fragment
+- Cards: [`cards/M10-mail-body.md`](cards/M10-mail-body.md), [`M10-settings-sources.md`](cards/M10-settings-sources.md), [`M10-mailbox-sidebar.md`](cards/M10-mailbox-sidebar.md), [`M10-reading-pane.md`](cards/M10-reading-pane.md), [`M10-editor-wiring.md`](cards/M10-editor-wiring.md)
+- Types: `WorkspaceSelection`, `WorkspaceStore`, `WorkspacePersistence`, `SourceSidebar`, `LocalPlay`, `PlayPage`, `LocalPlayGraph`, `PreviewSession`, `PreviewURL`, `PreviewWindow`, `EditorSession`, `EditorURL`, `EditorWindow`, `AppRuntime`, `SolipsistApp`, `SolipsistCommands`, `Coordinator.registerWatch`
+
+---
+
+## PR Plan
+
+Map onto existing children. Recuts vs the original cards (already applied in `docs/cards/` **and** `docs/HARNESS.md` §4):
+
+- #99 does not edit `Commands.swift` or `Project.yml`.
+- #100 is the sole `MainWindow` owner; no `Project.yml`; tests via `WorkspaceSelectionRules`.
+- #101 named recut of `PlayHost` + Preview companion + `AppRuntime` (session lift + source binding).
+- #102 does not touch `LocalPlay.swift` or `MainWindow.swift`; **merges after #101**.
+
+Nested-trunk work is **not** a fifth implementation PR.
+
+### PR 0 — Design-lane record (docs only)
+
+- **Title:** `M10: design + HARNESS §4 recut`
+- **Branch:** `docs/m10-mail-body` (already docs-only)
+- **Depends on:** nothing
+- **Files:** `docs/M10-DESIGN.md` (this file), `docs/HARNESS.md` §4 (four M10 rows + sequence), `docs/cards/M10-*.md`, `docs/cards/README.md`. **Do not touch `Sources/` or #78 paths.**
+- **Changes:** Record the implementation design. Patch HARNESS so it does not win *against* the recut (Settings off `Commands.swift`; Mailboxes own selection/persist + `MainWindow`; Reading named Preview/`PlayHost`/`AppRuntime` recut; Editor wiring merges after Reading).
+- **Gate:** HARNESS §4, the four child cards, and this design name the same owners. No silent contradiction.
+
+### PR 1 — Settings → Sources (#99)
+
+- **Title:** `M10-1: Settings → Sources account book`
+- **Branch:** `feat/m10-settings-sources` off `main`
+- **Depends on:** nothing
+- **Files:** `Sources/App/Settings/SettingsRoot.swift` (new), `Sources/App/Settings/SourcesSettingsPane.swift` (new), `Sources/App/SolipsistApp.swift` (`Settings` scene + `.environment(store)`). **Do not edit `Commands.swift`. Do not edit `Project.yml`.** Do not touch `SourceSidebar.swift`.
+- **Changes:** Settings scene lists the same `WorkspaceStore.sources`. Add Local / Relocate / Remove call existing store methods. Empty-state copy names `Stunts/happy`. Relocate enabled only when the selected source is stale. Row click selects that source (in-session until #100 persists it).
+- **Gate:** card M10-1 + `SKIP_EMBED_BORIS=1 make build` + `make test`. Restart → source **list** still there (#59), not necessarily the same selected row.
+
+### PR 2 — Mailbox sidebar (#100)
+
+- **Title:** `M10-2: mailbox sidebar and selection.mailbox`
+- **Branch:** `feat/m10-mailbox-sidebar` off `main`
+- **Depends on:** nothing (parallel with PR 1)
+- **Files:** `Sources/Workspace/WorkspaceSelection.swift`, `WorkspaceStore.swift`, `WorkspacePersistence.swift`, `Sources/Chrome/SourceSidebar.swift`, `Sources/Chrome/MainWindow.swift` (width + Editor toolbar `canEditPage`), `Sources/Play/Local/LocalPlay.swift` (PlayTab Binding shim only), `Tests/ContractTests/WorkspaceSelectionTests.swift` (new), extend `WorkspacePersistenceTests.swift`. **Do not edit `Project.yml`.**
+- **Changes:** `mailbox` + `WorkspaceMailbox` + `MailboxRowID` + `sourcePath` on noun + `canEditPage` + `WorkspaceSelectionRules`. Persist raw mailbox; persist-on-select if changed. Header click → Pages (best-effort). Nested trunks not built. Play tabs follow `display(mailbox)`.
+- **Gate:** card M10-2 + tests above + `SKIP_EMBED_BORIS=1 make build` + `make test`. Hand-gate: Pages child always works; header tap if it registers.
+
+### PR 3 — Reading pane (#101)
+
+- **Title:** `M10-3: reading pane driven by selection.mailbox`
+- **Branch:** `feat/m10-reading-pane` off `main`
+- **Depends on:** PR 2 **merged**
+- **Files:** `Sources/Play/Local/LocalPlay.swift` (delete shim; stacked Pages; mailbox switch; gestures), `ReadingPane.swift` / `ReadingWebView.swift` (new), `ProblemsPane.swift` (jump → pages + `sourcePath`), `Sources/Chrome/PlayHost.swift` (session binder), `Sources/App/AppRuntime.swift` (`previewSession`), `Sources/Companions/Preview/{PreviewSession,PreviewWindow,PreviewURL}.swift`, extend `CompanionURLTests.swift`.
+- **Changes:** Center is mailbox contents. Pages = graph list + letter. Session lifted and **bound to the selected source** even if the companion is closed. Watch down or root mismatch → summary. Watch up and bound → `WKWebView` on `PreviewURL.pageURL` (`id`, not swapped `sourcePath`). Navigation delegate for 404. Double-click / Return / Edit open `CompanionID.editor`. Other mailboxes full-height. No SSE. No second `Process`. No `file://`.
+- **Gate:** card M10-3 + URL tests (including `recipe/soup`) + `SKIP_EMBED_BORIS=1 make build` + `make test`. Hand-gate: switch source with Preview closed while watch was up → letter is this source or summary, never the previous folder. If a cook corpus is available, confirm `GET /{id}.html`.
+
+### PR 4 — Editor from the selected page (#102)
+
+- **Title:** `M10-4: Edit Page surfaces sourcePath in boris-editor chrome`
+- **Branch:** `feat/m10-editor-wiring` off `main`
+- **Depends on:** **PR 3 merged** (writer of `noun.sourcePath` + list gestures). Development may start after PR 2.
+- **Files:** `Sources/App/Commands.swift` (File → Edit Page), `Sources/Companions/Editor/EditorWindow.swift` (header). **Do not touch `LocalPlay.swift`, `MainWindow.swift`, Engine, Inspector, `Project.yml`.** Do not draft a boris issue.
+- **Changes:** Edit Page enabled iff `canEditPage`. Opens existing `EditorSession`. Header shows `noun.title` + `noun.sourcePath`. View → Editor (⌘⇧E) remains source-gated. Paste-URL and link-out unchanged.
+- **Gate:** card M10-4 + `SKIP_EMBED_BORIS=1 make build` + `make test`. Title and `sourcePath` visible because #101 wrote them.
+
+### Not a PR in this plan
+
+- #78 ship / any `Project.yml` edit.
+- Nested Pages trunks in the sidebar.
+- EventSource on the reading pane.
+- `docs/help.md` refresh (design-lane follow-up after PR 3).
+- `docs/issues/boris-A*-editor-open-file.md`.

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -10,9 +10,9 @@
 
 **Solipsist is a native Mac harness for Boris:** Radio UserLand’s job in
 Mail’s body. It turns the graph-native publication compiler into a
-one-window workstation for sources, play, inspection, preview, and
-broadcast — and it refuses to invent anything the HIG or a Boris
-contract already named.
+one-window workstation for sources (in Settings), mailboxes, a reading
+place, inspection, preview, and broadcast — and it refuses to invent
+anything the HIG or a Boris contract already named.
 
 ## The engine we harness
 
@@ -71,21 +71,26 @@ compiler repo. Solipsist is the complementary **native desktop citizen**:
 
 - **M0–M8 gates plus depth.** Spike, chassis, list, verbs,
   preview/editor, outputs, publish family, first-run, filter, profile
-  1:1, `recipe-scale`. Remaining card:
+  1:1, `recipe-scale`. Remaining **ship** card:
   [#78](https://github.com/drawmeanelephant/solipsist/issues/78).
-  Sequence: [ROADMAP.md](ROADMAP.md) §8.
+  Next **product cut:** M10 Mail body
+  ([#98](https://github.com/drawmeanelephant/solipsist/issues/98) —
+  Settings, mailbox sidebar, reading pane). Sequence:
+  [ROADMAP.md](ROADMAP.md) §8.
 - **Engine baseline:** afterparty `boris/0.8.1`. Kit pin `b82e9e2`.
   A3/A4/A13/A1/A14/A7 have merged after that pin — bump when we vendor
   a newer kit (#78).
-- **Next:** clean-Mac ship (#78). Roadmap **P** is withdrawn — the
-  public site ships via Cloudflare Pages (`site/`).
+- **Next:** clean-Mac ship (#78), then the Mail-body recut. Roadmap
+  **P** is withdrawn — the public site ships via Cloudflare Pages
+  (`site/`).
 
 ## What success looks like
 
-Open any folder of Boris content on a Mac → it is a **source** → play
-shows the real graph from `graph.json` → the drawer shows the profile
-and the selected page → Plan / Validate / Build surface every diagnostic
-→ Preview reloads through `watch --serve` → Edit hosts `boris-editor` →
-publish to GitHub Pages, Standard.site, or Nostr with the Proof Pack
-attached. All of it driven by the compiler's contracts; none of it by
-scraped prose or reimplemented logic.
+Open any folder of Boris content on a Mac → it is a **source** in
+Settings → it appears as an account with mailboxes → the reading place
+shows the graph as messages and a pane for the selected page → the
+drawer shows the profile and that page → Plan / Validate / Build
+surface every diagnostic → Preview reloads through `watch --serve` →
+Edit hosts `boris-editor` → publish to GitHub Pages, Standard.site, or
+Nostr with the Proof Pack attached. All of it driven by the compiler's
+contracts; none of it by scraped prose or reimplemented logic.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -382,7 +382,8 @@ green.
 **Lanes.** Settings, Mailboxes, Reading, Editor wiring — paths in
 [`HARNESS.md`](HARNESS.md) §4. Tracker
 [#98](https://github.com/drawmeanelephant/solipsist/issues/98);
-cards in [`cards/`](cards/README.md).
+cards in [`cards/`](cards/README.md). Implementation design:
+[`M10-DESIGN.md`](M10-DESIGN.md).
 
 **Not this milestone.** Native editor. GitHub as a source. Finder
 sidebar. In-app HTTP server. Growing #78.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,13 +18,20 @@ Boris stays a better Boris. We vendor the binary, file issues, render
 contracts, host the surfaces we will not rewrite.
 
 ```
+Settings → Sources (the account book; not a column)
+
 ┌──────────────────┬─────────────────────────────┬──────────────────┐
-│ SOURCES          │ PLAY                        │ DRAWER           │
-│ Local / GitHub / │ Graph, outputs, activity,   │ Profile, page    │
-│ …                │ reports                     │ fields, options  │
+│ MAILBOXES        │ READING                     │ DRAWER           │
+│ Source as        │ Message list + reading      │ Profile, page    │
+│ account header;  │ pane for the selected       │ fields, options  │
+│ folders under it │ message                     │                  │
 └──────────────────┴─────────────────────────────┴──────────────────┘
-Companion windows we host: Preview (watch --serve) · Editor (boris-editor)
+Companion windows we host: Preview (full site) · Editor (boris-editor)
+Native buffer: named later, not a v1 gate.
 ```
+
+M2–M8 shipped a flatter cut (source list + tabbed play). M10 is the
+recut to the diagram above. Spatial detail: [`HARNESS.md`](HARNESS.md).
 
 **Engine baseline:** afterparty `boris/0.8.1`. **Pinned kit:** `b82e9e2`.
 A3/A4/A13 have merged *after* that pin — bump when we want them in the
@@ -35,18 +42,21 @@ discussion (`docs/issues/README.md`).
 
 ## 2. North-star success
 
-Open a folder of Boris content → it appears as a **source** → the play
-place shows the real graph from `graph.json` → the drawer shows the
-publication profile and the selected page’s fields from
-`completion.json` → Plan / Validate / Build are menu verbs that surface
-every diagnostic and exit code → Preview reloads through `watch --serve`
-→ Edit opens `boris-editor` → Build All fans the profile out to HTML
-targets and editions (IR, RAG, Context, llms, RSS, sitemap, search) →
-Publish runs GitHub Pages evidence (Boris-powered, we do not need
-full GitHub access to *use* the target), Standard.site, or Nostr with
-the Proof Pack attached. This project’s own public face is a Cloudflare
-subdomain on Boris’s official Worker + Wasm embed host — stood up
-early, on the Free tier, not as an in-app engine.
+Open a folder of Boris content → it is added as a **source** in
+Settings (File → Open… writes the same store) → it appears as an
+account header with mailboxes underneath → the reading place shows
+the selected mailbox’s messages and a reading pane for the selected
+page → the drawer shows the publication profile and that page’s
+fields from `completion.json` → Plan / Validate / Build are menu
+verbs that surface every diagnostic and exit code → Preview reloads
+the full site through `watch --serve` (the reading pane reuses that
+watch for the selected page) → Edit opens `boris-editor` against the
+selected page → Build All fans the profile out to HTML targets and
+editions (IR, RAG, Context, llms, RSS, sitemap, search) → Publish
+runs GitHub Pages evidence (Boris-powered, we do not need full
+GitHub access to *use* the target), Standard.site, or Nostr with the
+Proof Pack attached. This project’s own public face ships via
+Cloudflare Pages (`site/`).
 
 No scraped prose. No homegrown graph. No third settings store.
 
@@ -58,14 +68,14 @@ No scraped prose. No homegrown graph. No third settings store.
 
 | Goal | Why |
 |------|-----|
-| One-window Mail-grade chrome | Sources, play, inspector drawer, real menus |
-| Local source via security-scoped bookmark | The first account |
+| One-window Mail-grade chrome | Settings for sources; mailboxes; reading pane; inspector drawer; real menus |
+| Local source via security-scoped bookmark | The first account; added in Settings (Open… is the same store) |
 | Graph as a workable list | Trunks, satellites, status, relations — from contracts |
 | Profile is `boris.json` | D2. Drawer writes it. `plan` lints it |
 | Coordinator verbs | Plan, Validate, Build, Check, Impact, Stop — each a menu item |
 | Diagnostics as a place | `html-build-report` / IR `build-report` / check findings, clickable |
 | Engine-owned preview | Companion; `watch --serve` + SSE; no app HTTP server |
-| Hosted editor | Companion; `boris-editor` token URL; link-out fallback |
+| Hosted editor | Companion; `boris-editor` token URL; opened from the selected page; link-out fallback |
 | Outputs fan-out | Every profile target and edition, isolated, reported |
 | Publication console | GH Pages evidence (Boris-owned workflow + audit), Standard.site, Nostr — secrets on stdin |
 | Proof Pack visible | `boris-package` evidence, read-only |
@@ -74,24 +84,32 @@ No scraped prose. No homegrown graph. No third settings store.
 
 ### v1 must not
 
-- A from-scratch native editor or frontmatter parser
+- A frontmatter parser, a graph algorithm, or a homegrown Markdown
+  renderer in Swift
+- A Finder clone of the content tree in the sidebar
 - An app-side HTTP server or `file://` preview
-- A graph algorithm in Swift
 - Cloudflare / Vercel / Netlify as *in-app* deploy adapters or a
   `publication.target` we invent (Boris has not added `"cloudflare"`)
 - Wasm / `compileBundle` *inside* Solipsist (subprocess isolation stays)
 - Theme *authoring* (selection only)
 - Migration labs as runtime
 - iOS
+- A native editor *instead of* hosting `boris-editor` (see Later)
 
 ### Later (named so they stay later)
 
-- GitHub as a second **source** in the sidebar (we do not have full
-  GitHub access; Pages as a *target* does not require it)
-- Content-audit play surface (`boris-content-audit`)
+- A **native editor**: buffer + save + problems over `sourcePath`.
+  Still no frontmatter parser. Still no compile. Still hosts
+  `watch --serve` for preview. Cut a card only when the hosted
+  Svelte shell is the wrong Mac citizen, not because Play looks
+  empty.
+- GitHub as a second **source** (account header + its own mailboxes;
+  we do not have full GitHub access; Pages as a *target* does not
+  require it)
+- Content-audit mailbox (`boris-content-audit`)
 - Source-RAG export for AI assist
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)
-- Cooklang recipe-scale as a first-class play pane (v1: available from
+- Cooklang recipe-scale as a first-class mailbox (v1: available from
   the page inspector when the corpus has recipes)
 - The fart app (CI job reserved, `make fart` refuses; do not build it)
 
@@ -112,14 +130,16 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M7** Outputs | ✅ gate — Build this / Build all fan-out (#76, #81) |
 | **M8** Publish | ✅ gate — stdin secrets, Standard.site / Nostr buttons (#77, #82/#84) |
 | **M9** Ship | 🔧 pipeline exists; clean-Mac proof + credentials + pin open (#78) |
+| **M10** Mail body | 📋 Settings for sources; mailbox sidebar; reading pane; editor from the selected page ([#98](https://github.com/drawmeanelephant/solipsist/issues/98)) |
 
 **Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
 batch then landed: first-run and problem→page (#88/#94), graph filter /
 activity / plan document (#89/#96), profile 1:1 + execution knobs +
 `recipe-scale` (#90/#95), Standard.site family + package + readable
-proof (#91/#93). Remaining pickable card is
-[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (M9
-ship). Do not grow `MainWindow`.
+proof (#91/#93). Remaining **ship** card is
+[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (M9).
+M10 is the next product cut after ship; it does not expand #78. Do
+not grow `MainWindow`.
 
 ---
 
@@ -330,6 +350,43 @@ not block the local publish flows.
 **Gate.** Download the build on a machine without this repo, open a
 folder, plan, validate, build, preview.
 
+### M10 — Mail body
+
+**Goal.** The window is Mail, not a tabbed workbench. Sources live in
+Settings. The left pane is a mailbox tree. The center is messages plus
+a reading pane. Edit still hosts `boris-editor`; a native buffer stays
+Later.
+
+This is a chrome recut, not a new compiler surface. Contracts,
+coordinator verbs, publish flows, and the subprocess boundary do not
+move. [#78](https://github.com/drawmeanelephant/solipsist/issues/78)
+does not grow to absorb this.
+
+| Surface | Where it appears |
+|---------|------------------|
+| Settings → Sources | Account book: add / relocate / remove local sources (GitHub later). Same `WorkspaceStore` as File → Open… |
+| Mailbox sidebar | Source as account header; Pages / Outputs / Publish / Plan / Activity as mailboxes. Nested Pages folders only from `graph.json` (`parent`), never from walking the disk |
+| Reading place | Message list of the selected mailbox + reading pane for the selected page (watch URL if up; contract summary if not) |
+| Full-site Preview | Companion, unchanged |
+| Editor | Companion, opened from the selected page; link-out fallback |
+| Drawer | Still minutiae of the selection, not the account book |
+
+**Gate.** Settings → Sources adds a local folder that also appears as
+an account header. Selecting Pages shows the graph as a message list.
+Selecting a page shows a reading pane (watch URL or summary — never
+`file://`, never a Swift Markdown renderer). Outputs / Publish / Plan
+/ Activity are mailboxes, not tabs. Edit ▶ on a selected page opens
+the hosted editor. `SKIP_EMBED_BORIS=1 make build` + `make test`
+green.
+
+**Lanes.** Settings, Mailboxes, Reading, Editor wiring — paths in
+[`HARNESS.md`](HARNESS.md) §4. Tracker
+[#98](https://github.com/drawmeanelephant/solipsist/issues/98);
+cards in [`cards/`](cards/README.md).
+
+**Not this milestone.** Native editor. GitHub as a source. Finder
+sidebar. In-app HTTP server. Growing #78.
+
 ---
 
 ## 6. Capability coverage
@@ -344,7 +401,7 @@ here, it is not a v1 promise.
 | Trunk/Satellite graph, wiki-links, includes, relations | M3 | Play list from `graph.json` |
 | HTML + layouts + theme catalog | M4, M7 | Build target; theme picker |
 | `validate` | M4 | Save-triggered problems; A5 later |
-| `watch --serve` + SSE | M5 | Preview companion |
+| `watch --serve` + SSE | M5, M10 | Preview companion; M10 reading pane reuses the same session |
 | `--watch-json` (A1) | M5 once pinned | Replaces port regex + watch prose |
 | `plan --profile` | M4, M8 | Settings lint; publish prelude |
 | `build --report` / `--timings` | M4, M7 | Results + Activity |
@@ -354,7 +411,7 @@ here, it is not a v1 promise.
 | `check` / `impact` | M4 | Advisory play + selected-page impact |
 | `init` | M4 | File → New Project… |
 | `recipe-scale` | M6 | Drawer, cook corpora only |
-| `boris-editor` | M6 | Companion (A14) |
+| `boris-editor` | M6, M10 | Companion (A14); M10 opens it from the selected page |
 | GitHub Pages + audit | M8 | In-app evidence; Boris workflow owns push; we are not the GH operator |
 | `hosts/cloudflare-worker` + `compileBundle` Wasm | **P (now)** | This project’s subdomain. Free-tier host glue. Not in-app |
 | `boris-job-runner` / CF Containers (#300) | parked | Different host (native binary in a container), not the Free Wasm path |
@@ -386,15 +443,18 @@ here, it is not a v1 promise.
 ## 8. Pickup (what to do next)
 
 The gate batch (#72–#77) and the depth batch (#88–#91) are closed.
-Next is ship.
+Next **ship** is #78. Next **product cut** is M10 (Mail body) — after
+or beside ship, never inside it.
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
 | 1 | Ship | [#78](https://github.com/drawmeanelephant/solipsist/issues/78) | Credentials, clean-Mac proof, pin bump, testdata. |
+| 2 | Mail body | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) ([#99](https://github.com/drawmeanelephant/solipsist/issues/99)–[#102](https://github.com/drawmeanelephant/solipsist/issues/102)) | Sources in Settings; left pane is folders; center is messages + reading; Edit from the selected page. |
 
 #78 stays build-lane only (`scripts/embed-boris.sh`, `Project.yml`,
 entitlements, release workflow, `docs/SHIP-HARDENING.md`). Do not
-expand it into chrome, play, inspector, or publish.
+expand it into chrome, play, inspector, or publish. M10 owns those
+paths.
 
 ### Landed depth (do not redo)
 
@@ -419,7 +479,9 @@ Named in this file and **not** a product surface yet: browser OAuth,
 `github-pages-audit`.
 
 Out of v1 (unchanged): GitHub as a source, content-audit, source-rag,
-migration labs, Wasm in the app, `validate --watch` until A5 + pin.
+migration labs, Wasm in the app, `validate --watch` until A5 + pin,
+a from-scratch native editor (named Later; M10 still hosts
+`boris-editor`).
 
 #30 is a pr-cop dump, not a card.
 

--- a/docs/cards/M10-editor-wiring.md
+++ b/docs/cards/M10-editor-wiring.md
@@ -1,0 +1,71 @@
+# Card M10-4 — Editor from the selected page
+
+**Milestone:** M10 · **Issue:**
+[#102](https://github.com/drawmeanelephant/solipsist/issues/102) ·
+**Lane:** Editor wiring. One worktree, one PR against `main`; branch
+suggestion `feat/m10-editor-wiring`.
+
+May overlap [#101](https://github.com/drawmeanelephant/solipsist/issues/101)
+if it only keys off `noun.kind == "page"`.
+
+## Owns
+
+- `Sources/Companions/Editor/` — open against the selected page when
+  the launch contract allows
+- Edit verb in `Sources/App/Commands.swift` and the toolbar button
+  in `Sources/Chrome/MainWindow.swift` (enable/disable only; do not
+  grow the window)
+- Double-click / Return on a Pages row in
+  `Sources/Play/Local/LocalPlay.swift` (one action, not a new list)
+
+## Do not touch
+
+- `Sources/Engine/**` beyond existing `editorStart`
+- `Sources/Inspector/**` (PageSection already has an open-editor
+  control; leave it or point it at the same verb)
+- A native `NSTextView` / SwiftUI `TextEditor` buffer
+- Preview companion internals
+
+## Why
+
+M6 hosted `boris-editor` as a source-scoped companion. Mail's
+compose is about the selected message. Edit ▶, Return, and
+double-click on a page should open that page, not just the project.
+
+A14 pinned the launch line (`BORIS_EDITOR_URL=`). There is **no**
+fact-checked file-open deep link yet. Do not invent one. If the
+hosted shell has no page-open contract, open the session as today
+and surface the selected `sourcePath` in the companion chrome
+(title / status). If you can prove an existing query/fragment the
+Svelte shell already honors, use that. If Boris needs a contract,
+draft `docs/issues/boris-A*-editor-open-file.md` against afterparty
+and stop — do not patch boris.
+
+## Do
+
+1. File → Edit Page (or Edit) enabled when `noun.kind == "page"`.
+   Keyboard: Return in the Pages list; double-click a row. Menu
+   first.
+2. The verb opens the Editor `WindowGroup` and starts the existing
+   `EditorSession` for the selected local source.
+3. Show the selected page title + `sourcePath` in the companion
+   header so the human knows which letter they opened.
+4. Keep paste-`BORIS_EDITOR_URL=` and “Open in Browser” as the
+   fallback. SIGTERM on close, as today.
+5. Link-out remains accepted if WKWebView/CSP fails.
+
+## Do not
+
+- Write a native editor. That card is Later
+  ([ROADMAP.md](../ROADMAP.md) §3).
+- Parse frontmatter to decide what to open. `sourcePath` on the
+  graph node is the path.
+- Change token/CSP/loopback rules.
+- Block on a Boris deep-link that does not exist.
+
+## Gate
+
+Select a page in `Stunts/happy` → Edit ▶ / double-click opens the
+editor companion with that page's title and `sourcePath` visible.
+No source selected / no page → the verb is disabled. Link-out still
+works. `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/M10-editor-wiring.md
+++ b/docs/cards/M10-editor-wiring.md
@@ -5,26 +5,27 @@
 **Lane:** Editor wiring. One worktree, one PR against `main`; branch
 suggestion `feat/m10-editor-wiring`.
 
-May overlap [#101](https://github.com/drawmeanelephant/solipsist/issues/101)
-if it only keys off `noun.kind == "page"`.
+**Merge after [#101](https://github.com/drawmeanelephant/solipsist/issues/101)
+is on `main`.** Development may start after #100 (`sourcePath` is on
+the type). #101 writes `noun.sourcePath` and lands list gestures.
+Design: [`docs/M10-DESIGN.md`](../M10-DESIGN.md).
 
 ## Owns
 
-- `Sources/Companions/Editor/` — open against the selected page when
-  the launch contract allows
-- Edit verb in `Sources/App/Commands.swift` and the toolbar button
-  in `Sources/Chrome/MainWindow.swift` (enable/disable only; do not
-  grow the window)
-- Double-click / Return on a Pages row in
-  `Sources/Play/Local/LocalPlay.swift` (one action, not a new list)
+- `Sources/Companions/Editor/` — header shows selected page title +
+  `sourcePath`; session stays source-scoped
+- File → Edit Page in `Sources/App/Commands.swift` (enable when
+  `store.selection.canEditPage`)
 
 ## Do not touch
 
+- `Sources/Play/Local/**` (double-click / Return is #101)
+- `Sources/Chrome/MainWindow.swift` (Editor toolbar is #100)
 - `Sources/Engine/**` beyond existing `editorStart`
-- `Sources/Inspector/**` (PageSection already has an open-editor
-  control; leave it or point it at the same verb)
+- `Sources/Inspector/**` (PageSection already opens the companion)
 - A native `NSTextView` / SwiftUI `TextEditor` buffer
 - Preview companion internals
+- `docs/issues/` (do not draft an editor-open-file issue)
 
 ## Why
 
@@ -36,16 +37,14 @@ A14 pinned the launch line (`BORIS_EDITOR_URL=`). There is **no**
 fact-checked file-open deep link yet. Do not invent one. If the
 hosted shell has no page-open contract, open the session as today
 and surface the selected `sourcePath` in the companion chrome
-(title / status). If you can prove an existing query/fragment the
-Svelte shell already honors, use that. If Boris needs a contract,
-draft `docs/issues/boris-A*-editor-open-file.md` against afterparty
-and stop — do not patch boris.
+(title / status). There is **no** proven query/fragment. Do not invent one. Do **not**
+draft `docs/issues/boris-A*-editor-open-file.md` in this milestone.
 
 ## Do
 
-1. File → Edit Page (or Edit) enabled when `noun.kind == "page"`.
-   Keyboard: Return in the Pages list; double-click a row. Menu
-   first.
+1. File → Edit Page enabled when `store.selection.canEditPage`.
+   Menu first. Return / double-click are #101. View → Editor (⌘⇧E)
+   stays source-gated.
 2. The verb opens the Editor `WindowGroup` and starts the existing
    `EditorSession` for the selected local source.
 3. Show the selected page title + `sourcePath` in the companion
@@ -65,7 +64,8 @@ and stop — do not patch boris.
 
 ## Gate
 
-Select a page in `Stunts/happy` → Edit ▶ / double-click opens the
-editor companion with that page's title and `sourcePath` visible.
-No source selected / no page → the verb is disabled. Link-out still
-works. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+Select a page in `Stunts/happy` (after #101) → File → Edit Page
+opens the editor companion with that page's title and `sourcePath`
+visible. No source selected / no page → the verb is disabled.
+Link-out still works. `SKIP_EMBED_BORIS=1 make build` + `make test`
+green.

--- a/docs/cards/M10-mail-body.md
+++ b/docs/cards/M10-mail-body.md
@@ -1,0 +1,71 @@
+# M10 — Mail body (tracker)
+
+**Milestone:** M10 · **Lane:** design (this file) + four child cards.
+Does **not** own `Sources/`. Children do.
+
+Parent issue:
+[#98](https://github.com/drawmeanelephant/solipsist/issues/98).
+#78 (M9 ship) stays its own track.
+
+## Why
+
+The window is Mail-shaped and still behaves like a tabbed workbench.
+Sources are a flat sidebar added via File → Open…. Play stacks Pages /
+Outputs / Publish / Plan / Activity as a segmented control. Preview
+and Editor are companions with no reading pane and no page-scoped
+Edit. That is the M2–M8 chassis. It is not Mail's body.
+
+[`HARNESS.md`](../HARNESS.md) §2 is now the destination: Settings for
+the account book, mailboxes on the left, messages + reading pane in
+the middle, drawer for minutiae, companions for the full site and
+`boris-editor`. A native buffer is named Later, not this milestone.
+
+## Children
+
+One card = one worktree = one PR. Settings can run next to Mailboxes.
+Reading follows Mailboxes. Editor wiring can overlap Reading if it
+only keys off `noun.kind == "page"`.
+
+| Card | Issue | Lane | Gate (short) |
+|------|-------|------|----------------|
+| [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | Settings | Settings → Sources adds/removes/relocates; same store as Open… |
+| [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | Sidebar is account headers + mailboxes; writes `selection.mailbox` |
+| [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | Reading | Tabs gone; list + reading pane; no `file://`, no Swift Markdown |
+| [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | Edit / double-click a page opens hosted `boris-editor` |
+
+## Not this tracker
+
+- #78 ship (build lane)
+- A native `TextView` / from-scratch editor
+- GitHub as a source
+- Walking the content directory as a Finder tree
+- An app-side HTTP server or `file://` preview
+- Reimplementing coordinator verbs, publish, or contracts
+
+## Shared nouns
+
+Do not invent a second vocabulary. `WorkspaceSelection` grows
+`mailbox` (open string, same style as `noun.kind`):
+
+| `mailbox` | Meaning |
+|-----------|---------|
+| `pages` | graph nodes as messages |
+| `outputs` | profile targets / editions |
+| `publish` | publication console |
+| `plan` | plan document |
+| `activity` | timings / job log |
+| later: a trunk id | nested folder under Pages, from `graph.parent` only |
+
+Existing `WorkspaceNoun.kind` values (`page`, `profile`, `target`,
+`edition`) stay. Chrome writes `sourceID` + `mailbox`. Play writes
+`noun`. Drawer and companions only read.
+
+## Sequence
+
+1. M10-1 and M10-2 may start in parallel (Settings does not restructure
+   the sidebar; Mailboxes does not own the Settings scene).
+2. M10-3 starts after M10-2 lands `selection.mailbox` (a sync shim
+   that keeps today's tabs driven by `mailbox` is an acceptable
+   M10-2 landing if Reading is not ready).
+3. M10-4 may start once a page noun is selectable — true today, so
+   it can overlap M10-3.

--- a/docs/cards/M10-mail-body.md
+++ b/docs/cards/M10-mail-body.md
@@ -23,15 +23,16 @@ the middle, drawer for minutiae, companions for the full site and
 ## Children
 
 One card = one worktree = one PR. Settings can run next to Mailboxes.
-Reading follows Mailboxes. Editor wiring can overlap Reading if it
-only keys off `noun.kind == "page"`.
+Reading follows Mailboxes. Editor wiring **merges after Reading**
+(it reads `noun.sourcePath` that Reading writes). Development of
+#102 may start after #100. See [`docs/M10-DESIGN.md`](../M10-DESIGN.md).
 
 | Card | Issue | Lane | Gate (short) |
 |------|-------|------|----------------|
 | [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | Settings | Settings → Sources adds/removes/relocates; same store as Open… |
 | [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | Sidebar is account headers + mailboxes; writes `selection.mailbox` |
 | [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | Reading | Tabs gone; list + reading pane; no `file://`, no Swift Markdown |
-| [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | Edit / double-click a page opens hosted `boris-editor` |
+| [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | File → Edit Page; header shows title + `sourcePath` |
 
 ## Not this tracker
 
@@ -67,5 +68,6 @@ Existing `WorkspaceNoun.kind` values (`page`, `profile`, `target`,
 2. M10-3 starts after M10-2 lands `selection.mailbox` (a sync shim
    that keeps today's tabs driven by `mailbox` is an acceptable
    M10-2 landing if Reading is not ready).
-3. M10-4 may start once a page noun is selectable — true today, so
-   it can overlap M10-3.
+3. M10-4 **merges after M10-3**. It may be *developed* after M10-2
+   (`sourcePath` on the type) but must not touch `LocalPlay.swift`
+   or `MainWindow.swift`.

--- a/docs/cards/M10-mailbox-sidebar.md
+++ b/docs/cards/M10-mailbox-sidebar.md
@@ -1,0 +1,70 @@
+# Card M10-2 — Mailbox sidebar
+
+**Milestone:** M10 · **Issue:**
+[#100](https://github.com/drawmeanelephant/solipsist/issues/100) ·
+**Lane:** Mailboxes. One worktree, one PR against `main`; branch
+suggestion `feat/m10-mailbox-sidebar`.
+
+## Owns
+
+- `Sources/Chrome/SourceSidebar.swift` (recut into an account +
+  mailbox tree; do not add a second sidebar file unless the current
+  one cannot hold it)
+- `Sources/Workspace/WorkspaceSelection.swift` — add `mailbox`
+- `Sources/Workspace/WorkspaceStore.swift` — select mailbox; changing
+  source picks that source's default mailbox (`pages`)
+- Thin adapter in `Sources/Play/Local/LocalPlay.swift` so today's
+  segmented tabs follow `selection.mailbox` (Reading will delete the
+  tabs)
+
+## Do not touch
+
+- `Sources/App/Settings/` (M10-1)
+- `Sources/Inspector/**`
+- `Sources/Engine/**`
+- `Sources/Companions/**`
+- `Sources/Chrome/MainWindow.swift` beyond a title / column-width
+  tweak if the sidebar needs it
+- Play row rendering, preview, editor
+
+## Why
+
+Mail's left pane is folders, not a flat account list. Each source is
+an account header. Under it: Pages, Outputs, Publish, Plan, Activity.
+Selecting a mailbox is what the reading place will listen to.
+
+This is **not** a Finder tree. Nested folders under Pages, if you
+show any, come from `graph.json` `parent` (trunks as folders). Do not
+walk the content directory.
+
+## Do
+
+1. Grow `WorkspaceSelection` with `mailbox: String?` (open string,
+   same style as `noun.kind`). Default `pages`.
+2. Sidebar `List`:
+   - Section / header per source (title, stale badge, existing
+     Relocate / Remove context menu).
+   - Child rows: Pages, Outputs, Publish, Plan, Activity.
+   - Selecting a header selects that source + `pages`.
+   - Selecting a child writes `sourceID` + `mailbox` and clears
+     `noun` when the mailbox changes.
+3. Keep the plus button as a shortcut to `presentOpenPanel()`.
+4. Point `LocalPlay`'s segmented control at `selection.mailbox` so
+   the app does not go dark if M10-3 has not landed. Do not redesign
+   the center list in this card.
+5. Empty workspace: keep the No Sources empty state.
+
+## Do not
+
+- Walk `content/` as folders.
+- Show `.boris/`, `themes/`, or `dist/` as mailboxes.
+- Delete the play tabs (M10-3).
+- Add GitHub-specific rows.
+
+## Gate
+
+Open `Stunts/happy`. Sidebar shows the folder as an account with
+five mailboxes. Clicking Outputs / Publish / Plan / Activity changes
+the play tab (via `mailbox`). Changing source resets to Pages and
+clears the page noun. `SKIP_EMBED_BORIS=1 make build` + `make test`
+green.

--- a/docs/cards/M10-mailbox-sidebar.md
+++ b/docs/cards/M10-mailbox-sidebar.md
@@ -5,27 +5,38 @@
 **Lane:** Mailboxes. One worktree, one PR against `main`; branch
 suggestion `feat/m10-mailbox-sidebar`.
 
+Design: [`docs/M10-DESIGN.md`](../M10-DESIGN.md). Nested `graph.parent`
+trunks are **out of this card**. Do not edit `Project.yml`.
+
 ## Owns
 
 - `Sources/Chrome/SourceSidebar.swift` (recut into an account +
-  mailbox tree; do not add a second sidebar file unless the current
-  one cannot hold it)
-- `Sources/Workspace/WorkspaceSelection.swift` — add `mailbox`
-- `Sources/Workspace/WorkspaceStore.swift` — select mailbox; changing
-  source picks that source's default mailbox (`pages`)
+  mailbox tree; do not add a second sidebar file)
+- `Sources/Chrome/MainWindow.swift` — **sole M10 owner**: column
+  width + Editor toolbar `.disabled(!store.selection.canEditPage)`
+- `Sources/Workspace/WorkspaceSelection.swift` — `mailbox`,
+  `WorkspaceMailbox`, `MailboxRowID`, `canEditPage`,
+  `WorkspaceSelectionRules`, `WorkspaceNoun.sourcePath`
+- `Sources/Workspace/WorkspaceStore.swift` — `select(mailbox:)`;
+  persist-on-select if changed; changing source writes `pages`
+- `Sources/Workspace/WorkspacePersistence.swift` —
+  `mailbox: String? = nil` (raw string; do not canonicalize on load)
 - Thin adapter in `Sources/Play/Local/LocalPlay.swift` so today's
   segmented tabs follow `selection.mailbox` (Reading will delete the
-  tabs)
+  tabs). **#101 must not start until this PR is on `main`.**
+- `Tests/ContractTests/WorkspaceSelectionTests.swift` (new) + extend
+  `WorkspacePersistenceTests.swift`. Do **not** add `WorkspaceStore`
+  to ContractTests.
 
 ## Do not touch
 
 - `Sources/App/Settings/` (M10-1)
+- `Sources/App/Commands.swift` (#102)
 - `Sources/Inspector/**`
 - `Sources/Engine/**`
 - `Sources/Companions/**`
-- `Sources/Chrome/MainWindow.swift` beyond a title / column-width
-  tweak if the sidebar needs it
 - Play row rendering, preview, editor
+- `Project.yml` / `scripts/embed-boris.sh`
 
 ## Why
 
@@ -33,26 +44,28 @@ Mail's left pane is folders, not a flat account list. Each source is
 an account header. Under it: Pages, Outputs, Publish, Plan, Activity.
 Selecting a mailbox is what the reading place will listen to.
 
-This is **not** a Finder tree. Nested folders under Pages, if you
-show any, come from `graph.json` `parent` (trunks as folders). Do not
-walk the content directory.
+This is **not** a Finder tree. Do **not** show nested Pages folders
+in this card (later: `graph.parent` trunks only, never a disk walk).
 
 ## Do
 
-1. Grow `WorkspaceSelection` with `mailbox: String?` (open string,
-   same style as `noun.kind`). Default `pages`.
-2. Sidebar `List`:
-   - Section / header per source (title, stale badge, existing
-     Relocate / Remove context menu).
+1. Grow `WorkspaceSelection` with `mailbox: String? = nil`. Persist
+   the **raw** string. M10 UI admits five tokens; unknown → Pages
+   *display* without writing `pages` back (`WorkspaceMailbox.display`).
+2. Sidebar `List` + `Section`, selection type `MailboxRowID`:
+   - Header per source (title, stale badge, Relocate / Remove).
+     Header tap is **best-effort** (macOS Section + gesture is
+     flaky); the Pages row is the accessible control.
    - Child rows: Pages, Outputs, Publish, Plan, Activity.
-   - Selecting a header selects that source + `pages`.
+   - Selecting a header (if it registers) selects that source + `pages`.
    - Selecting a child writes `sourceID` + `mailbox` and clears
      `noun` when the mailbox changes.
 3. Keep the plus button as a shortcut to `presentOpenPanel()`.
-4. Point `LocalPlay`'s segmented control at `selection.mailbox` so
-   the app does not go dark if M10-3 has not landed. Do not redesign
-   the center list in this card.
+4. Point `LocalPlay`'s segmented control at `selection.mailbox`.
+   Do not redesign the center list.
 5. Empty workspace: keep the No Sources empty state.
+6. `MainWindow`: wider sidebar column; Editor toolbar uses
+   `canEditPage`. Do not add views.
 
 ## Do not
 
@@ -64,7 +77,8 @@ walk the content directory.
 ## Gate
 
 Open `Stunts/happy`. Sidebar shows the folder as an account with
-five mailboxes. Clicking Outputs / Publish / Plan / Activity changes
-the play tab (via `mailbox`). Changing source resets to Pages and
-clears the page noun. `SKIP_EMBED_BORIS=1 make build` + `make test`
-green.
+five mailboxes. Clicking the **Pages** child (and the header if the
+tap registers) selects Pages. Clicking Outputs / Publish / Plan /
+Activity changes the play tab (via `mailbox`). Changing source
+resets to Pages and clears the page noun. Restart restores the
+mailbox string. `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/M10-reading-pane.md
+++ b/docs/cards/M10-reading-pane.md
@@ -1,0 +1,74 @@
+# Card M10-3 — Reading pane
+
+**Milestone:** M10 · **Issue:**
+[#101](https://github.com/drawmeanelephant/solipsist/issues/101) ·
+**Lane:** Reading. One worktree, one PR against `main`; branch
+suggestion `feat/m10-reading-pane`.
+
+Depends on [#100](https://github.com/drawmeanelephant/solipsist/issues/100)
+(`selection.mailbox` exists).
+
+## Owns
+
+- `Sources/Play/Local/` — `LocalPlay.swift` and the pane files it
+  already hosts. Tabs go away. Center becomes mailbox contents + a
+  reading pane for a selected page.
+- Shared preview URL loading **inside Play only** (reuse
+  `PreviewURL` / the existing `PreviewSession` if it is already up;
+  do not spawn a second watch)
+
+## Do not touch
+
+- `Sources/Chrome/SourceSidebar.swift` / `WorkspaceSelection` shape
+  (M10-2)
+- `Sources/Engine/**` (no new `Process`)
+- `Sources/Companions/Preview/` beyond calling into the existing
+  session
+- `Sources/Inspector/**`
+- Native text editing (M10-4 / Later)
+
+## Why
+
+Mail's middle is messages, then the letter. Play is currently five
+tabs and a problems strip. After M10-2 the tabs are just a view of
+`mailbox`. This card makes the center a message list plus a reading
+pane, and leaves Outputs / Publish / Plan / Activity as the body of
+those mailboxes — not as a segmented control on top of Pages.
+
+## Do
+
+1. Remove the segmented `PlayTab` picker. Switch on
+   `store.selection.mailbox`.
+2. **Pages mailbox:** keep the existing graph list (filter, badges,
+   indent). Under it or beside it, a reading pane for the selected
+   page:
+   - If preview watch is up, load that page's served URL in a
+     `WKWebView` (path from `sourcePath` / already-decoded graph —
+     do not invent a permalink). Reuse the existing watch; do not
+     start a second one.
+   - If watch is down: contract-backed summary (title, id, status,
+     `sourcePath`, relations from `completion.json` if the inspector
+     already decoded them) + Preview / Edit buttons that open the
+     existing companions.
+3. **Other mailboxes:** the existing Outputs / Publish / Plan /
+   Activity panes, full-height, no fake message list.
+4. Problems strip stays under the reading place (it is the diagnostic
+   mailbox-adjacent surface we already have).
+5. Empty / failed / unavailable states stay
+   `ContentUnavailableView`. No monospaced dump.
+
+## Do not
+
+- `file://` the built HTML.
+- Write a Markdown renderer or frontmatter parser.
+- Spawn `Process`. Only `BorisEngine` / the existing
+  `PreviewSession`.
+- Grow `MainWindow`.
+- Walk the disk for the list — `graph.json` is the structure.
+
+## Gate
+
+Open `Stunts/happy`, select Pages, click a page → reading pane shows
+the summary (and the served page if Preview is already running).
+Select Outputs → the outputs pane, no tab bar. No `file://`. No
+Swift Markdown. `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/M10-reading-pane.md
+++ b/docs/cards/M10-reading-pane.md
@@ -6,25 +6,40 @@
 suggestion `feat/m10-reading-pane`.
 
 Depends on [#100](https://github.com/drawmeanelephant/solipsist/issues/100)
-(`selection.mailbox` exists).
+on `main` (`selection.mailbox` exists). **#102 merges after this
+card.** Design: [`docs/M10-DESIGN.md`](../M10-DESIGN.md).
 
 ## Owns
 
 - `Sources/Play/Local/` — `LocalPlay.swift` and the pane files it
   already hosts. Tabs go away. Center becomes mailbox contents + a
-  reading pane for a selected page.
-- Shared preview URL loading **inside Play only** (reuse
-  `PreviewURL` / the existing `PreviewSession` if it is already up;
-  do not spawn a second watch)
+  reading pane. Double-click / Return / summary Edit →
+  `openWindow(id: CompanionID.editor)`. Problems jump writes mailbox
+  `pages` **and** `noun.sourcePath`. Graph reload rewrites the noun
+  (or clears it).
+- `Sources/Play/Local/ReadingPane.swift` / `ReadingWebView.swift` (new)
+- Named recut — session sharing **without** a second watch:
+  - `Sources/App/AppRuntime.swift` — `let previewSession = PreviewSession()`
+  - `Sources/Chrome/PlayHost.swift` — bind session to
+    `store.selection.sourceID` even when the companion is closed
+    (retarget if serving; stop if no source; **do not auto-start**
+    from idle)
+  - `Sources/Companions/Preview/PreviewSession.swift` — expose
+    `boundRootPath` / `isBound(to:)`
+  - `Sources/Companions/Preview/PreviewWindow.swift` — use
+    `runtime.previewSession`; drop `onDisappear { session.stop() }`
+  - `Sources/Companions/Preview/PreviewURL.swift` — `siteOrigin` /
+    `pageURL(helper:pageID:)` using **`GraphNode.id`**, not swapped
+    `sourcePath`
 
 ## Do not touch
 
 - `Sources/Chrome/SourceSidebar.swift` / `WorkspaceSelection` shape
   (M10-2)
-- `Sources/Engine/**` (no new `Process`)
-- `Sources/Companions/Preview/` beyond calling into the existing
-  session
+- `Sources/Chrome/MainWindow.swift` (#100)
+- `Sources/Engine/**` (no new `Process`; do not change `WatchServer` argv)
 - `Sources/Inspector/**`
+- A second `PreviewSession`
 - Native text editing (M10-4 / Later)
 
 ## Why
@@ -42,10 +57,14 @@ those mailboxes — not as a segmented control on top of Pages.
 2. **Pages mailbox:** keep the existing graph list (filter, badges,
    indent). Under it or beside it, a reading pane for the selected
    page:
-   - If preview watch is up, load that page's served URL in a
-     `WKWebView` (path from `sourcePath` / already-decoded graph —
-     do not invent a permalink). Reuse the existing watch; do not
-     start a second one.
+   - If preview watch is up **and** `previewSession.isBound` to this
+     source, load `PreviewURL.pageURL(helper:pageID:)` in a
+     `WKWebView` (`pageID` is `GraphNode.id` / `PlayPage.id` — **not**
+     `sourcePath` with the extension swapped). Do not invent a
+     permalink. Reuse the existing session; do not start a second
+     watch. Foreign-root `phase == .serving` is idle (summary).
+     `WKNavigationDelegate` detects 404 / load failure → in-pane
+     summary. Retry on `serveURL` change or row re-select, not SSE.
    - If watch is down: contract-backed summary (title, id, status,
      `sourcePath`, relations from `completion.json` if the inspector
      already decoded them) + Preview / Edit buttons that open the
@@ -69,6 +88,10 @@ those mailboxes — not as a segmented control on top of Pages.
 ## Gate
 
 Open `Stunts/happy`, select Pages, click a page → reading pane shows
-the summary (and the served page if Preview is already running).
+the summary (and the served page if Preview is already running **for
+this source**). Switch source with Preview closed while watch was
+up → letter is this source or summary, never the previous folder.
 Select Outputs → the outputs pane, no tab bar. No `file://`. No
-Swift Markdown. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+Swift Markdown. If a cook / id≠stem corpus is available, confirm
+`GET /{id}.html` vs stem. `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.

--- a/docs/cards/M10-settings-sources.md
+++ b/docs/cards/M10-settings-sources.md
@@ -1,0 +1,57 @@
+# Card M10-1 — Settings → Sources
+
+**Milestone:** M10 · **Issue:**
+[#99](https://github.com/drawmeanelephant/solipsist/issues/99) ·
+**Lane:** Settings. One worktree, one PR against `main`; branch
+suggestion `feat/m10-settings-sources`.
+
+## Owns
+
+- `Sources/App/Settings/` (new)
+- Settings scene registration in `Sources/App/SolipsistApp.swift`
+- Settings menu / Sources commands in `Sources/App/Commands.swift`
+- Read-only use of `WorkspaceStore` add / remove / relocate APIs
+
+## Do not touch
+
+- `Sources/Play/**`
+- `Sources/Chrome/SourceSidebar.swift` internals (plus button may
+  stay; it already calls `presentOpenPanel()`)
+- `Sources/Engine/**`
+- `Sources/Inspector/**`
+- `scripts/embed-boris.sh`, `Project.yml` entitlements, #78 paths
+
+## Why
+
+Sources are accounts. Mail puts the account book in Preferences, not
+in the sidebar plus button. File → Open… stays — that is the Mac verb
+for a folder — but the inventory you can add, relocate, and remove
+has to live in Settings too, same `WorkspaceStore`, no second list.
+
+## Do
+
+1. Add a SwiftUI `Settings` scene with a **Sources** pane.
+2. List current sources (title, kind, path, stale badge). Actions:
+   Add Local…, Relocate…, Remove. Reuse
+   `WorkspaceStore.presentOpenPanel` / `presentRelocatePanel` /
+   `remove` — do not invent a second bookmark store.
+3. Empty state: say what a source is and point at `Stunts/happy`.
+4. Menu: Solipsist → Settings… is the system item. File menu keeps
+   Open… / Open Recent / Relocate / Remove.
+5. D2: this pane writes bookmarks / plist only. It does not write
+   `boris.json`. Do not move profile keys or execution knobs here.
+
+## Do not
+
+- Redesign the three-column layout (M10-2 / M10-3).
+- Add a GitHub account row that does not work.
+- Auto-open a repo path or `SUPPORT-NOT-FOR-GITHUB/`.
+- Grow `MainWindow`.
+
+## Gate
+
+Solipsist → Settings… → Sources → Add Local… a folder with
+`boris.json` → it appears in the sidebar and is selected. Relocate
+and Remove from Settings match the File-menu verbs. Restart → source
+still there (#59 persistence). `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.

--- a/docs/cards/M10-settings-sources.md
+++ b/docs/cards/M10-settings-sources.md
@@ -5,21 +5,25 @@
 **Lane:** Settings. One worktree, one PR against `main`; branch
 suggestion `feat/m10-settings-sources`.
 
+Design: [`docs/M10-DESIGN.md`](../M10-DESIGN.md). Recut vs the original
+Owns: **do not edit `Commands.swift`** — Solipsist → Settings… is the
+system item for a `Settings` scene. #102 owns `Commands.swift`.
+
 ## Owns
 
 - `Sources/App/Settings/` (new)
 - Settings scene registration in `Sources/App/SolipsistApp.swift`
-- Settings menu / Sources commands in `Sources/App/Commands.swift`
 - Read-only use of `WorkspaceStore` add / remove / relocate APIs
 
 ## Do not touch
 
+- `Sources/App/Commands.swift` (system Settings… is enough; #102 owns this file)
 - `Sources/Play/**`
 - `Sources/Chrome/SourceSidebar.swift` internals (plus button may
   stay; it already calls `presentOpenPanel()`)
 - `Sources/Engine/**`
 - `Sources/Inspector/**`
-- `scripts/embed-boris.sh`, `Project.yml` entitlements, #78 paths
+- `scripts/embed-boris.sh`, **any of** `Project.yml`, #78 paths
 
 ## Why
 
@@ -36,8 +40,9 @@ has to live in Settings too, same `WorkspaceStore`, no second list.
    `WorkspaceStore.presentOpenPanel` / `presentRelocatePanel` /
    `remove` — do not invent a second bookmark store.
 3. Empty state: say what a source is and point at `Stunts/happy`.
-4. Menu: Solipsist → Settings… is the system item. File menu keeps
-   Open… / Open Recent / Relocate / Remove.
+4. Menu: Solipsist → Settings… is the system item (adding the
+   `Settings` scene is sufficient). File menu keeps Open… / Open
+   Recent / Relocate / Remove. Do not add a Sources command.
 5. D2: this pane writes bookmarks / plist only. It does not write
    `boris.json`. Do not move profile keys or execution knobs here.
 
@@ -52,6 +57,8 @@ has to live in Settings too, same `WorkspaceStore`, no second list.
 
 Solipsist → Settings… → Sources → Add Local… a folder with
 `boris.json` → it appears in the sidebar and is selected. Relocate
-and Remove from Settings match the File-menu verbs. Restart → source
-still there (#59 persistence). `SKIP_EMBED_BORIS=1 make build` +
-`make test` green.
+and Remove from Settings match the File-menu verbs. Restart → the
+source is still **in the list** (#59). Selected-row persistence is
+#100 (`select` does not write defaults until then). After #100,
+Settings `select(id)` also resets mailbox to `pages`.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -19,8 +19,11 @@ with a dispatch comment — [#72 M3](https://github.com/drawmeanelephant/solipsi
 [#78 M9](https://github.com/drawmeanelephant/solipsist/issues/78).
 
 M3–M8 **gates** are closed (#72–#77). The #87 depth batch is closed
-(#88/#94 · #89/#96 · #90/#95 · #91/#93). Active card:
+(#88/#94 · #89/#96 · #90/#95 · #91/#93). Active **ship** card:
 [#78 ship](https://github.com/drawmeanelephant/solipsist/issues/78).
+Next **product cut** is [M10 Mail body](M10-mail-body.md)
+([#98](https://github.com/drawmeanelephant/solipsist/issues/98)) —
+after #78, never inside it.
 
 **Legacy board (landed or withdrawn — do not pick):**
 
@@ -54,10 +57,26 @@ stdin wiring merges after B3-1. B3-4 must keep
 `files.user-selected.read-write` (B3-2) and `network.server` (M5
 preview) in the entitlements matrix.
 
+## M10 — Mail body (after #78, not instead of it)
+
+Spatial recut. Settings for sources, mailbox sidebar, reading pane,
+editor from the selected page. Native editor stays Later.
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [M10 tracker](M10-mail-body.md) | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) | design | — | children filed; HARNESS §2 is the destination |
+| [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | Settings | #100, #102 | Settings → Sources adds/removes/relocates |
+| [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | #99, #102 | account headers + mailboxes; writes `mailbox` |
+| [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | Reading | #102 (after #100) | tabs gone; list + reading pane |
+| [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | #99, #100, #101 | Edit / double-click opens hosted editor |
+
+#78 stays build-lane only. Do not pick an M10 card by growing ship.
+
 ## Do not start yet
 
-GitHub as a source. Wasm in the app. The fart app. Preview, editor,
-and publish already have gates — do not rebuild them.
+GitHub as a source. Wasm in the app. The fart app. A native
+`TextView` editor. Preview, editor host, and publish already have
+gates — M10 wires them into Mail's shape; it does not rebuild them.
 
 ## Shared noun kinds (play writes, inspector reads)
 

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -64,11 +64,11 @@ editor from the selected page. Native editor stays Later.
 
 | Card | Issue | Lane | Parallel with | Gate |
 |------|-------|------|----------------|------|
-| [M10 tracker](M10-mail-body.md) | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) | design | — | children filed; HARNESS §2 is the destination |
-| [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | Settings | #100, #102 | Settings → Sources adds/removes/relocates |
-| [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | #99, #102 | account headers + mailboxes; writes `mailbox` |
-| [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | Reading | #102 (after #100) | tabs gone; list + reading pane |
-| [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | #99, #100, #101 | Edit / double-click opens hosted editor |
+| [M10 tracker](M10-mail-body.md) | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) | design | — | children filed; [`M10-DESIGN.md`](../M10-DESIGN.md) + HARNESS §2 |
+| [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | Settings | #100 | Settings → Sources adds/removes/relocates |
+| [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | #99 | account headers + mailboxes; writes `mailbox` |
+| [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | Reading | — (after #100) | tabs gone; list + reading pane |
+| [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | — (merge after #101) | File → Edit Page; header `sourcePath` |
 
 #78 stays build-lane only. Do not pick an M10 card by growing ship.
 

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -67,7 +67,10 @@ lives in the issue tracker (#58–#61; briefs in
 `docs/cards/B3-*.md`) — those own grind-lane paths, so they are not
 queue cards.
 
-The depth batch (#88–#91) landed. The remaining pickable card is
-[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (M9
-ship). It owns the build lane, not this queue. The queue stays empty
-unless someone cuts a docs-only or `Tests/`-only slice.
+The depth batch (#88–#91) landed. The remaining **ship** card is
+[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (M9).
+M10 Mail body
+([#98](https://github.com/drawmeanelephant/solipsist/issues/98),
+[`../M10-mail-body.md`](../M10-mail-body.md)) is the next product cut
+and owns grind-lane chrome/play paths, so it is not a queue card. The queue stays empty unless someone cuts a docs-only
+or `Tests/`-only slice.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -16,7 +16,9 @@ PR against boris from this repo.
 
 - A5 [boris#647](https://github.com/drawmeanelephant/boris/issues/647) — RFC, filed as an issue (Discussions disabled on the repo). Still open; no fixing PR yet.
 
-**File next:** none.
+**File next:** none. M10 editor wiring (#102) may later need an
+open-file deep link on `boris-editor`; do not draft it until it is
+fact-checked against afterparty. Do not invent a query/fragment.
 
 Do not ask: unifying `compiler` field names, library mode, relaxing
 editor token/CSP, shipping `boris-editor` in the agent-pack.

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -12,13 +12,18 @@ Solipsist is built in Swift 6 with SwiftUI for macOS 14+.
 ## Spatial Model
 
 ```
+Settings → Sources (the account book)
+
 ┌──────────────────┬─────────────────────────────┬──────────────────┐
-│ SOURCES          │ PLAY                        │ DRAWER           │
-│ Local / GitHub   │ Graph, outputs, activity,   │ Profile, page    │
-│                  │ reports                     │ fields, options  │
+│ MAILBOXES        │ READING                     │ DRAWER           │
+│ Source as        │ Message list + reading      │ Profile, page    │
+│ account header   │ pane for the selected page  │ fields, options  │
 └──────────────────┴─────────────────────────────┴──────────────────┘
-Companion windows: Preview (watch --serve) · Editor (boris-editor)
+Companion windows: Preview (full site) · Editor (boris-editor)
 ```
+
+M2–M8 shipped a flatter cut (source list + tabbed play). M10 is the
+recut to the diagram above.
 
 ## Engine Integration
 
@@ -34,4 +39,4 @@ The subprocess boundary is a feature, not an accident:
 - Swift never reimplements compiler semantics. The JSON contracts (`manifest`, `graph`, `completion`, `build-report`, analysis reports) are the single source of truth; the app mirrors and renders them.
 - Diagnostics and exit codes are surfaced, never silently swallowed.
 
-These boundaries are the architectural form of the [[mission]]’s non-negotiables, and they are the reason the graph shown in the play list is the *real* graph from `graph.json` — not a Swift reconstruction.
+These boundaries are the architectural form of the [[mission]]’s non-negotiables, and they are the reason the graph shown in the reading place is the *real* graph from `graph.json` — not a Swift reconstruction.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -17,7 +17,7 @@ Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeane
 <div class="feature-grid">
   <div class="feature-card">
     <h3>Mail-grade chrome</h3>
-    <p>Sources on the left, the graph as a workable play list in the middle, the inspector drawer on the right — one window, real menus, real keyboard.</p>
+    <p>Sources in Settings, mailboxes on the left, a reading pane in the middle, the inspector drawer on the right — one window, real menus, real keyboard.</p>
   </div>
   <div class="feature-card">
     <h3>Subprocess isolation</h3>

--- a/site/content/mission.md
+++ b/site/content/mission.md
@@ -7,7 +7,7 @@ tags: [mission]
 
 # Mission
 
-**Solipsist is Radio UserLand’s job in Mail’s body**: a native Mac harness that turns the graph-native publication compiler into a one-window workstation for sources, play, inspection, preview, and broadcast — and refuses to invent anything the HIG or a Boris contract already named.
+**Solipsist is Radio UserLand’s job in Mail’s body**: a native Mac harness that turns the graph-native publication compiler into a one-window workstation for sources (in Settings), mailboxes, a reading place, inspection, preview, and broadcast — and refuses to invent anything the HIG or a Boris contract already named.
 
 ## The engine we harness
 
@@ -33,4 +33,4 @@ Boris ships its own browser-based editor. Solipsist is the complementary **nativ
 
 ## Where we are
 
-M0–M8 gates and the depth batch (first-run, filter, profile 1:1, publish family) are in. Next is a clean-Mac ship — see [[roadmap]].
+M0–M8 gates and the depth batch (first-run, filter, profile 1:1, publish family) are in. Next ship is a clean-Mac DMG; next product cut is the Mail body (Settings, mailboxes, reading pane) — see [[roadmap]].

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -13,7 +13,9 @@ Solipsist is a **harness**, not a better compiler and not a Markdown IDE. Boris 
 
 M0–M8 **gates** and the depth batch exist: first-run, filter, plan as
 a document, profile 1:1, `recipe-scale`, the rest of `standard-site`,
-readable proof. Remaining work is a notarized DMG on a clean Mac.
+readable proof. Remaining **ship** work is a notarized DMG on a clean
+Mac. Remaining **product** cut is the Mail body: sources in Settings,
+a mailbox sidebar, a reading pane.
 
 | Track | Status |
 |-------|--------|
@@ -22,32 +24,34 @@ readable proof. Remaining work is a notarized DMG on a clean Mac.
 | Usability | landed — first-run, status, problem → page |
 | Play / inspector / publish depth | landed |
 | M9 Ship | open — notarized DMG on a clean Mac |
+| M10 Mail body | planned — Settings, mailboxes, reading pane ([#98](https://github.com/drawmeanelephant/solipsist/issues/98)) |
 
 ## v1 must
 
-- One-window Mail-grade chrome: sources, play, inspector drawer, real menus
-- Local source via security-scoped bookmark
+- One-window Mail-grade chrome: Settings for sources, mailboxes, reading pane, inspector drawer, real menus
+- Local source via security-scoped bookmark — the first account, added in Settings
 - Graph as a workable list — trunks, satellites, status, relations — from contracts
 - The publication profile (`boris.json`) is the single source of truth
 - Coordinator verbs: Plan, Validate, Build, Check, Impact, Stop — each a menu item
 - Diagnostics as a place: clickable reports, not monospaced dumps
 - Engine-owned preview via `watch --serve` + SSE
-- A hosted editor: `boris-editor` in a companion window
+- A hosted editor: `boris-editor` in a companion window, opened from the selected page
 - Outputs fan-out: every profile target and edition, isolated, reported
 - A publication console: GitHub Pages, Standard.site, Nostr — secrets on stdin
 - Sandboxed, bundled, pinned engine
 
 ## v1 must not
 
-- A from-scratch native editor or frontmatter parser
+- A frontmatter parser, a graph algorithm, or a homegrown Markdown renderer
+- A Finder clone of the content tree
+- A native editor *instead of* hosting `boris-editor` (named later: buffer + save + problems)
 - An app-side HTTP server or `file://` preview
-- A graph algorithm in Swift
 - Cloudflare / Vercel / Netlify as *in-app* deploy adapters
 - Wasm or `compileBundle` *inside* Solipsist — subprocess isolation stays
 - Theme *authoring* (selection only)
 
 ## The north star
 
-Open a folder of Boris content → it appears as a **source** → the play place shows the real graph from `graph.json` → the drawer shows the profile and the selected page → Plan / Validate / Build surface every diagnostic → Preview reloads through `watch --serve` → Edit opens `boris-editor` → Publish runs GitHub Pages evidence, Standard.site, or Nostr with the Proof Pack attached.
+Open a folder of Boris content → it is a **source** in Settings → it appears as an account with mailboxes → the reading place shows the graph as messages and a pane for the selected page → the drawer shows the profile and that page → Plan / Validate / Build surface every diagnostic → Preview reloads through `watch --serve` → Edit opens `boris-editor` → Publish runs GitHub Pages evidence, Standard.site, or Nostr with the Proof Pack attached.
 
 This project’s own public face is a Cloudflare subdomain on Boris’s official Worker + Wasm embed host — stood up early, on the Free tier, not as an in-app engine. Full detail lives in the repository [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).


### PR DESCRIPTION
## Why

[#98](https://github.com/drawmeanelephant/solipsist/issues/98) is the M10 tracker. The filed cards named the destination; they did not specify enough to implement without colliding. This is the design-lane PR (PR 0): extra planning plus a recut of HARNESS §4 and the four child cards so they name the same owners.

Implementation stays on new feature branches off `main`, one per card. #78 is untouched.

## What landed

- [`docs/M10-DESIGN.md`](docs/M10-DESIGN.md) — accepted implementation design (selection, Settings store sharing, reading-pane URL + `PreviewSession` reuse, editor header fallback, file-ownership matrix, tests).
- HARNESS §4 M10 rows + sequence aligned with the recut.
- Child cards #99–#102 Owns / Do-not-touch / Gate patched.
- ROADMAP M10 pointer.

## Recuts vs the original cards

| Child | Change |
|-------|--------|
| #99 | Does not edit `Commands.swift` or `Project.yml`. |
| #100 | Sole `MainWindow` owner; persist mailbox raw; no `Project.yml`; no `WorkspaceStore` in ContractTests. Nested trunks out of M10. |
| #101 | Named recut: lift `PreviewSession` onto `AppRuntime`, bind from `PlayHost`, URL from `GraphNode.id`. Lands double-click / Return. |
| #102 | Off `LocalPlay` and `MainWindow`. Merge after #101. No invented editor deep link. |

## Merge order after this PR

`#99 ∥ #100` → `#101` → `#102`

## Gate

HARNESS §4, the four child cards, and `docs/M10-DESIGN.md` name the same owners. Docs only — no `Sources/`, no `Project.yml`.