### PR TITLE
feat(m10): Settings → Sources account book (#99)

### DIFF
--- a/Sources/App/Settings/SettingsRoot.swift
+++ b/Sources/App/Settings/SettingsRoot.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// Settings scene root. One tab now so later panes slot in without a new scene.
+struct SettingsRoot: View {
+    var body: some View {
+        TabView {
+            SourcesSettingsPane()
+                .tabItem {
+                    Label("Sources", systemImage: "folder")
+                }
+        }
+        .frame(minWidth: 520, minHeight: 360)
+    }
+}

--- a/Sources/App/Settings/SourcesSettingsPane.swift
+++ b/Sources/App/Settings/SourcesSettingsPane.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+/// Account book for local sources. Writes bookmarks and the workspace plist
+/// through `WorkspaceStore` only — never `boris.json`.
+struct SourcesSettingsPane: View {
+    @Environment(WorkspaceStore.self) private var store
+    @State private var confirmRemove = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if store.sources.isEmpty {
+                emptyState
+            } else {
+                sourceList
+                actionBar
+                Text("A source is a folder of Boris content.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .confirmationDialog(
+            removePrompt,
+            isPresented: $confirmRemove,
+            titleVisibility: .visible
+        ) {
+            Button("Remove", role: .destructive) {
+                if let id = store.selection.sourceID {
+                    store.remove(id)
+                }
+            }
+        } message: {
+            Text("The folder on disk is not deleted.")
+        }
+    }
+
+    private var sourceList: some View {
+        List(selection: selectedSource) {
+            ForEach(store.sources) { item in
+                SourceAccountRow(item: item)
+                    .tag(item.id)
+            }
+        }
+        .listStyle(.bordered(alternatesRowBackgrounds: true))
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: 8) {
+            Button("Add Local…") {
+                store.presentOpenPanel()
+            }
+            Button("Relocate…") {
+                if let id = store.selection.sourceID {
+                    store.presentRelocatePanel(for: id)
+                }
+            }
+            .disabled(store.selectedSource?.isAvailable != false)
+            Button("Remove", role: .destructive) {
+                confirmRemove = true
+            }
+            .disabled(store.selection.sourceID == nil)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Spacer(minLength: 0)
+            Image(systemName: "folder.badge.plus")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+            Text("No Sources")
+                .font(.headline)
+            Text("A source is a folder of Boris content — an account, not a file tree. Add a folder that contains `boris.json` (for example `Stunts/happy`) to get started.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 380)
+            Button("Add Local…") {
+                store.presentOpenPanel()
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var selectedSource: Binding<SourceID?> {
+        Binding(
+            get: { store.selection.sourceID },
+            set: { store.select($0) }
+        )
+    }
+
+    private var removePrompt: String {
+        let name = store.selectedSource?.title ?? "this source"
+        return "Remove “\(name)” from Solipsist?"
+    }
+}
+
+private struct SourceAccountRow: View {
+    let item: SourceItem
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(item.title)
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                    Text(item.kind.displayName)
+                        .foregroundStyle(.secondary)
+                }
+                if let path = item.detailLine {
+                    Text(path)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                if !item.isAvailable {
+                    Text("Unreachable — Relocate / Remove")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .lineLimit(1)
+                }
+            }
+        } icon: {
+            Image(systemName: item.symbolName)
+                .symbolVariant(item.isAvailable ? .none : .slash)
+                .foregroundStyle(item.isAvailable ? Color.primary : Color.orange)
+        }
+        .help(
+            item.isAvailable
+                ? (item.detailLine ?? item.title)
+                : "Unreachable — Relocate / Remove"
+        )
+    }
+}

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -97,5 +97,11 @@ struct SolipsistApp: App {
         }
         .windowResizability(.contentSize)
         .defaultSize(width: 400, height: 280)
+
+        Settings {
+            SettingsRoot()
+                .environment(store)
+                .environment(runtime)
+        }
     }
 }


### PR DESCRIPTION
## Why

[#99](https://github.com/drawmeanelephant/solipsist/issues/99) / M10-1. Sources are accounts. Mail puts the account book in Preferences. File → Open… stays; this pane is the same `WorkspaceStore`.

Parent tracker: [#98](https://github.com/drawmeanelephant/solipsist/issues/98). Design: [#103](https://github.com/drawmeanelephant/solipsist/pull/103) / [`docs/M10-DESIGN.md`](https://github.com/drawmeanelephant/solipsist/blob/docs/m10-mail-body/docs/M10-DESIGN.md).

## What

- New `Settings` scene with a Sources pane (`SettingsRoot` + `SourcesSettingsPane`).
- Same `@State store` via `.environment(store)`. Add Local… / Relocate… / Remove call existing store methods.
- Relocate enabled only when the selected source is stale (same predicate as File → Relocate).
- Remove confirms. Row click selects that source (in-session; persist-on-select is #100).
- Empty state names `Stunts/happy`.

## Recut

- Does **not** edit `Commands.swift` (system Settings… is enough).
- Does **not** edit `Project.yml`.
- Parallel with #100. Does not touch the sidebar.

## Gate

`SKIP_EMBED_BORIS=1 make build` + `make test` green (102 tests). Restart → source still **in the list** (#59). Selected-row persistence waits for #100.