### PR TITLE
feat(m10): mailbox sidebar and selection.mailbox (#100)

### DIFF
--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -15,7 +15,7 @@ struct MainWindow: View {
     var body: some View {
         NavigationSplitView {
             SourceSidebar()
-                .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 300)
+                .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 340)
         } detail: {
             PlayHost()
         }
@@ -64,7 +64,7 @@ struct MainWindow: View {
                     Label("Editor", systemImage: "square.and.pencil")
                 }
                 .help("Open Editor")
-                .disabled(store.selectedSource == nil)
+                .disabled(!store.selection.canEditPage)
             }
         }
         .onAppear {

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -1,31 +1,33 @@
 import SwiftUI
 
-/// Left column. A source list, Mail-style — accounts, not a file tree.
+/// Left column. Each source is an account header; mailboxes are the folders.
 struct SourceSidebar: View {
     @Environment(WorkspaceStore.self) private var store
 
     var body: some View {
-        @Bindable var store = store
-        List(selection: selectedSource) {
-            Section("Sources") {
-                ForEach(store.sources) { item in
-                    SourceRow(item: item)
-                        .tag(item.id)
-                        .contextMenu {
-                            if !item.isAvailable {
-                                Button("Relocate…") {
-                                    store.presentRelocatePanel(for: item.id)
-                                }
-                            }
-                            Button("Remove from Sidebar", role: .destructive) {
-                                store.remove(item.id)
-                            }
+        List(selection: selectedRow) {
+            ForEach(store.sources) { item in
+                Section {
+                    ForEach(WorkspaceMailbox.all, id: \.self) { box in
+                        Label(
+                            WorkspaceMailbox.displayName(box),
+                            systemImage: WorkspaceMailbox.symbolName(box)
+                        )
+                        .tag(MailboxRowID(sourceID: item.id, mailbox: box))
+                        .contextMenu { sourceMenu(item) }
+                    }
+                } header: {
+                    SourceAccountHeader(item: item)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            store.select(item.id, mailbox: WorkspaceMailbox.pages)
                         }
+                        .contextMenu { sourceMenu(item) }
                 }
             }
         }
         .listStyle(.sidebar)
-        .navigationTitle("Sources")
+        .navigationTitle("Mailboxes")
         .overlay {
             if store.sources.isEmpty {
                 EmptyStateView(
@@ -47,15 +49,39 @@ struct SourceSidebar: View {
         }
     }
 
-    private var selectedSource: Binding<SourceID?> {
+    private var selectedRow: Binding<MailboxRowID?> {
         Binding(
-            get: { store.selection.sourceID },
-            set: { store.select($0) }
+            get: {
+                guard let id = store.selection.sourceID else { return nil }
+                return MailboxRowID(
+                    sourceID: id,
+                    mailbox: WorkspaceMailbox.display(store.selection.mailbox)
+                )
+            },
+            set: { row in
+                guard let row else {
+                    store.select(nil)
+                    return
+                }
+                store.select(row.sourceID, mailbox: row.mailbox)
+            }
         )
+    }
+
+    @ViewBuilder
+    private func sourceMenu(_ item: SourceItem) -> some View {
+        if !item.isAvailable {
+            Button("Relocate…") {
+                store.presentRelocatePanel(for: item.id)
+            }
+        }
+        Button("Remove from Sidebar", role: .destructive) {
+            store.remove(item.id)
+        }
     }
 }
 
-private struct SourceRow: View {
+private struct SourceAccountHeader: View {
     let item: SourceItem
 
     var body: some View {

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -21,13 +21,19 @@ struct LocalPlay: PlaySurface {
         var id: String { rawValue }
     }
 
-    @State private var selectedTab: PlayTab = .pages
     @State private var state: LoadState = .idle
     @State private var searchText = ""
 
+    private var selectedTab: Binding<PlayTab> {
+        Binding(
+            get: { PlayTab(mailbox: store.selection.mailbox) },
+            set: { store.select(mailbox: $0.mailboxKey) }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            Picker("View", selection: $selectedTab) {
+            Picker("View", selection: selectedTab) {
                 ForEach(PlayTab.allCases) { tab in
                     Text(tab.rawValue).tag(tab)
                 }
@@ -38,7 +44,7 @@ struct LocalPlay: PlaySurface {
 
             Divider()
 
-            switch selectedTab {
+            switch selectedTab.wrappedValue {
             case .pages:
                 pagesContent
             case .outputs:
@@ -261,6 +267,28 @@ struct LocalPlay: PlaySurface {
         case empty
         case ready([PlayPage])
         case failed(String)
+    }
+}
+
+extension LocalPlay.PlayTab {
+    var mailboxKey: String {
+        switch self {
+        case .pages: return WorkspaceMailbox.pages
+        case .outputs: return WorkspaceMailbox.outputs
+        case .publish: return WorkspaceMailbox.publish
+        case .plan: return WorkspaceMailbox.plan
+        case .activity: return WorkspaceMailbox.activity
+        }
+    }
+
+    init(mailbox: String?) {
+        switch WorkspaceMailbox.display(mailbox) {
+        case WorkspaceMailbox.outputs: self = .outputs
+        case WorkspaceMailbox.publish: self = .publish
+        case WorkspaceMailbox.plan: self = .plan
+        case WorkspaceMailbox.activity: self = .activity
+        default: self = .pages
+        }
     }
 }
 

--- a/Sources/Workspace/WorkspacePersistence.swift
+++ b/Sources/Workspace/WorkspacePersistence.swift
@@ -5,6 +5,8 @@ import Foundation
 struct PersistedWorkspace: Codable, Equatable, Sendable {
     var sources: [LocalSource]
     var selected: SourceID?
+    /// Raw mailbox token. Missing key decodes as nil; do not canonicalize.
+    var mailbox: String? = nil
 }
 
 enum WorkspacePersistence {

--- a/Sources/Workspace/WorkspaceSelection.swift
+++ b/Sources/Workspace/WorkspaceSelection.swift
@@ -1,21 +1,132 @@
 import Foundation
 
-/// The single selected source plus the noun selected in play.
+/// The single selected source, mailbox, and the noun selected in play.
 ///
 /// Drawer and companions **read** this. They never own it. Play writes `noun`;
-/// chrome writes `sourceID` when the sidebar changes.
+/// chrome writes `sourceID` + `mailbox` when the sidebar changes.
 ///
 /// `noun` is an open pair of strings so the play / inspector lanes can agree
 /// on kinds (`page`, `target`, `edition`, …) without editing this file.
+/// `mailbox` is an open string. Persist the raw value; do not canonicalize.
 struct WorkspaceSelection: Hashable, Sendable, Codable {
     var sourceID: SourceID?
+    /// Open string. Persist raw. Nil when no source is selected.
+    var mailbox: String? = nil
     var noun: WorkspaceNoun?
 
-    static let empty = WorkspaceSelection(sourceID: nil, noun: nil)
+    var canEditPage: Bool { noun?.kind == "page" }
+
+    static let empty = WorkspaceSelection(sourceID: nil, mailbox: nil, noun: nil)
 }
 
 struct WorkspaceNoun: Hashable, Sendable, Codable {
     var kind: String
     var id: String
     var title: String
+    /// Content-root-relative path from `GraphNode.sourcePath`. Page nouns only.
+    var sourcePath: String? = nil
+}
+
+/// Sidebar `List` selection. Lives here so ContractTests can construct it
+/// without importing SwiftUI.
+struct MailboxRowID: Hashable, Sendable {
+    var sourceID: SourceID
+    var mailbox: String
+}
+
+/// M10 mailbox tokens. Open vocabulary — not a closed enum.
+/// M10 UI admits only `all`; unknown values display as Pages
+/// without being rewritten to `pages` in the plist.
+enum WorkspaceMailbox {
+    static let pages = "pages"
+    static let outputs = "outputs"
+    static let publish = "publish"
+    static let plan = "plan"
+    static let activity = "activity"
+
+    static let all: [String] = [pages, outputs, publish, plan, activity]
+    static let defaultMailbox = pages
+
+    static func isKnown(_ raw: String?) -> Bool {
+        guard let raw else { return false }
+        return all.contains(raw)
+    }
+
+    /// M10 display/switch value. Does **not** write back.
+    /// A later trunk card must stop using this for persist.
+    static func display(_ raw: String?) -> String {
+        guard let raw, isKnown(raw) else { return defaultMailbox }
+        return raw
+    }
+
+    static func displayName(_ raw: String) -> String {
+        switch raw {
+        case pages: return "Pages"
+        case outputs: return "Outputs"
+        case publish: return "Publish"
+        case plan: return "Plan"
+        case activity: return "Activity"
+        default: return raw
+        }
+    }
+
+    static func symbolName(_ raw: String) -> String {
+        switch raw {
+        case pages: return "doc.text"
+        case outputs: return "square.stack"
+        case publish: return "paperplane"
+        case plan: return "doc.plaintext"
+        case activity: return "clock"
+        default: return "folder"
+        }
+    }
+}
+
+/// Pure selection transitions. `WorkspaceStore` calls these, then
+/// `persist()` if the value changed. ContractTests compile this file
+/// already — do not add `WorkspaceStore.swift` to the test target.
+enum WorkspaceSelectionRules {
+    static func selectSource(_ current: WorkspaceSelection, id: SourceID?) -> WorkspaceSelection {
+        var next = current
+        let changed = current.sourceID != id
+        next.sourceID = id
+        if id == nil {
+            next.mailbox = nil
+            next.noun = nil
+        } else if changed {
+            next.mailbox = WorkspaceMailbox.defaultMailbox
+            next.noun = nil
+        }
+        return next
+    }
+
+    static func selectMailbox(_ current: WorkspaceSelection, mailbox: String) -> WorkspaceSelection {
+        guard current.sourceID != nil else { return current }
+        // Store what chrome wrote (one of `all` in M10). Do not coerce unknown → pages.
+        guard current.mailbox != mailbox else { return current }
+        var next = current
+        next.mailbox = mailbox
+        next.noun = nil
+        return next
+    }
+
+    static func select(_ current: WorkspaceSelection, id: SourceID, mailbox: String) -> WorkspaceSelection {
+        var next = current
+        let sourceChanged = current.sourceID != id
+        let mailboxChanged = current.mailbox != mailbox
+        next.sourceID = id
+        next.mailbox = mailbox
+        if sourceChanged || mailboxChanged {
+            next.noun = nil
+        }
+        return next
+    }
+
+    static func restore(selected: SourceID?, mailbox: String?, available: Set<SourceID>) -> WorkspaceSelection {
+        guard let selected, available.contains(selected) else {
+            return .empty
+        }
+        // Raw mailbox. Do not run `display` here.
+        return WorkspaceSelection(sourceID: selected, mailbox: mailbox, noun: nil)
+    }
 }

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -32,9 +32,25 @@ final class WorkspaceStore {
     }
 
     func select(_ id: SourceID?) {
-        guard selection.sourceID != id else { return }
-        selection.sourceID = id
-        selection.noun = nil
+        let next = WorkspaceSelectionRules.selectSource(selection, id: id)
+        guard next != selection else { return }
+        selection = next
+        persist()
+    }
+
+    func select(mailbox: String) {
+        let next = WorkspaceSelectionRules.selectMailbox(selection, mailbox: mailbox)
+        guard next != selection else { return }
+        selection = next
+        persist()
+    }
+
+    /// Sidebar write path. Header click passes `mailbox: WorkspaceMailbox.pages`.
+    func select(_ id: SourceID, mailbox: String) {
+        let next = WorkspaceSelectionRules.select(selection, id: id, mailbox: mailbox)
+        guard next != selection else { return }
+        selection = next
+        persist()
     }
 
     func select(noun: WorkspaceNoun?) {
@@ -190,7 +206,8 @@ final class WorkspaceStore {
         }
         let payload = PersistedWorkspace(
             sources: locals,
-            selected: selection.sourceID
+            selected: selection.sourceID,
+            mailbox: selection.mailbox
         )
         do {
             defaults.set(try WorkspacePersistence.encode(payload), forKey: WorkspacePersistence.defaultsKey)
@@ -214,11 +231,11 @@ final class WorkspaceStore {
                 }
                 return .local(local)
             }
-            if let selected = payload.selected,
-               sources.contains(where: { $0.id == selected })
-            {
-                selection.sourceID = selected
-            }
+            selection = WorkspaceSelectionRules.restore(
+                selected: payload.selected,
+                mailbox: payload.mailbox,
+                available: Set(sources.map(\.id))
+            )
             if refreshed {
                 persist()
             }

--- a/Tests/ContractTests/WorkspacePersistenceTests.swift
+++ b/Tests/ContractTests/WorkspacePersistenceTests.swift
@@ -50,9 +50,78 @@ final class WorkspacePersistenceTests: XCTestCase {
         }
         let decoded = try WorkspacePersistence.decode(data)
         XCTAssertEqual(decoded.selected, source.id)
+        XCTAssertNil(decoded.mailbox)
         XCTAssertEqual(decoded.sources.count, 1)
         XCTAssertEqual(decoded.sources[0].id, source.id)
         XCTAssertEqual(decoded.sources[0].bookmarkData, source.bookmarkData)
+    }
+
+    func testV1PayloadWithoutMailboxDecodesNil() throws {
+        let source = try LocalSource.make(from: scratch)
+        let encodedSource = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(source)
+        )
+        let encodedSelected = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(source.id)
+        )
+        let v1: [String: Any] = [
+            "sources": [encodedSource],
+            "selected": encodedSelected,
+        ]
+        let decoded = try WorkspacePersistence.decode(
+            try JSONSerialization.data(withJSONObject: v1)
+        )
+        XCTAssertNil(decoded.mailbox)
+        XCTAssertEqual(decoded.selected, source.id)
+        XCTAssertEqual(decoded.sources.count, 1)
+        XCTAssertEqual(decoded.sources[0].id, source.id)
+    }
+
+    func testMailboxActivitySurvivesRoundTrip() throws {
+        let source = try LocalSource.make(from: scratch)
+        let payload = PersistedWorkspace(
+            sources: [source],
+            selected: source.id,
+            mailbox: WorkspaceMailbox.activity
+        )
+        let decoded = try WorkspacePersistence.decode(try WorkspacePersistence.encode(payload))
+        XCTAssertEqual(decoded.mailbox, WorkspaceMailbox.activity)
+        XCTAssertEqual(decoded.selected, source.id)
+    }
+
+    func testUnknownMailboxIsNotRewrittenToPages() throws {
+        let source = try LocalSource.make(from: scratch)
+        for raw in ["trunk:guides", "guides/overview"] {
+            let payload = PersistedWorkspace(
+                sources: [source],
+                selected: source.id,
+                mailbox: raw
+            )
+            let decoded = try WorkspacePersistence.decode(try WorkspacePersistence.encode(payload))
+            XCTAssertEqual(decoded.mailbox, raw)
+            XCTAssertNotEqual(decoded.mailbox, WorkspaceMailbox.pages)
+        }
+    }
+
+    func testForwardCompatibleLegacyShapeIgnoresMailbox() throws {
+        struct LegacyPersistedWorkspace: Codable {
+            var sources: [LocalSource]
+            var selected: SourceID?
+        }
+
+        let source = try LocalSource.make(from: scratch)
+        let payload = PersistedWorkspace(
+            sources: [source],
+            selected: source.id,
+            mailbox: WorkspaceMailbox.outputs
+        )
+        let decoded = try JSONDecoder().decode(
+            LegacyPersistedWorkspace.self,
+            from: try WorkspacePersistence.encode(payload)
+        )
+        XCTAssertEqual(decoded.selected, source.id)
+        XCTAssertEqual(decoded.sources.count, 1)
+        XCTAssertEqual(decoded.sources[0].id, source.id)
     }
 
     func testDeletedFolderFailsResolve() throws {

--- a/Tests/ContractTests/WorkspacePersistenceTests.swift
+++ b/Tests/ContractTests/WorkspacePersistenceTests.swift
@@ -64,12 +64,12 @@ final class WorkspacePersistenceTests: XCTestCase {
         let encodedSelected = try JSONSerialization.jsonObject(
             with: try JSONEncoder().encode(source.id)
         )
-        let v1: [String: Any] = [
+        let legacyPayload: [String: Any] = [
             "sources": [encodedSource],
             "selected": encodedSelected,
         ]
         let decoded = try WorkspacePersistence.decode(
-            try JSONSerialization.data(withJSONObject: v1)
+            try JSONSerialization.data(withJSONObject: legacyPayload)
         )
         XCTAssertNil(decoded.mailbox)
         XCTAssertEqual(decoded.selected, source.id)

--- a/Tests/ContractTests/WorkspaceSelectionTests.swift
+++ b/Tests/ContractTests/WorkspaceSelectionTests.swift
@@ -1,0 +1,222 @@
+import XCTest
+
+final class WorkspaceSelectionTests: XCTestCase {
+    private let sourceA = SourceID()
+    private let sourceB = SourceID()
+    private let page = WorkspaceNoun(kind: "page", id: "index", title: "Home")
+    private let target = WorkspaceNoun(kind: "target", id: "html", title: "html")
+
+    func testMemberwiseInitsDefaultMailboxAndSourcePath() {
+        let selection = WorkspaceSelection(sourceID: nil, noun: nil)
+        XCTAssertNil(selection.mailbox)
+        XCTAssertEqual(selection, .empty)
+
+        let noun = WorkspaceNoun(kind: "page", id: "index", title: "Home")
+        XCTAssertNil(noun.sourcePath)
+    }
+
+    func testDisplayMapsUnknownAndNilToPagesWithoutRewriting() {
+        XCTAssertEqual(WorkspaceMailbox.display(nil), WorkspaceMailbox.pages)
+        XCTAssertEqual(WorkspaceMailbox.display("trunk:guides"), WorkspaceMailbox.pages)
+        XCTAssertEqual(WorkspaceMailbox.display("guides/overview"), WorkspaceMailbox.pages)
+        XCTAssertEqual(WorkspaceMailbox.display(WorkspaceMailbox.activity), WorkspaceMailbox.activity)
+        XCTAssertEqual(WorkspaceMailbox.display(WorkspaceMailbox.pages), WorkspaceMailbox.pages)
+
+        XCTAssertFalse(WorkspaceMailbox.isKnown(nil))
+        XCTAssertFalse(WorkspaceMailbox.isKnown("trunk:guides"))
+        XCTAssertTrue(WorkspaceMailbox.isKnown(WorkspaceMailbox.pages))
+        XCTAssertTrue(WorkspaceMailbox.isKnown(WorkspaceMailbox.outputs))
+        XCTAssertEqual(WorkspaceMailbox.all, [
+            WorkspaceMailbox.pages,
+            WorkspaceMailbox.outputs,
+            WorkspaceMailbox.publish,
+            WorkspaceMailbox.plan,
+            WorkspaceMailbox.activity,
+        ])
+    }
+
+    func testMailboxRowIDHashEquality() {
+        let a = MailboxRowID(sourceID: sourceA, mailbox: WorkspaceMailbox.pages)
+        let b = MailboxRowID(sourceID: sourceA, mailbox: WorkspaceMailbox.pages)
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(Set([a, b]).count, 1)
+        XCTAssertNotEqual(
+            a,
+            MailboxRowID(sourceID: sourceA, mailbox: WorkspaceMailbox.outputs)
+        )
+        XCTAssertNotEqual(
+            a,
+            MailboxRowID(sourceID: sourceB, mailbox: WorkspaceMailbox.pages)
+        )
+    }
+
+    func testNounRoundTripsMissingAndPresentSourcePath() throws {
+        let withoutPath = WorkspaceNoun(kind: "page", id: "index", title: "Home")
+        let decodedMissing = try JSONDecoder().decode(
+            WorkspaceNoun.self,
+            from: try JSONEncoder().encode(withoutPath)
+        )
+        XCTAssertNil(decodedMissing.sourcePath)
+
+        let legacy = Data(#"{"kind":"page","id":"index","title":"Home"}"#.utf8)
+        let decodedLegacy = try JSONDecoder().decode(WorkspaceNoun.self, from: legacy)
+        XCTAssertNil(decodedLegacy.sourcePath)
+        XCTAssertEqual(decodedLegacy.id, "index")
+
+        let withPath = WorkspaceNoun(
+            kind: "page",
+            id: "index",
+            title: "Home",
+            sourcePath: "index.md"
+        )
+        let decodedPresent = try JSONDecoder().decode(
+            WorkspaceNoun.self,
+            from: try JSONEncoder().encode(withPath)
+        )
+        XCTAssertEqual(decodedPresent.sourcePath, "index.md")
+    }
+
+    func testCanEditPageRequiresPageNoun() {
+        XCTAssertFalse(WorkspaceSelection.empty.canEditPage)
+        XCTAssertFalse(
+            WorkspaceSelection(sourceID: sourceA, mailbox: WorkspaceMailbox.pages, noun: target)
+                .canEditPage
+        )
+        XCTAssertTrue(
+            WorkspaceSelection(sourceID: sourceA, mailbox: WorkspaceMailbox.pages, noun: page)
+                .canEditPage
+        )
+    }
+
+    func testSelectSourceChangeWritesPagesAndClearsNoun() {
+        let current = WorkspaceSelection(
+            sourceID: sourceA,
+            mailbox: WorkspaceMailbox.activity,
+            noun: page
+        )
+        let next = WorkspaceSelectionRules.selectSource(current, id: sourceB)
+        XCTAssertEqual(next.sourceID, sourceB)
+        XCTAssertEqual(next.mailbox, WorkspaceMailbox.pages)
+        XCTAssertNil(next.noun)
+    }
+
+    func testSelectSourceSameIdDoesNotClobberMailboxOrNoun() {
+        let current = WorkspaceSelection(
+            sourceID: sourceA,
+            mailbox: WorkspaceMailbox.activity,
+            noun: page
+        )
+        let next = WorkspaceSelectionRules.selectSource(current, id: sourceA)
+        XCTAssertEqual(next, current)
+    }
+
+    func testSelectSourceNilClearsMailboxAndNoun() {
+        let current = WorkspaceSelection(
+            sourceID: sourceA,
+            mailbox: WorkspaceMailbox.outputs,
+            noun: page
+        )
+        let next = WorkspaceSelectionRules.selectSource(current, id: nil)
+        XCTAssertEqual(next, .empty)
+    }
+
+    func testSelectMailboxClearsNounAndStoresRaw() {
+        let current = WorkspaceSelection(
+            sourceID: sourceA,
+            mailbox: WorkspaceMailbox.pages,
+            noun: page
+        )
+        let next = WorkspaceSelectionRules.selectMailbox(current, mailbox: WorkspaceMailbox.publish)
+        XCTAssertEqual(next.sourceID, sourceA)
+        XCTAssertEqual(next.mailbox, WorkspaceMailbox.publish)
+        XCTAssertNil(next.noun)
+
+        let unknown = WorkspaceSelectionRules.selectMailbox(current, mailbox: "trunk:guides")
+        XCTAssertEqual(unknown.mailbox, "trunk:guides")
+        XCTAssertNil(unknown.noun)
+    }
+
+    func testSelectMailboxNoopsWhenUnchangedOrNoSource() {
+        let current = WorkspaceSelection(
+            sourceID: sourceA,
+            mailbox: WorkspaceMailbox.plan,
+            noun: page
+        )
+        XCTAssertEqual(
+            WorkspaceSelectionRules.selectMailbox(current, mailbox: WorkspaceMailbox.plan),
+            current
+        )
+        XCTAssertEqual(
+            WorkspaceSelectionRules.selectMailbox(.empty, mailbox: WorkspaceMailbox.pages),
+            .empty
+        )
+    }
+
+    func testSelectWritesSourceAndMailboxAndClearsNounWhenChanged() {
+        let current = WorkspaceSelection(
+            sourceID: sourceA,
+            mailbox: WorkspaceMailbox.pages,
+            noun: page
+        )
+        let mailboxChange = WorkspaceSelectionRules.select(
+            current,
+            id: sourceA,
+            mailbox: WorkspaceMailbox.outputs
+        )
+        XCTAssertEqual(mailboxChange.sourceID, sourceA)
+        XCTAssertEqual(mailboxChange.mailbox, WorkspaceMailbox.outputs)
+        XCTAssertNil(mailboxChange.noun)
+
+        let sourceChange = WorkspaceSelectionRules.select(
+            current,
+            id: sourceB,
+            mailbox: WorkspaceMailbox.pages
+        )
+        XCTAssertEqual(sourceChange.sourceID, sourceB)
+        XCTAssertEqual(sourceChange.mailbox, WorkspaceMailbox.pages)
+        XCTAssertNil(sourceChange.noun)
+
+        let sameRow = WorkspaceSelectionRules.select(
+            current,
+            id: sourceA,
+            mailbox: WorkspaceMailbox.pages
+        )
+        XCTAssertEqual(sameRow, current)
+    }
+
+    func testRestoreKeepsRawMailboxIncludingUnknown() {
+        XCTAssertEqual(
+            WorkspaceSelectionRules.restore(selected: nil, mailbox: WorkspaceMailbox.activity, available: [sourceA]),
+            .empty
+        )
+        XCTAssertEqual(
+            WorkspaceSelectionRules.restore(selected: sourceB, mailbox: WorkspaceMailbox.activity, available: [sourceA]),
+            .empty
+        )
+
+        let known = WorkspaceSelectionRules.restore(
+            selected: sourceA,
+            mailbox: WorkspaceMailbox.activity,
+            available: [sourceA]
+        )
+        XCTAssertEqual(known.sourceID, sourceA)
+        XCTAssertEqual(known.mailbox, WorkspaceMailbox.activity)
+        XCTAssertNil(known.noun)
+
+        let unknown = WorkspaceSelectionRules.restore(
+            selected: sourceA,
+            mailbox: "trunk:guides",
+            available: [sourceA]
+        )
+        XCTAssertEqual(unknown.mailbox, "trunk:guides")
+        XCTAssertNotEqual(unknown.mailbox, WorkspaceMailbox.pages)
+
+        let missing = WorkspaceSelectionRules.restore(
+            selected: sourceA,
+            mailbox: nil,
+            available: [sourceA]
+        )
+        XCTAssertNil(missing.mailbox)
+        XCTAssertEqual(WorkspaceMailbox.display(missing.mailbox), WorkspaceMailbox.pages)
+    }
+}

--- a/Tests/ContractTests/WorkspaceSelectionTests.swift
+++ b/Tests/ContractTests/WorkspaceSelectionTests.swift
@@ -36,16 +36,16 @@ final class WorkspaceSelectionTests: XCTestCase {
     }
 
     func testMailboxRowIDHashEquality() {
-        let a = MailboxRowID(sourceID: sourceA, mailbox: WorkspaceMailbox.pages)
-        let b = MailboxRowID(sourceID: sourceA, mailbox: WorkspaceMailbox.pages)
-        XCTAssertEqual(a, b)
-        XCTAssertEqual(Set([a, b]).count, 1)
+        let firstRow = MailboxRowID(sourceID: sourceA, mailbox: WorkspaceMailbox.pages)
+        let sameRow = MailboxRowID(sourceID: sourceA, mailbox: WorkspaceMailbox.pages)
+        XCTAssertEqual(firstRow, sameRow)
+        XCTAssertEqual(Set([firstRow, sameRow]).count, 1)
         XCTAssertNotEqual(
-            a,
+            firstRow,
             MailboxRowID(sourceID: sourceA, mailbox: WorkspaceMailbox.outputs)
         )
         XCTAssertNotEqual(
-            a,
+            firstRow,
             MailboxRowID(sourceID: sourceB, mailbox: WorkspaceMailbox.pages)
         )
     }


### PR DESCRIPTION
## Why

[#100](https://github.com/drawmeanelephant/solipsist/issues/100) / M10-2. Mail's left pane is folders, not a flat account list. Each source is an account header; under it: Pages, Outputs, Publish, Plan, Activity.

Parent tracker: [#98](https://github.com/drawmeanelephant/solipsist/issues/98). Design: [#103](https://github.com/drawmeanelephant/solipsist/pull/103) / [`docs/M10-DESIGN.md`](https://github.com/drawmeanelephant/solipsist/blob/docs/m10-mail-body/docs/M10-DESIGN.md).

## What

- `WorkspaceSelection.mailbox` (open string) + `WorkspaceMailbox` tokens + `MailboxRowID` + `canEditPage` + `WorkspaceNoun.sourcePath` + `WorkspaceSelectionRules`.
- Persist raw mailbox on `PersistedWorkspace`. Missing key → nil. Unknown (`trunk:guides`) survives. Do not canonicalize on load.
- `select` persists only when the selection actually changed. Source change writes `pages` and clears noun.
- Sidebar: `List` + `Section` per source, five tagged children. Header tap is best-effort → Pages.
- PlayTab shim so today's tabs follow `selection.mailbox`. Tabs are not deleted (#101).
- `MainWindow`: wider sidebar; Editor toolbar uses `canEditPage`. Sole M10 owner of this file.

## Recut

- Nested `graph.parent` trunks are **out**.
- No `Project.yml`. No `WorkspaceStore` in ContractTests.
- Parallel with #99. **#101 must not start until this is on `main`.**

## Tests

New `WorkspaceSelectionTests` + extended `WorkspacePersistenceTests` (backward / forward / unknown token). `SKIP_EMBED_BORIS=1 make build` + `make test` green (118 tests).

## Hand-gate

Open `Stunts/happy`. Sidebar shows the folder as an account with five mailboxes. Clicking Outputs / Publish / Plan / Activity changes the play tab. Changing source resets to Pages and clears the page noun.