### PR TITLE
feat(m10): native compose window — Markdown / Textile / Cooklang (#106)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -34,6 +34,7 @@ targets:
       - path: Sources/Play
       - path: Sources/Inspector
       - path: Sources/Companions
+      - path: Sources/Compose
       - path: Sources/Models
       - path: Sources/Engine
       - path: Sources/Security
@@ -107,6 +108,12 @@ targets:
       - path: Sources/Companions/CompanionID.swift
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Sources/Companions/Preview/PreviewURL.swift
+      - path: Sources/Compose/ComposeLanguage.swift
+      - path: Sources/Compose/ComposeDocument.swift
+      - path: Sources/Compose/ComposeHighlighter.swift
+      - path: Sources/Compose/MarkupRenderService.swift
+      - path: Sources/Compose/ComposePageResolver.swift
+      - path: Sources/Compose/OliverRenderService.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.drawmeanelephant.solipsist.contracttests

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -176,6 +176,11 @@ struct SolipsistCommands: Commands {
                 openWindow(id: CompanionID.editor)
             }
             .keyboardShortcut("e", modifiers: [.command, .shift])
+
+            Button("Compose") {
+                openWindow(id: CompanionID.compose)
+            }
+            .keyboardShortcut("c", modifiers: [.command, .shift])
         }
 
         CommandGroup(replacing: .help) {

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -85,6 +85,13 @@ struct SolipsistApp: App {
         }
         .defaultSize(width: 720, height: 560)
 
+        WindowGroup("Compose", id: CompanionID.compose) {
+            ComposeWindow()
+                .environment(store)
+                .environment(runtime)
+        }
+        .defaultSize(width: 900, height: 620)
+
         Window("Solipsist Help", id: "help") {
             HelpWindow()
         }

--- a/Sources/Companions/CompanionID.swift
+++ b/Sources/Companions/CompanionID.swift
@@ -4,4 +4,5 @@ import Foundation
 enum CompanionID {
     static let preview = "preview"
     static let editor = "editor"
+    static let compose = "compose"
 }

--- a/Sources/Compose/ComposeDocument.swift
+++ b/Sources/Compose/ComposeDocument.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Observation
+
+/// The buffer behind the compose element: the source text, the frontend it
+/// targets, and the save seam. Standalone by design — the window that hosts
+/// it is a later card; this type only knows about a URL it may write to.
+///
+/// Boundary 4 of `agents.md` applies: the buffer is never written to disk
+/// except through an explicit `save()`. Nothing in the view layer calls
+/// `save()` implicitly.
+@MainActor
+@Observable
+final class ComposeDocument {
+    /// The authored source text. Single source of truth.
+    var text: String = "" {
+        didSet {
+            if text != oldValue {
+                isDirty = true
+                // Auto-detect only until the language is pinned (by the
+                // initial load or an explicit picker choice); never override
+                // the user's selection mid-session.
+                if !languageExplicit {
+                    language = ComposeLanguage.detect(fileURL: fileURL, contents: text)
+                }
+            }
+        }
+    }
+
+    /// The frontend this buffer targets. Auto-detected until pinned; the
+    /// picker's binding writes through this setter, which pins it.
+    var language: ComposeLanguage {
+        didSet {
+            languageExplicit = true
+        }
+    }
+
+    /// Whether `language` has been pinned (initial load or explicit choice).
+    private var languageExplicit: Bool
+
+    /// The URL `save()` writes to. Nil until the host supplies one.
+    var fileURL: URL?
+
+    /// Whether the buffer differs from the last save/load.
+    private(set) var isDirty = false
+
+    /// Human-readable state for the compose window's status line.
+    var statusText: String {
+        var parts: [String] = []
+        if let fileURL {
+            parts.append(fileURL.lastPathComponent)
+        } else {
+            parts.append("Untitled")
+        }
+        parts.append(language.displayName)
+        if let frontmatter {
+            parts.append("front matter: \(frontmatter.kind.rawValue)")
+        }
+        if isDirty {
+            parts.append("edited")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    init(text: String = "", fileURL: URL? = nil, language: ComposeLanguage? = nil) {
+        self.text = text
+        self.fileURL = fileURL
+        self.language = language ?? ComposeLanguage.detect(fileURL: fileURL, contents: text)
+        self.languageExplicit = language != nil
+        self.isDirty = false
+    }
+
+    /// The frontmatter dialect, mirroring Oliver's shared pre-pass
+    /// (`src/frontmatter.zig`): YAML (`---`) / TOML (`+++`) sniffed at
+    /// index 0, stripped before dispatch.
+    enum FrontmatterKind: String {
+        case yaml
+        case toml
+    }
+
+    /// The raw frontmatter boundary. We expose it for highlighting and
+    /// editing; we never fake a parsed view.
+    struct Frontmatter: Equatable {
+        let kind: FrontmatterKind
+        /// Range of the whole `--- … ---` block, including both fences.
+        let range: Range<String.Index>
+        /// Raw payload between the fences (exclusive of the fence lines).
+        let payload: Substring
+
+        var payloadString: String { String(payload) }
+    }
+
+    /// Detects a `---`/`+++` frontmatter block anchored at index 0, matching
+    /// Oliver's sniff-then-strip rule. An unclosed opener is *not* front
+    /// matter (Oliver passes it through with an `unclosed-frontmatter`
+    /// diagnostic).
+    var frontmatter: Frontmatter? {
+        Frontmatter.parse(in: text)
+    }
+
+    /// Explicit save. Returns false when there is nothing to save.
+    @discardableResult
+    func save() throws -> Bool {
+        guard let fileURL, isDirty else { return false }
+        try text.write(to: fileURL, atomically: true, encoding: .utf8)
+        isDirty = false
+        return true
+    }
+
+    /// Loads a file into the buffer (used by the future host; keeps the
+    /// element testable in isolation).
+    func load(from url: URL) throws {
+        let loaded = try String(contentsOf: url, encoding: .utf8)
+        fileURL = url
+        text = loaded
+        language = ComposeLanguage.detect(fileURL: url, contents: loaded)
+        isDirty = false
+    }
+}
+
+extension ComposeDocument.Frontmatter {
+    static func parse(in text: String) -> ComposeDocument.Frontmatter? {
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: false).makeIterator()
+        guard let first = lines.next() else { return nil }
+        let fence = first.trimmingCharacters(in: .whitespaces)
+        guard fence == "---" || fence == "+++" else { return nil }
+        let kind: ComposeDocument.FrontmatterKind = fence == "---" ? .yaml : .toml
+
+        // Reconstruct line offsets to find the closing fence.
+        var index = text.startIndex
+        var fenceLineStart: String.Index?
+        var payloadStart: String.Index = text.startIndex
+        var payloadEnd: String.Index = text.startIndex
+        for (lineIndex, line) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+            if lineIndex == 0 {
+                index = text.index(index, offsetBy: line.count)
+                if index < text.endIndex, text[index] == "\n" {
+                    index = text.index(after: index)
+                }
+                payloadStart = index
+                continue
+            }
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == fence {
+                fenceLineStart = index
+                payloadEnd = index
+                break
+            }
+            index = text.index(index, offsetBy: line.count)
+            if index < text.endIndex, text[index] == "\n" {
+                index = text.index(after: index)
+            }
+        }
+        guard let fenceLineStart else { return nil }
+
+        // `payloadEnd` is the fence line's start; back off the newline that
+        // terminated the last content line so the payload excludes it.
+        if payloadEnd > payloadStart, text[text.index(before: payloadEnd)] == "\n" {
+            payloadEnd = text.index(before: payloadEnd)
+        }
+
+        let payload = text[payloadStart..<payloadEnd]
+        // Range covers both fences: from the start of the document through
+        // the closing fence line.
+        let closeLineEnd = text.index(fenceLineStart, offsetBy: fence.count)
+        let range = text.startIndex..<closeLineEnd
+        return ComposeDocument.Frontmatter(kind: kind, range: range, payload: payload)
+    }
+}

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -1,0 +1,275 @@
+import AppKit
+import SwiftUI
+
+/// One diagnostic for the compose element's problems seam. The hook-in card
+/// maps Oliver's structured diagnostics (exact source spans) into this
+/// shape; the element itself only renders what it is given.
+struct ComposeDiagnostic: Identifiable, Equatable {
+    enum Severity: Equatable {
+        case warning
+        case error
+    }
+
+    let id = UUID()
+    let severity: Severity
+    let message: String
+    let line: Int?
+
+    init(severity: Severity, message: String, line: Int? = nil) {
+        self.severity = severity
+        self.message = message
+        self.line = line
+    }
+}
+
+/// The compose element: a full-featured Markdown / Textile / Cooklang
+/// editing surface that will be hooked into the app by a later card.
+///
+/// Standalone contract:
+/// - The buffer is the source of truth (`ComposeDocument`).
+/// - Highlighting is heuristic paint derived from Oliver's language surface;
+///   it never claims to be a parse.
+/// - Nothing writes to disk except the explicit Save button / ⌘S.
+/// - Preview renders through the injected `MarkupRenderService`.
+struct ComposeEditorView: View {
+    @Bindable var document: ComposeDocument
+
+    var renderService: any MarkupRenderService = PlaceholderRenderService()
+    var diagnostics: [ComposeDiagnostic] = []
+    /// Called after an explicit save actually wrote the buffer. The host
+    /// (ComposeWindow) uses this to flow the save into the coordinator's
+    /// save→validate gate.
+    var onSave: (() -> Void)?
+
+    @State private var showPreview = true
+    @State private var previewOptions = MarkupRenderOptions()
+    @State private var saveError: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            HSplitView {
+                ComposeTextView(document: document)
+                    .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)
+                if showPreview {
+                    ComposePreviewView(
+                        source: document.text,
+                        language: document.language,
+                        options: previewOptions,
+                        renderService: renderService
+                    )
+                    .frame(minWidth: 240, maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            if !diagnostics.isEmpty {
+                Divider()
+                ComposeDiagnosticsPane(diagnostics: diagnostics)
+                    .frame(minHeight: 72, idealHeight: 110, maxHeight: 180)
+            }
+        }
+        .navigationTitle(document.statusText)
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Picker("Language", selection: $document.language) {
+                ForEach(ComposeLanguage.allCases) { language in
+                    Text(language.displayName).tag(language)
+                }
+            }
+            .pickerStyle(.menu)
+            .fixedSize()
+            .help("Authoring frontend (Oliver's \(document.language.oliverFrontend))")
+
+            Text(document.language.conformanceNote)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            Spacer()
+
+            Toggle(isOn: $showPreview) {
+                Label("Preview", systemImage: "eye")
+            }
+            .toggleStyle(.button)
+
+            Menu {
+                previewOptionsContent
+            } label: {
+                Label("Render Options", systemImage: "slider.horizontal.3")
+            }
+            .help("Oliver ParseOptions — every extension is off by default.")
+
+            Button {
+                do {
+                    saveError = nil
+                    if try document.save() {
+                        onSave?()
+                    }
+                } catch {
+                    saveError = error.localizedDescription
+                }
+            } label: {
+                Label("Save", systemImage: "square.and.arrow.down")
+            }
+            .keyboardShortcut("s", modifiers: .command)
+            .disabled(!document.isDirty)
+
+            if let saveError {
+                Text(saveError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+
+    /// Author-facing extension surface, mirroring Oliver's `ParseOptions`:
+    /// all extensions off by default; profile / frontmatter / raw-HTML
+    /// policies map 1:1 to Oliver's CLI flags.
+    @ViewBuilder
+    private var previewOptionsContent: some View {
+        Menu("Markdown Extensions") {
+            Toggle("Wikilinks", isOn: $previewOptions.wikilinks)
+            Toggle("Callouts", isOn: $previewOptions.callouts)
+            Toggle("Smart Typography", isOn: $previewOptions.smartypants)
+            Toggle("Footnotes", isOn: $previewOptions.footnotes)
+            Toggle("Definition Lists", isOn: $previewOptions.definitionLists)
+            Toggle("Heading Attributes", isOn: $previewOptions.headingAttributes)
+            Toggle("Strikethrough", isOn: $previewOptions.strikethrough)
+            Toggle("Heading IDs", isOn: $previewOptions.headingIDs)
+            Toggle("Task Lists", isOn: $previewOptions.taskLists)
+        }
+        Picker("Front Matter", selection: $previewOptions.frontmatter) {
+            Text("None").tag(MarkupRenderOptions.FrontmatterPolicy.none)
+            Text("YAML").tag(MarkupRenderOptions.FrontmatterPolicy.yaml)
+            Text("TOML").tag(MarkupRenderOptions.FrontmatterPolicy.toml)
+        }
+        Picker("Raw HTML", selection: $previewOptions.rawHTML) {
+            Text("Allowed").tag(MarkupRenderOptions.RawHTMLPolicy.allowed)
+            Text("Escaped").tag(MarkupRenderOptions.RawHTMLPolicy.escaped)
+            Text("Rejected").tag(MarkupRenderOptions.RawHTMLPolicy.rejected)
+        }
+        Picker("Profile", selection: $previewOptions.profile) {
+            Text("HTML").tag(MarkupRenderOptions.Profile.html)
+            Text("XHTML").tag(MarkupRenderOptions.Profile.xhtml)
+        }
+    }
+}
+
+/// The problems seam: renders diagnostics the host injects. Empty by design
+/// until the hook-in card wires Oliver's structured diagnostics through.
+private struct ComposeDiagnosticsPane: View {
+    let diagnostics: [ComposeDiagnostic]
+
+    var body: some View {
+        List(diagnostics) { diagnostic in
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: diagnostic.severity == .error ? "xmark.octagon" : "exclamationmark.triangle")
+                    .foregroundStyle(diagnostic.severity == .error ? .red : .orange)
+                if let line = diagnostic.line {
+                    Text("\(line)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                Text(diagnostic.message)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+}
+
+/// NSTextView host with live heuristic highlighting. The text storage is
+/// re-painted after every edit; the buffer in `ComposeDocument` stays the
+/// single source of truth.
+private struct ComposeTextView: NSViewRepresentable {
+    @Bindable var document: ComposeDocument
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(document: document)
+    }
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+        textView.delegate = context.coordinator
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.font = baseFont
+        textView.textContainerInset = NSSize(width: 10, height: 10)
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+
+        context.coordinator.applyHighlight(
+            textView,
+            text: document.text,
+            language: document.language,
+            force: true
+        )
+        return textView
+    }
+
+    func updateNSView(_ textView: NSTextView, context: Context) {
+        context.coordinator.document = document
+        if textView.string != document.text {
+            textView.string = document.text
+            context.coordinator.applyHighlight(textView, text: document.text, language: document.language, force: true)
+        } else {
+            context.coordinator.applyHighlight(textView, text: document.text, language: document.language)
+        }
+    }
+
+    private var baseFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var document: ComposeDocument
+        private var isApplying = false
+
+        /// Last state we painted, so programmatic syncs (which fire on every
+        /// `document` change) do not re-paint an unchanged buffer.
+        private var lastHighlightedText: String?
+        private var lastHighlightedLanguage: ComposeLanguage?
+
+        init(document: ComposeDocument) {
+            self.document = document
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard
+                !isApplying,
+                let textView = notification.object as? NSTextView
+            else { return }
+            isApplying = true
+            defer { isApplying = false }
+
+            document.text = textView.string
+            applyHighlight(textView, text: textView.string, language: document.language)
+        }
+
+        func applyHighlight(_ textView: NSTextView, text: String, language: ComposeLanguage, force: Bool = false) {
+            guard force || text != lastHighlightedText || language != lastHighlightedLanguage else { return }
+            lastHighlightedText = text
+            lastHighlightedLanguage = language
+
+            let highlighted = ComposeHighlighter.highlight(text, language: language)
+            textView.textStorage?.beginEditing()
+            textView.textStorage?.setAttributedString(highlighted)
+            textView.textStorage?.endEditing()
+            textView.typingAttributes = [.font: baseFont, .foregroundColor: NSColor.labelColor]
+        }
+
+        private var baseFont: NSFont {
+            NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        }
+    }
+}

--- a/Sources/Compose/ComposeHighlighter.swift
+++ b/Sources/Compose/ComposeHighlighter.swift
@@ -1,0 +1,222 @@
+import AppKit
+import Foundation
+
+/// A paint style for one highlight rule.
+struct ComposeHighlightStyle {
+    var color: NSColor
+    var bold = false
+    var italic = false
+
+    static let plain = ComposeHighlightStyle(color: .labelColor)
+}
+
+/// One ordered highlight rule: a regex plus the style applied to every match.
+/// Rules apply in array order; later rules repaint over earlier ones, so
+/// region rules (fenced code, front matter) must come last.
+struct ComposeHighlightRule {
+    let pattern: String
+    let style: ComposeHighlightStyle
+    let options: NSRegularExpression.Options
+}
+
+/// Token highlighting for the compose element.
+///
+/// This is **not** a parser and never will be. The grammar for all three
+/// frontends lives in Oliver (the clean-room library behind Boris); these
+/// rules are a heuristic paint layer derived from Oliver's documented
+/// language surface (`docs/FEATURE-MATRIX.md`, `docs/TEXTILE-PARITY.md`,
+/// `docs/COOKLANG.md`). Where Oliver pins a behavior, we match its shape;
+/// where the shape is ambiguous, we prefer the most common reading and
+/// record it in the rule comment.
+enum ComposeHighlighter {
+    // MARK: - Public API
+
+    static func highlight(_ text: String, language: ComposeLanguage) -> NSAttributedString {
+        let result = NSMutableAttributedString(
+            string: text,
+            attributes: [.font: baseFont, .foregroundColor: NSColor.labelColor]
+        )
+
+        for rule in rules(for: language) {
+            guard let regex = try? NSRegularExpression(pattern: rule.pattern, options: rule.options) else {
+                continue
+            }
+            let full = NSRange(location: 0, length: (text as NSString).length)
+            regex.enumerateMatches(in: text, range: full) { match, _, _ in
+                guard let match else { return }
+                paint(rule.style, over: match.range, in: result)
+            }
+        }
+
+        // Front matter is data, not content: paint it last so no inner rule
+        // (a `#` in YAML, an `@` in a cooklang ingredient list) bleeds in.
+        if let frontmatter = ComposeDocument.Frontmatter.parse(in: text) {
+            let lower = text.utf16.distance(from: text.utf16.startIndex, to: frontmatter.range.lowerBound)
+            let upper = text.utf16.distance(from: text.utf16.startIndex, to: frontmatter.range.upperBound)
+            paint(
+                ComposeHighlightStyle(color: .systemGray, italic: true),
+                over: NSRange(location: lower, length: upper - lower),
+                in: result
+            )
+        }
+
+        return result
+    }
+
+    static func rules(for language: ComposeLanguage) -> [ComposeHighlightRule] {
+        switch language {
+        case .markdown: return markdownRules
+        case .textile: return textileRules
+        case .cooklang: return cooklangRules
+        }
+    }
+
+    // MARK: - Palette
+
+    private static let heading = ComposeHighlightStyle(color: .systemPurple, bold: true)
+    private static let strong = ComposeHighlightStyle(color: .systemRed, bold: true)
+    private static let emphasis = ComposeHighlightStyle(color: .systemOrange)
+    private static let code = ComposeHighlightStyle(color: .systemGreen)
+    private static let link = ComposeHighlightStyle(color: .systemBlue)
+    private static let image = ComposeHighlightStyle(color: .systemTeal)
+    private static let table = ComposeHighlightStyle(color: .systemTeal)
+    private static let marker = ComposeHighlightStyle(color: .systemPurple)
+    private static let quote = ComposeHighlightStyle(color: .systemGray)
+    private static let footnote = ComposeHighlightStyle(color: .systemBrown)
+    private static let callout = ComposeHighlightStyle(color: .systemYellow, bold: true)
+    private static let ingredient = ComposeHighlightStyle(color: .systemGreen)
+    private static let cookware = ComposeHighlightStyle(color: .systemBlue)
+    private static let timer = ComposeHighlightStyle(color: .systemOrange)
+    private static let note = ComposeHighlightStyle(color: .systemTeal)
+    private static let comment = ComposeHighlightStyle(color: .secondaryLabelColor, italic: true)
+
+    private static var baseFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    }
+
+    private static var boldFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: 13, weight: .bold)
+    }
+
+    // MARK: - Markdown (CommonMark 0.31.2 + Oliver's opt-in extensions)
+
+    private static let markdownRules: [ComposeHighlightRule] = [
+        // Inline: emphasis family first, widest delimiter runs first.
+        rule(#"(\*\*\*|___)(?=\S)(.+?)(?<=\S)\1"#, strong),
+        rule(#"(?<![*_])(\*\*|__)(?=\S)(.+?)(?<=\S)\1(?!\1)(?![*_])"#, strong),
+        rule(#"(?<![*_])(\*|_)(?!\1)(?=\S)(.+?)(?<=\S)\1(?!\1)(?![*_])"#, emphasis),
+        rule(#"~~[^~\n]+~~"#, emphasis),
+        rule(#"`[^`\n]+`"#, code),
+        // Links before images so the image rule repaints the whole construct.
+        rule(#"\[([^\]\n]+)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)"#, link),
+        rule(#"\[([^\]\n]+)\](?:\[([^\]\n]*)\])?"#, link),
+        rule(#"!\[([^\]\n]*)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)"#, image),
+        rule(#"!\[([^\]\n]*)\](?:\[([^\]\n]*)\])?"#, image),
+        // Oliver extension: Obsidian [[wikilinks]] (docs/WIKILINKS.md).
+        rule(#"\[\[([^\]\n|]+)(?:\|([^\]\n]+))?\]\]"#, image),
+        rule(#"<[^<>\s]+>"#, link),
+        rule(#"\[\^[^\]]+\]"#, footnote),
+        rule(#"^[ \t]*[-*+] \[[ xX]\]"#, ingredient),
+        // Blocks.
+        // Oliver extension: > [!note] callouts (docs/CALLOUTS.md).
+        rule(#"^>[ \t]*\[![A-Za-z0-9-]+\][^\n]*"#, callout),
+        rule(#"^(#{1,6})(?:[ \t]+.*)?$"#, heading, anchors: true),
+        rule(#"^[ \t]*=+[ \t]*$"#, heading, anchors: true),
+        rule(#"^[ \t]*(-{3,}|\*{3,}|_{3,})[ \t]*$"#, quote, anchors: true),
+        rule(#"^>[ \t]?"#, quote, anchors: true),
+        rule(#"^[ \t]*([-*+]|\d+[.)])[ \t]+"#, marker, anchors: true),
+        rule(#"^[ \t]*\|.*\|[ \t]*$"#, table, anchors: true),
+        rule(#"^\[\^[^\]]+\]:"#, footnote, anchors: true),
+        // Regions last: fenced code (```` and `~~~`), indented code.
+        rule(#"(?:^|\n)([`~]{3,})[^\n]*\n[\s\S]*?(?:\n|\z)\1[ \t]*(?:\n|\z)"#, code, dotMatches: true),
+        rule(#"(?:^|\n)([ \t]{4,}[^\n]*(?:\n[ \t]{4,}[^\n]*)*)"#, code, dotMatches: true),
+    ]
+
+    // MARK: - Textile (Textile 2 surface, docs/TEXTILE-PARITY.md)
+
+    private static let textileRules: [ComposeHighlightRule] = [
+        // == escaping and @code@ first (they suspend all other formatting).
+        rule(#"==[^\n]*=="#, quote),
+        rule(#"@[^@\n]+@"#, code),
+        // Phrase family: doubled/long runs before single runs.
+        rule(#"(?<![*_])(\*\*|__)(?=\S)(.+?)(?<=\S)\1(?!\1)(?![*_])"#, strong),
+        rule(#"(?<![*_])(\*|_)(?!\1)(?=\S)(.+?)(?<=\S)\1(?!\1)(?![*_])"#, emphasis),
+        rule(#"(\+\+[^+]{2,}\+\+|--[^-]{2,}--)"#, quote),
+        rule(#"(-[^-]+-|\+[^+]+)"#, emphasis),
+        rule(#"\^[^^\n]{1,}\^"#, footnote),
+        rule(#"~[^~\n]{1,}~"#, footnote),
+        rule(#"%[^%\n]{1,}%"#, quote),
+        rule(#"\?\?[^?\n]{1,}\?\?"#, footnote),
+        rule(#"[A-Z]{2,}\([^)\n]+\)"#, footnote),
+        // Textile 2 {...} character macros.
+        rule(#"\{[^}\n]{1,4}\}"#, quote),
+        // "text":url links and !url! images.
+        rule(#""([^"\n]+)":([^\s)]+)"#, link),
+        rule(#"!([^!\n]+)!(?::([^\s]+))?"#, image),
+        rule(#"\[\d+\]"#, footnote),
+        // Blocks: signatures, list markers, tables.
+        rule(#"^bq\.:[^\s]+"#, link, anchors: true),
+        rule(#"^(h[1-6]\.|p\.{1,2}|bq\.{1,2}|bc\.{1,2}|pre\.{1,2}|dl\.|notextile\.{1,2}|clear[<>]?\.|fn\d+\.)"#, marker, anchors: true),
+        rule(#"^[ \t]*[*#]+"#, marker, anchors: true),
+        rule(#"^[ \t]*\|.*\|[ \t]*$"#, table, anchors: true),
+        rule(#"^fn\d+\."#, footnote, anchors: true),
+    ]
+
+    // MARK: - Cooklang (typed Recipe surface, docs/COOKLANG.md)
+
+    private static let cooklangRules: [ComposeHighlightRule] = [
+        // Token family first so line-level paints (notes/comments) win over
+        // tokens that happen to sit inside them.
+        // Ingredients: @name, @multi word{quantity%unit}, recipe refs @./path.
+        rule(#"@[^\s@#~{]+(?:[ \t]+[^\s@#~{]+)*[ \t]*\{[^}\n]*\}"#, ingredient),
+        rule(#"@[^\s@#~{]+"#, ingredient),
+        // Cookware: #name / #multi word{quantity}.
+        rule(#"#[^\s@#~{]+(?:[ \t]+[^\s@#~{]+)*[ \t]*\{[^}\n]*\}"#, cookware),
+        rule(#"#[^\s@#~{]+"#, cookware),
+        // Timers: ~name{3%minutes} / ~{25%minutes} / ~rest.
+        rule(#"~\{[^}\n]*\}"#, timer),
+        rule(#"~[^\s@#~{]+(?:\{[^}\n]*\})?"#, timer),
+        // Steps, notes, sections, comments.
+        rule(#"^>[ \t]?[^\n]*"#, note, anchors: true),
+        rule(#"^=+[ \t]*[^\n]*"#, heading, anchors: true),
+        rule(#"^--[^\n]*"#, comment, anchors: true),
+        rule(#"\[-[^]*?-\]"#, comment, dotMatches: true),
+    ]
+
+    // MARK: - Rule helpers
+
+    private static func rule(
+        _ pattern: String,
+        _ style: ComposeHighlightStyle,
+        anchors: Bool = false,
+        dotMatches: Bool = false
+    ) -> ComposeHighlightRule {
+        var options: NSRegularExpression.Options = []
+        if anchors { options.insert(.anchorsMatchLines) }
+        if dotMatches { options.insert(.dotMatchesLineSeparators) }
+        return ComposeHighlightRule(pattern: pattern, style: style, options: options)
+    }
+
+    private static func paint(
+        _ style: ComposeHighlightStyle,
+        over range: NSRange,
+        in attributed: NSMutableAttributedString
+    ) {
+        guard range.location != NSNotFound, range.length > 0 else { return }
+        attributed.addAttribute(.foregroundColor, value: style.color, range: range)
+        if style.bold {
+            attributed.addAttribute(.font, value: boldFont, range: range)
+        } else if style.italic {
+            let italic = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+                .withTraits(.italic)
+            attributed.addAttribute(.font, value: italic, range: range)
+        }
+    }
+}
+
+extension NSFont {
+    func withTraits(_ traits: NSFontDescriptor.SymbolicTraits) -> NSFont {
+        let descriptor = fontDescriptor.withSymbolicTraits(traits)
+        return NSFont(descriptor: descriptor, size: pointSize) ?? self
+    }
+}

--- a/Sources/Compose/ComposeLanguage.swift
+++ b/Sources/Compose/ComposeLanguage.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// The three authoring languages the compose element understands.
+///
+/// Oliver — the clean-room markup library that is the rendering engine
+/// behind Boris — is the language reference for this surface
+/// (`github.com/drawmeanelephant/oliver`). We mirror Oliver's frontends and
+/// their feature surface here; we never reimplement parse semantics. The
+/// feature notes in each case mirror Oliver's own capability docs
+/// (`docs/CAPABILITIES.md`, `docs/FEATURE-MATRIX.md`, `docs/COOKLANG.md`).
+enum ComposeLanguage: String, CaseIterable, Identifiable, Sendable {
+    case markdown
+    case textile
+    case cooklang
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .markdown: return "Markdown"
+        case .textile: return "Textile"
+        case .cooklang: return "Cooklang"
+        }
+    }
+
+    /// Oliver frontend entry point, for documentation and later wiring.
+    var oliverFrontend: String {
+        switch self {
+        case .markdown: return "oliver.parse(..., .markdown, ...)"
+        case .textile: return "oliver.parse(..., .textile, ...)"
+        case .cooklang: return "oliver.cooklang.parse(...)"
+        }
+    }
+
+    /// File extensions that conventionally select this frontend.
+    var fileExtensions: Set<String> {
+        switch self {
+        case .markdown: return ["md", "markdown", "mdown"]
+        case .textile: return ["textile"]
+        case .cooklang: return ["cook", "menu"]
+        }
+    }
+
+    /// Oliver's conformance wall for this frontend (docs/CAPABILITIES.md).
+    var conformanceNote: String {
+        switch self {
+        case .markdown:
+            return "CommonMark 0.31.2 — 652/652 examples byte-for-byte"
+        case .textile:
+            return "Textile fixture wall — fully green (TEXTILE-PARITY.md)"
+        case .cooklang:
+            return "Canonical Cooklang corpus — 60/60 (docs/COOKLANG.md)"
+        }
+    }
+
+    /// Whether the frontmatter pre-pass (shared Oliver `src/frontmatter.zig`)
+    /// applies to this frontend. Cooklang treats YAML front matter as a raw
+    /// boundary; Markdown/Textile can parse the bounded YAML/TOML subset.
+    var supportsFrontmatter: Bool {
+        true
+    }
+
+    // MARK: - Detection
+
+    /// Picks a language from a file URL's extension first, then falls back
+    /// to content sniffing. Content sniffing is advisory — the user can
+    /// always override.
+    static func detect(fileURL: URL?, contents: String) -> ComposeLanguage {
+        if let fileURL {
+            let ext = fileURL.pathExtension.lowercased()
+            if let byExtension = allCases.first(where: { $0.fileExtensions.contains(ext) }) {
+                return byExtension
+            }
+        }
+        return sniff(contents) ?? .markdown
+    }
+
+    /// Advisory content sniffing, ordered by how unambiguous the signal is:
+    /// Cooklang ingredient/cookware/timer tokens, then Textile signatures,
+    /// then Markdown defaults. Returns nil when the buffer is ambiguous.
+    static func sniff(_ contents: String) -> ComposeLanguage? {
+        let head = contents.prefix(2000)
+
+        if CooklangSignals.isCooklang(head) {
+            return .cooklang
+        }
+        if TextileSignals.isTextile(head) {
+            return .textile
+        }
+        if MarkdownSignals.isMarkdown(head) {
+            return .markdown
+        }
+        return nil
+    }
+}
+
+/// Signal patterns mirroring Oliver's frontends. These are *heuristics for
+/// choosing a frontend*, deliberately a coarse subset of the real grammar —
+/// the grammar itself lives in Oliver.
+private enum MarkdownSignals {
+    static func isMarkdown(_ text: Substring) -> Bool {
+        lines(text).contains { line in
+            line.hasPrefix("#")
+                || line.hasPrefix("> ")
+                || line.hasPrefix("```")
+                || line.hasPrefix("~~~")
+                || line.hasPrefix("- ")
+                || line.hasPrefix("* ")
+                || line.hasPrefix("1. ")
+                || line.hasPrefix("|")
+        }
+    }
+}
+
+private enum TextileSignals {
+    static func isTextile(_ text: Substring) -> Bool {
+        lines(text).contains { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            return trimmed.hasPrefix("h1.")
+                || trimmed.hasPrefix("h2.")
+                || trimmed.hasPrefix("h3.")
+                || trimmed.hasPrefix("h4.")
+                || trimmed.hasPrefix("h5.")
+                || trimmed.hasPrefix("h6.")
+                || trimmed.hasPrefix("p.")
+                || trimmed.hasPrefix("bq.")
+                || trimmed.hasPrefix("bc.")
+                || trimmed.hasPrefix("pre.")
+                || trimmed.hasPrefix("fn")
+                || trimmed.hasPrefix("* ")
+                // NB: `# ` is deliberately absent — it collides with a
+                // Markdown ATX heading (`# Title`); Textile ordered lists
+                // are the weaker reading and lose the sniff.
+                || trimmed.hasPrefix("|")
+        }
+    }
+}
+
+private enum CooklangSignals {
+    static func isCooklang(_ text: Substring) -> Bool {
+        lines(text).contains { line in
+            (line.contains("@") && !line.hasPrefix("```"))
+                || (line.hasPrefix("#") && !line.hasPrefix("# ") && !line.hasPrefix("##"))
+                || line.hasPrefix("= ")
+                || line.hasPrefix("--")
+                || line.hasPrefix("> ")
+                || line.hasPrefix("[-")
+        }
+    }
+}
+
+private func lines(_ text: Substring) -> [Substring] {
+    text.split(separator: "\n", omittingEmptySubsequences: false)
+}

--- a/Sources/Compose/ComposePageResolver.swift
+++ b/Sources/Compose/ComposePageResolver.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Maps the page selected in play to the source file the compose window
+/// edits, through the published graph contract (`graph.json`).
+///
+/// The selection noun carries only the page `id`; the file the author edits
+/// lives in the graph as `GraphNode.sourcePath` (relative to the content
+/// root, forward slashes — per `Models/BorisContracts.swift`). This type is
+/// pure and testable; it never touches SwiftUI or the store.
+enum ComposePageResolver {
+    /// `workspaceRoot/.boris/graph.json` — the frozen graph play reads.
+    static func graphURL(workspaceRoot: URL) -> URL {
+        workspaceRoot
+            .appendingPathComponent(".boris", isDirectory: true)
+            .appendingPathComponent("graph.json")
+    }
+
+    /// The authored file for a graph node, relative to the content root
+    /// (`content/` when the workspace root is a project root).
+    static func fileURL(contentRoot: URL, sourcePath: String) -> URL {
+        contentRoot.appendingPathComponent(sourcePath)
+    }
+
+    /// Finds the graph node for a page id.
+    static func page(id: String, in graph: Graph) -> GraphNode? {
+        graph.nodes.first { $0.id == id }
+    }
+
+    /// Decodes `graph.json` for a workspace root and finds the page.
+    static func page(id: String, workspaceRoot: URL) throws -> GraphNode? {
+        let data = try Data(contentsOf: graphURL(workspaceRoot: workspaceRoot))
+        let graph = try JSONDecoder().decode(Graph.self, from: data)
+        return page(id: id, in: graph)
+    }
+}

--- a/Sources/Compose/ComposePreview.swift
+++ b/Sources/Compose/ComposePreview.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// The compose element's preview pane. Renders through the injected
+/// `MarkupRenderService` (Oliver-backed in the app; placeholder standalone),
+/// debounced so the subprocess render runs only when the author pauses.
+struct ComposePreviewView: View {
+    let source: String
+    let language: ComposeLanguage
+    let options: MarkupRenderOptions
+    let renderService: any MarkupRenderService
+
+    @State private var html: String?
+    @State private var renderError: String?
+
+    var body: some View {
+        Group {
+            if let html {
+                ComposeHTMLPreview(html: html)
+            } else if let renderError {
+                ContentUnavailableView {
+                    Label("Render Failed", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(renderError)
+                        .multilineTextAlignment(.center)
+                }
+            } else {
+                ProgressView("Rendering…")
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .task(id: PreviewRequest(language: language, options: options, source: source)) {
+            do {
+                try await Task.sleep(for: .milliseconds(300))
+                guard !Task.isCancelled else { return }
+                let rendered = try await renderService.render(source, language: language, options: options)
+                guard !Task.isCancelled else { return }
+                html = rendered
+                renderError = nil
+            } catch is CancellationError {
+                // A newer request superseded this one; keep the last frame.
+            } catch {
+                renderError = String(describing: error)
+            }
+        }
+    }
+}
+
+/// Equatable request identity so `.task(id:)` restarts (and cancels) the
+/// previous render whenever the buffer, language, or options change.
+private struct PreviewRequest: Equatable {
+    let language: ComposeLanguage
+    let options: MarkupRenderOptions
+    let source: String
+}
+
+/// Hosts the rendered fragment. `WKWebView`-free on purpose: the compose
+/// preview is a sandboxed HTML fragment view, not a browser surface.
+private struct ComposeHTMLPreview: NSViewRepresentable {
+    let html: String
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = true
+        textView.backgroundColor = .textBackgroundColor
+        textView.textContainerInset = NSSize(width: 12, height: 12)
+        apply(html, to: textView)
+        return textView
+    }
+
+    func updateNSView(_ textView: NSTextView, context: Context) {
+        apply(html, to: textView)
+    }
+
+    private func apply(_ html: String, to textView: NSTextView) {
+        guard
+            let data = html.data(using: .utf8),
+            let attributed = try? NSAttributedString(
+                data: data,
+                options: [.documentType: NSAttributedString.DocumentType.html],
+                documentAttributes: nil
+            )
+        else {
+            textView.string = html
+            return
+        }
+        textView.textStorage?.setAttributedString(attributed)
+    }
+}

--- a/Sources/Compose/ComposeWindow.swift
+++ b/Sources/Compose/ComposeWindow.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+
+/// The compose window: hosts the `ComposeEditorView` element for the page
+/// selected in the play list.
+///
+/// Hook-in contract (COMPOSE-EDITOR card, hook-in phase):
+/// - The buffer is sourced from the selected `page` noun; the file is
+///   resolved through the published graph contract (`graph.json`) so the
+///   selection store stays a pair of strings.
+/// - Files are read/written under the local source's security-scoped access
+///   (the same bookmark the play surface uses). Nothing writes except an
+///   explicit Save / ⌘S.
+/// - A successful save flows into the coordinator's save→validate gate
+///   (`noteSave()`) and suspends the preview watch for the write, exactly
+///   like play's own tree-writing invocations.
+struct ComposeWindow: View {
+    @Environment(WorkspaceStore.self) private var store
+    @Environment(AppRuntime.self) private var runtime
+
+    @State private var document = ComposeDocument()
+    @State private var currentNoun: WorkspaceNoun?
+    @State private var pendingSwitch: WorkspaceNoun?
+    @State private var loadError: String?
+    @State private var saveStatus: String?
+
+    var body: some View {
+        Group {
+            if let source = selectedLocalSource, pageNoun != nil {
+                ComposeEditorView(
+                    document: document,
+                    renderService: OliverRenderService(),
+                    diagnostics: [],
+                    onSave: save
+                )
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    statusBar
+                }
+            } else {
+                emptyState
+            }
+        }
+        .frame(minWidth: 640, minHeight: 420)
+        .navigationTitle("Compose")
+        .task(id: store.selection.noun) {
+            handleSelection()
+        }
+        .confirmationDialog(
+            "Discard unsaved changes?",
+            isPresented: Binding(
+                get: { pendingSwitch != nil },
+                set: { if !$0 { pendingSwitch = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Discard Changes", role: .destructive) {
+                if let source = selectedLocalSource, let noun = pendingSwitch {
+                    switchTo(noun, source: source)
+                }
+                pendingSwitch = nil
+            }
+            Button("Cancel", role: .cancel) {
+                // Snap the selection back so the compose window keeps the
+                // buffer the author is mid-edit on.
+                if let noun = currentNoun {
+                    store.select(noun: noun)
+                }
+                pendingSwitch = nil
+            }
+        } message: {
+            Text(currentNoun.map { "“\($0.title)” has unsaved changes." }
+                ?? "The current page has unsaved changes.")
+        }
+    }
+
+    // MARK: - Selection
+
+    private var pageNoun: WorkspaceNoun? {
+        guard let noun = store.selection.noun, noun.kind == "page" else { return nil }
+        return noun
+    }
+
+    private var selectedLocalSource: LocalSource? {
+        if case .local(let source) = store.selectedSource {
+            return source
+        }
+        return nil
+    }
+
+    private func handleSelection() {
+        guard let source = selectedLocalSource, let noun = pageNoun else { return }
+        guard noun != currentNoun else { return }
+        if document.isDirty {
+            pendingSwitch = noun
+        } else {
+            switchTo(noun, source: source)
+        }
+    }
+
+    private func switchTo(_ noun: WorkspaceNoun, source: LocalSource) {
+        defer { currentNoun = noun }
+        do {
+            let workspaceRoot = try source.workspaceRoot()
+            let contentRoot = try source.contentRoot()
+            guard let node = try ComposePageResolver.page(id: noun.id, workspaceRoot: workspaceRoot) else {
+                loadError = "No graph node for “\(noun.title)”."
+                return
+            }
+            let url = ComposePageResolver.fileURL(contentRoot: contentRoot, sourcePath: node.sourcePath)
+            try document.load(from: url)
+            loadError = nil
+            saveStatus = nil
+        } catch {
+            loadError = String(describing: error)
+        }
+    }
+
+    // MARK: - Save → coordinator gate
+
+    private func save() {
+        saveStatus = nil
+        do {
+            // Tree write: suspend the preview watch for the write, like
+            // play's IR build does; resume on the way out.
+            runtime.coordinator.beginTreeWrite()
+            defer { runtime.coordinator.endTreeWrite() }
+            guard try document.save() else { return }
+            runtime.coordinator.noteSave()
+            saveStatus = "Saved · queued validate"
+        } catch {
+            saveStatus = error.localizedDescription
+        }
+    }
+
+    // MARK: - Chrome
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("Compose", systemImage: "square.and.pencil")
+        } description: {
+            Text("Select a page in the main window, then open the compose window.")
+        }
+    }
+
+    private var statusBar: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(spacing: 8) {
+                if let loadError {
+                    Text(loadError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                } else {
+                    Text(document.statusText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer()
+                if let saveStatus {
+                    Text(saveStatus)
+                        .font(.caption)
+                        .foregroundStyle(saveStatus.contains("Saved") ? Color.secondary : Color.red)
+                }
+                Text(runtime.coordinator.summary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+        }
+    }
+}

--- a/Sources/Compose/MarkupRenderService.swift
+++ b/Sources/Compose/MarkupRenderService.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Author-facing render options, mirroring Oliver's `ParseOptions` (the
+/// rendering engine behind Boris): every extension is off by default, and
+/// the profile / frontmatter / raw-HTML policies map 1:1 to Oliver's CLI
+/// flags. `docs/FEATURE-MATRIX.md` pins each behavior.
+struct MarkupRenderOptions: Equatable, Sendable {
+    enum Profile: String, Sendable {
+        case html
+        case xhtml
+    }
+
+    enum RawHTMLPolicy: String, Sendable {
+        case allowed
+        case escaped
+        case rejected
+    }
+
+    enum FrontmatterPolicy: String, Sendable {
+        case none
+        case yaml
+        case toml
+    }
+
+    var profile: Profile = .html
+    var wikilinks = false
+    var callouts = false
+    var smartypants = false
+    var footnotes = false
+    var definitionLists = false
+    var headingAttributes = false
+    var strikethrough = false
+    var headingIDs = false
+    var taskLists = false
+    var rawHTML: RawHTMLPolicy = .allowed
+    var frontmatter: FrontmatterPolicy = .none
+}
+
+/// The seam between the compose element and a renderer.
+///
+/// The rendering engine behind Boris is **Oliver** (`oliver render --from
+/// markdown|textile|cooklang`). Solipsist's rule is that only the Engine
+/// lane starts subprocesses, so the real implementation lives behind
+/// `OliverRenderService` (Engine seam). The element ships the placeholder
+/// below so the preview pane is functional and testable standalone.
+protocol MarkupRenderService: Sendable {
+    /// Renders a source buffer to an HTML fragment for the given options.
+    func render(
+        _ source: String,
+        language: ComposeLanguage,
+        options: MarkupRenderOptions
+    ) async throws -> String
+}
+
+/// Placeholder: HTML-escapes the source so the preview is safe and shows
+/// exactly what was authored. Same escape policy as Oliver's text writer
+/// (`& < > "` and NUL → U+FFFD) so the swap to the real renderer changes
+/// content, not posture.
+struct PlaceholderRenderService: MarkupRenderService {
+    func render(
+        _ source: String,
+        language: ComposeLanguage,
+        options: MarkupRenderOptions
+    ) async throws -> String {
+        let escaped = source
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "\u{0}", with: "\u{FFFD}")
+        return "<pre style=\"white-space: pre-wrap; font: 12px ui-monospace;\">\(escaped)</pre>"
+    }
+}

--- a/Sources/Compose/OliverRenderService.swift
+++ b/Sources/Compose/OliverRenderService.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// The Oliver-backed `MarkupRenderService`: renders buffers through the
+/// Engine's `OliverRenderer` subprocess seam. The mapping between the
+/// compose surface's types and Oliver's frontends / flags lives here, so
+/// the Engine lane never imports the Compose lane.
+struct OliverRenderService: MarkupRenderService {
+    var renderer: OliverRenderer
+
+    init(renderer: OliverRenderer = OliverRenderer()) {
+        self.renderer = renderer
+    }
+
+    func render(
+        _ source: String,
+        language: ComposeLanguage,
+        options: MarkupRenderOptions
+    ) async throws -> String {
+        let result = try await renderer.render(
+            source: source,
+            frontend: Self.frontend(for: language),
+            options: Self.engineOptions(options)
+        )
+        return result.html
+    }
+
+    // MARK: - Mapping (pure, tested)
+
+    static func frontend(for language: ComposeLanguage) -> OliverFrontend {
+        switch language {
+        case .markdown: return .markdown
+        case .textile: return .textile
+        case .cooklang: return .cooklang
+        }
+    }
+
+    static func engineOptions(_ options: MarkupRenderOptions) -> OliverRenderOptions {
+        var engine = OliverRenderOptions()
+        engine.profile = options.profile == .xhtml ? .xhtml : .html
+        engine.wikilinks = options.wikilinks
+        engine.callouts = options.callouts
+        engine.smartypants = options.smartypants
+        engine.footnotes = options.footnotes
+        engine.definitionLists = options.definitionLists
+        engine.headingAttributes = options.headingAttributes
+        engine.strikethrough = options.strikethrough
+        engine.headingIDs = options.headingIDs
+        engine.taskLists = options.taskLists
+        switch options.rawHTML {
+        case .allowed: engine.rawHTML = .allowed
+        case .escaped: engine.rawHTML = .escaped
+        case .rejected: engine.rawHTML = .rejected
+        }
+        switch options.frontmatter {
+        case .none: engine.frontmatter = .none
+        case .yaml: engine.frontmatter = .yaml
+        case .toml: engine.frontmatter = .toml
+        }
+        return engine
+    }
+}

--- a/Sources/Engine/BorisRunner.swift
+++ b/Sources/Engine/BorisRunner.swift
@@ -82,13 +82,62 @@ public enum BorisRunner {
 
     /// Launch and wait off the caller's executor. Completion uses
     /// `terminationHandler` so an actor can still `interrupt()` / `forceKill()`
-    /// a wedged child.
+    /// a wedged child. Stdin is a wiped secret buffer (Boris publication).
     public static func run(
         binary: URL,
         arguments: [String],
         workingDirectory: URL? = nil,
         handle: RunHandle? = nil,
         stdin: SecureBuffer? = nil
+    ) async throws -> RunOutput {
+        if let stdin {
+            return try await launch(
+                binary: binary,
+                arguments: arguments,
+                workingDirectory: workingDirectory,
+                handle: handle
+            ) { pipe in
+                try StdinSecretWriter.writeAndWipe(stdin, to: pipe.fileHandleForWriting)
+            }
+        }
+        // No stdin: close the write end immediately so the child sees EOF
+        // (the old behavior piped `nullDevice`; EOF is equivalent).
+        return try await launch(
+            binary: binary,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            handle: handle
+        ) { pipe in
+            pipe.fileHandleForWriting.closeFile()
+        }
+    }
+
+    /// Same launch, with plain-text stdin — the compose preview renders
+    /// buffers through this path (Oliver CLI), never secrets.
+    public static func run(
+        binary: URL,
+        arguments: [String],
+        workingDirectory: URL? = nil,
+        handle: RunHandle? = nil,
+        stdinText: String
+    ) async throws -> RunOutput {
+        try await launch(
+            binary: binary,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            handle: handle
+        ) { pipe in
+            let data = Data(stdinText.utf8)
+            try pipe.fileHandleForWriting.write(contentsOf: data)
+        }
+    }
+
+    private static func launch(
+        binary: URL,
+        arguments: [String],
+        workingDirectory: URL?,
+        handle: RunHandle?,
+        writeStdin: (Pipe) throws -> Void
     ) async throws -> RunOutput {
         let fm = FileManager.default
         let tmpDir = fm.temporaryDirectory
@@ -116,15 +165,8 @@ public enum BorisRunner {
         process.standardOutput = stdoutHandle
         process.standardError = stderrHandle
 
-        let stdinPipe: Pipe?
-        if stdin != nil {
-            let pipe = Pipe()
-            process.standardInput = pipe
-            stdinPipe = pipe
-        } else {
-            process.standardInput = FileHandle.nullDevice
-            stdinPipe = nil
-        }
+        let pipe = Pipe()
+        process.standardInput = pipe
 
         handle?.attach(process)
         defer {
@@ -147,14 +189,13 @@ public enum BorisRunner {
                 }
                 return
             }
-            if let stdin, let stdinPipe {
-                do {
-                    try StdinSecretWriter.writeAndWipe(stdin, to: stdinPipe.fileHandleForWriting)
-                } catch {
-                    process.terminate()
-                    box.resume {
-                        cont.resume(throwing: error)
-                    }
+            do {
+                try writeStdin(pipe)
+                pipe.fileHandleForWriting.closeFile()
+            } catch {
+                process.terminate()
+                box.resume {
+                    cont.resume(throwing: error)
                 }
             }
         }

--- a/Sources/Engine/OliverBinary.swift
+++ b/Sources/Engine/OliverBinary.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Locates the `oliver` CLI binary — the rendering engine behind Boris,
+/// used by the compose preview (`oliver render --from …`).
+///
+/// Search order:
+///   1. `SOLIPSIST_OLIVER_BIN` environment override
+///   2. `Resources/oliver` inside the running app bundle
+///   3. A sibling of the located `boris` binary (kit/bin dirs ship both)
+///   4. Common dev-checkout locations relative to the current directory
+public enum OliverBinary {
+    public static func locate(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        borisBinary: URL? = nil
+    ) -> URL? {
+        let fm = FileManager.default
+
+        func isExecutable(_ url: URL) -> Bool {
+            fm.isExecutableFile(atPath: url.path)
+        }
+
+        if let override = environment["SOLIPSIST_OLIVER_BIN"], !override.isEmpty {
+            let url = URL(fileURLWithPath: override)
+            if isExecutable(url) { return url }
+        }
+
+        if let resources = Bundle.main.resourceURL {
+            let bundled = resources.appendingPathComponent("oliver")
+            if isExecutable(bundled) { return bundled }
+        }
+
+        if let borisBinary {
+            let sibling = borisBinary.deletingLastPathComponent().appendingPathComponent("oliver")
+            if isExecutable(sibling) { return sibling }
+        }
+
+        let cwd = URL(fileURLWithPath: fm.currentDirectoryPath)
+        let devCandidates = [
+            "SUPPORT-NOT-FOR-GITHUB/oliver/zig-out/bin/oliver",
+            "../oliver/zig-out/bin/oliver",
+            "oliver/zig-out/bin/oliver",
+            "zig-out/bin/oliver",
+        ]
+        for relative in devCandidates {
+            let url = cwd.appendingPathComponent(relative).standardizedFileURL
+            if isExecutable(url) { return url }
+        }
+
+        return nil
+    }
+}

--- a/Sources/Engine/OliverRenderer.swift
+++ b/Sources/Engine/OliverRenderer.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// The three Oliver frontends (`oliver render --from …`).
+public enum OliverFrontend: String, Sendable {
+    case markdown
+    case textile
+    case cooklang
+}
+
+/// `--to` render profile: HTML (default) or the XML-compatible fragment.
+public enum OliverRenderProfile: String, Sendable {
+    case html
+    case xhtml
+}
+
+/// `--raw-html` policy for raw HTML/HTML blocks.
+public enum OliverRawHTMLPolicy: String, Sendable {
+    case allowed
+    case escaped
+    case rejected
+}
+
+/// `--frontmatter` policy for the shared pre-pass (`src/frontmatter.zig`).
+public enum OliverFrontmatterPolicy: String, Sendable {
+    case none
+    case yaml
+    case toml
+}
+
+/// Render options mirroring Oliver's `ParseOptions` — every flag is off by
+/// default, exactly as in Oliver (`docs/CAPABILITIES.md`, `docs/FEATURE-MATRIX.md`).
+public struct OliverRenderOptions: Sendable, Equatable {
+    public var profile: OliverRenderProfile = .html
+    public var wikilinks = false
+    public var callouts = false
+    public var smartypants = false
+    public var footnotes = false
+    public var definitionLists = false
+    public var headingAttributes = false
+    public var strikethrough = false
+    public var headingIDs = false
+    public var taskLists = false
+    public var rawHTML: OliverRawHTMLPolicy = .allowed
+    public var frontmatter: OliverFrontmatterPolicy = .none
+
+    public init() {}
+
+    /// The CLI arguments for `oliver render --from <frontend> …`.
+    /// Only non-default options are emitted, mirroring the documented CLI.
+    public func arguments(frontend: OliverFrontend) -> [String] {
+        var args = ["render", "--from", frontend.rawValue]
+        if profile != .html {
+            args += ["--to", profile.rawValue]
+        }
+        if wikilinks { args.append("--wikilinks") }
+        if callouts { args.append("--callouts") }
+        if smartypants { args.append("--smartypants") }
+        if footnotes { args.append("--footnotes") }
+        if definitionLists { args.append("--definition-lists") }
+        if headingAttributes { args.append("--heading-attributes") }
+        if strikethrough { args.append("--strikethrough") }
+        if headingIDs { args.append("--heading-ids") }
+        if taskLists { args.append("--task-lists") }
+        if rawHTML != .allowed {
+            args += ["--raw-html", rawHTML.rawValue]
+        }
+        if frontmatter != .none {
+            args += ["--frontmatter", frontmatter.rawValue]
+        }
+        return args
+    }
+}
+
+/// Result of a successful `oliver render` invocation.
+public struct OliverRenderResult: Sendable {
+    public let html: String
+    public let exitCode: Int32
+    public let stderr: String
+}
+
+public enum OliverRenderError: Error, Sendable, CustomStringConvertible {
+    case binaryNotFound
+    case renderFailed(exitCode: Int32, stderr: String)
+
+    public var description: String {
+        switch self {
+        case .binaryNotFound:
+            return "oliver renderer not found (set SOLIPSIST_OLIVER_BIN, bundle oliver, or build ../oliver)"
+        case .renderFailed(let exitCode, let stderr):
+            let tail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            let suffix = tail.isEmpty ? "" : " — \(tail.suffix(200))"
+            return "oliver render failed (exit \(exitCode))\(suffix)"
+        }
+    }
+}
+
+/// The Engine seam for markup rendering. Lives in the Engine lane because
+/// only the Engine starts subprocesses (`agents.md` boundary 5) — it reuses
+/// `BorisRunner` (same capture + interrupt machinery), never a new Process
+/// owner. Renders one buffer per call; cancellation terminates the child.
+public struct OliverRenderer: Sendable {
+    public let binaryURL: URL?
+
+    public init(binaryURL: URL? = nil) {
+        if let binaryURL {
+            self.binaryURL = binaryURL
+        } else {
+            self.binaryURL = OliverBinary.locate()
+        }
+    }
+
+    public func render(
+        source: String,
+        frontend: OliverFrontend,
+        options: OliverRenderOptions = OliverRenderOptions()
+    ) async throws -> OliverRenderResult {
+        guard let binaryURL else {
+            throw OliverRenderError.binaryNotFound
+        }
+        let handle = RunHandle()
+        return try await withTaskCancellationHandler {
+            let output = try await BorisRunner.run(
+                binary: binaryURL,
+                arguments: options.arguments(frontend: frontend),
+                handle: handle,
+                stdinText: source
+            )
+            guard output.exitCode == 0 else {
+                throw OliverRenderError.renderFailed(exitCode: output.exitCode, stderr: output.stderrText)
+            }
+            return OliverRenderResult(html: output.stdoutText, exitCode: output.exitCode, stderr: output.stderrText)
+        } onCancel: {
+            handle.terminate()
+        }
+    }
+}

--- a/Tests/ContractTests/ComposeDocumentTests.swift
+++ b/Tests/ContractTests/ComposeDocumentTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+
+@MainActor
+final class ComposeDocumentTests: XCTestCase {
+    // MARK: - Frontmatter boundary (Oliver's sniff-then-strip rule)
+
+    func testYamlFrontmatterDetected() {
+        let doc = ComposeDocument(text: "---\ntitle: Hello\n---\n\nBody")
+        guard let frontmatter = doc.frontmatter else {
+            return XCTFail("expected YAML frontmatter")
+        }
+        XCTAssertEqual(frontmatter.kind, .yaml)
+        XCTAssertEqual(frontmatter.payloadString, "title: Hello")
+    }
+
+    func testTomlFrontmatterDetected() {
+        let doc = ComposeDocument(text: "+++\ntitle = \"Hello\"\n+++\n\nBody")
+        guard let frontmatter = doc.frontmatter else {
+            return XCTFail("expected TOML frontmatter")
+        }
+        XCTAssertEqual(frontmatter.kind, .toml)
+        XCTAssertEqual(frontmatter.payloadString, "title = \"Hello\"")
+    }
+
+    func testEmptyFrontmatterPayload() {
+        let doc = ComposeDocument(text: "---\n---\n\nBody")
+        guard let frontmatter = doc.frontmatter else {
+            return XCTFail("expected frontmatter")
+        }
+        XCTAssertEqual(frontmatter.payloadString, "")
+    }
+
+    func testUnclosedOpenerIsNotFrontmatter() {
+        // Oliver: an unclosed opener passes through unchanged with an
+        // `unclosed-frontmatter` diagnostic — never treated as frontmatter.
+        let doc = ComposeDocument(text: "---\ntitle: Never closes\n\nBody")
+        XCTAssertNil(doc.frontmatter)
+    }
+
+    func testFenceNotAtIndexZeroIsNotFrontmatter() {
+        let doc = ComposeDocument(text: "Body first\n---\ntitle: No\n---\n")
+        XCTAssertNil(doc.frontmatter)
+    }
+
+    func testFrontmatterRangeCoversBothFences() {
+        let doc = ComposeDocument(text: "---\na: 1\n---\nBody")
+        guard let frontmatter = doc.frontmatter else {
+            return XCTFail("expected frontmatter")
+        }
+        XCTAssertEqual(String(doc.text[frontmatter.range]), "---\na: 1\n---")
+    }
+
+    // MARK: - Language pinning
+
+    func testLanguageAutoDetectsUntilPinned() {
+        let doc = ComposeDocument(text: "")
+        XCTAssertEqual(doc.language, .markdown)
+
+        doc.text = "@salt{1%tsp} into the bowl."
+        XCTAssertEqual(doc.language, .cooklang)
+
+        // Pinning (picker choice) survives later edits.
+        doc.language = .textile
+        doc.text = "# A heading that would sniff markdown"
+        XCTAssertEqual(doc.language, .textile, "explicit choice must not be overridden")
+    }
+
+    func testExplicitLanguageInInitIsPinned() {
+        let doc = ComposeDocument(text: "@salt", language: .textile)
+        doc.text = "# heading"
+        XCTAssertEqual(doc.language, .textile)
+    }
+
+    // MARK: - Dirty flag and explicit save
+
+    func testDirtyFlagTracksEdits() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("compose-doc-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = ComposeDocument(text: "Hello", fileURL: url)
+        XCTAssertFalse(doc.isDirty)
+
+        doc.text = "Hello, world."
+        XCTAssertTrue(doc.isDirty)
+
+        XCTAssertTrue(try doc.save())
+        XCTAssertFalse(doc.isDirty)
+
+        // Nothing to save when clean.
+        XCTAssertFalse(try doc.save())
+
+        let reloaded = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertEqual(reloaded, "Hello, world.")
+    }
+
+    func testSaveRequiresExplicitURL() throws {
+        let doc = ComposeDocument(text: "Never written")
+        XCTAssertFalse(try doc.save(), "save without a URL must be a no-op")
+    }
+
+    func testLoadSyncsBufferAndClearsDirty() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("compose-load-\(UUID().uuidString).cook")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "@salt{1}".write(to: url, atomically: true, encoding: .utf8)
+
+        let doc = ComposeDocument()
+        try doc.load(from: url)
+        XCTAssertEqual(doc.text, "@salt{1}")
+        XCTAssertEqual(doc.language, .cooklang)
+        XCTAssertFalse(doc.isDirty)
+    }
+
+    func testStatusTextSummarizes() {
+        let doc = ComposeDocument(text: "---\na: 1\n---\nBody", fileURL: URL(fileURLWithPath: "/tmp/note.md"))
+        let status = doc.statusText
+        XCTAssertTrue(status.contains("note.md"))
+        XCTAssertTrue(status.contains("Markdown"))
+        XCTAssertTrue(status.contains("front matter: yaml"))
+    }
+}

--- a/Tests/ContractTests/ComposeHighlighterTests.swift
+++ b/Tests/ContractTests/ComposeHighlighterTests.swift
@@ -1,0 +1,163 @@
+import AppKit
+import XCTest
+
+@MainActor
+final class ComposeHighlighterTests: XCTestCase {
+    // MARK: - Markdown
+
+    func testMarkdownHeadingPainted() {
+        let attributed = ComposeHighlighter.highlight("# Title", language: .markdown)
+        XCTAssertEqual(color(at: 1, in: attributed), NSColor.systemPurple)
+        XCTAssertEqual(color(at: 4, in: attributed), NSColor.systemPurple)
+    }
+
+    func testMarkdownSevenHashesIsNotHeading() {
+        let attributed = ComposeHighlighter.highlight("####### not a heading", language: .markdown)
+        XCTAssertEqual(color(at: 1, in: attributed), NSColor.labelColor)
+    }
+
+    func testMarkdownLinkPainted() {
+        let attributed = ComposeHighlighter.highlight("See [the docs](https://x.dev).", language: .markdown)
+        XCTAssertEqual(color(at: 5, in: attributed), NSColor.systemBlue)
+    }
+
+    func testMarkdownImagePaintedOverLink() {
+        let attributed = ComposeHighlighter.highlight("![alt](img.png)", language: .markdown)
+        XCTAssertEqual(color(at: 0, in: attributed), NSColor.systemTeal)
+        XCTAssertEqual(color(at: 7, in: attributed), NSColor.systemTeal)
+    }
+
+    func testMarkdownCodeSpanPainted() {
+        let attributed = ComposeHighlighter.highlight("Use `print(x)` now.", language: .markdown)
+        XCTAssertEqual(color(at: 5, in: attributed), NSColor.systemGreen)
+    }
+
+    func testMarkdownFencedCodeRegionPaintedLast() throws {
+        let text = "# Outer heading\n```\n# not a heading\n```\n"
+        let attributed = ComposeHighlighter.highlight(text, language: .markdown)
+        // The `#` inside the fence must stay code-colored, not heading-colored.
+        let fenceContent = try XCTUnwrap(text.range(of: "# not a heading"))
+        let location = text.distance(from: text.startIndex, to: fenceContent.lowerBound)
+        XCTAssertEqual(color(at: location, in: attributed), NSColor.systemGreen)
+    }
+
+    func testMarkdownWikilinkPainted() {
+        let attributed = ComposeHighlighter.highlight("See [[Notes|the note]].", language: .markdown)
+        XCTAssertEqual(color(at: 5, in: attributed), NSColor.systemTeal)
+    }
+
+    func testMarkdownCalloutPainted() {
+        let attributed = ComposeHighlighter.highlight("> [!note] Heads up\n> body", language: .markdown)
+        XCTAssertEqual(color(at: 3, in: attributed), NSColor.systemYellow)
+    }
+
+    func testMarkdownTaskListPainted() {
+        let attributed = ComposeHighlighter.highlight("- [x] done\n- [ ] todo", language: .markdown)
+        XCTAssertEqual(color(at: 2, in: attributed), NSColor.systemGreen)
+    }
+
+    func testMarkdownFrontmatterPaintedLast() throws {
+        let text = "---\n# a yaml comment\n---\n# Real heading"
+        let attributed = ComposeHighlighter.highlight(text, language: .markdown)
+        // The `#` inside frontmatter must stay gray (data, not content)…
+        XCTAssertEqual(color(at: 5, in: attributed), NSColor.systemGray)
+        // …while the heading after the fence is purple.
+        let heading = try XCTUnwrap(text.range(of: "# Real"))
+        let headingStart = text.distance(from: text.startIndex, to: heading.lowerBound)
+        XCTAssertEqual(color(at: headingStart + 1, in: attributed), NSColor.systemPurple)
+    }
+
+    // MARK: - Textile
+
+    func testTextileSignaturePainted() {
+        let attributed = ComposeHighlighter.highlight("h1. The Title", language: .textile)
+        XCTAssertEqual(color(at: 0, in: attributed), NSColor.systemPurple)
+        XCTAssertEqual(color(at: 2, in: attributed), NSColor.systemPurple)
+    }
+
+    func testTextileCodePainted() {
+        let attributed = ComposeHighlighter.highlight("Use @code@ here.", language: .textile)
+        XCTAssertEqual(color(at: 5, in: attributed), NSColor.systemGreen)
+    }
+
+    func testTextilePhrasePainted() {
+        let attributed = ComposeHighlighter.highlight("A **strong** phrase.", language: .textile)
+        XCTAssertEqual(color(at: 4, in: attributed), NSColor.systemRed)
+    }
+
+    func testTextileEmphasisPainted() {
+        let attributed = ComposeHighlighter.highlight("An *em* phrase.", language: .textile)
+        XCTAssertEqual(color(at: 4, in: attributed), NSColor.systemOrange)
+    }
+
+    func testTextileLinkPainted() {
+        let attributed = ComposeHighlighter.highlight("\"the docs\":https://x.dev", language: .textile)
+        XCTAssertEqual(color(at: 1, in: attributed), NSColor.systemBlue)
+    }
+
+    func testTextileImagePainted() {
+        let attributed = ComposeHighlighter.highlight("!img.png!", language: .textile)
+        XCTAssertEqual(color(at: 1, in: attributed), NSColor.systemTeal)
+    }
+
+    func testTextileTableRowPainted() {
+        let attributed = ComposeHighlighter.highlight("|a|b|", language: .textile)
+        XCTAssertEqual(color(at: 0, in: attributed), NSColor.systemTeal)
+    }
+
+    // MARK: - Cooklang
+
+    func testCooklangIngredientPainted() {
+        let attributed = ComposeHighlighter.highlight("Add @salt{1%tsp}.", language: .cooklang)
+        XCTAssertEqual(color(at: 5, in: attributed), NSColor.systemGreen)
+        XCTAssertEqual(color(at: 9, in: attributed), NSColor.systemGreen)
+    }
+
+    func testCooklangMultiWordIngredientPainted() {
+        let attributed = ComposeHighlighter.highlight("Add @ground black pepper{}.", language: .cooklang)
+        // The second word of the braced name is still the ingredient.
+        XCTAssertEqual(color(at: 12, in: attributed), NSColor.systemGreen)
+    }
+
+    func testCooklangCookwarePainted() {
+        let attributed = ComposeHighlighter.highlight("Use #frying pan{2}.", language: .cooklang)
+        XCTAssertEqual(color(at: 5, in: attributed), NSColor.systemBlue)
+    }
+
+    func testCooklangTimerPainted() {
+        let attributed = ComposeHighlighter.highlight("Cook ~{25%minutes}.", language: .cooklang)
+        XCTAssertEqual(color(at: 6, in: attributed), NSColor.systemOrange)
+    }
+
+    func testCooklangNamedTimerPainted() {
+        let attributed = ComposeHighlighter.highlight("Rest ~dough{10%minutes}.", language: .cooklang)
+        XCTAssertEqual(color(at: 6, in: attributed), NSColor.systemOrange)
+    }
+
+    func testCooklangSectionPainted() {
+        let attributed = ComposeHighlighter.highlight("= Ingredients", language: .cooklang)
+        XCTAssertEqual(color(at: 0, in: attributed), NSColor.systemPurple)
+    }
+
+    func testCooklangNotePainted() {
+        let attributed = ComposeHighlighter.highlight("> Do not skip this.", language: .cooklang)
+        XCTAssertEqual(color(at: 2, in: attributed), NSColor.systemTeal)
+    }
+
+    func testCooklangCommentPainted() {
+        let attributed = ComposeHighlighter.highlight("-- a comment\nAdd @salt{}", language: .cooklang)
+        XCTAssertEqual(color(at: 2, in: attributed), NSColor.secondaryLabelColor)
+    }
+
+    func testCooklangTokenInsideCommentStaysComment() {
+        let attributed = ComposeHighlighter.highlight("-- add @salt here", language: .cooklang)
+        XCTAssertEqual(color(at: 8, in: attributed), NSColor.secondaryLabelColor)
+    }
+
+    // MARK: - Helpers
+
+    private func color(at location: Int, in attributed: NSAttributedString) -> NSColor? {
+        guard location < attributed.length else { return nil }
+        return attributed.attribute(.foregroundColor, at: location, effectiveRange: nil) as? NSColor
+    }
+}

--- a/Tests/ContractTests/ComposeLanguageTests.swift
+++ b/Tests/ContractTests/ComposeLanguageTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+final class ComposeLanguageTests: XCTestCase {
+    // MARK: - Extension detection
+
+    func testMarkdownExtensions() {
+        for ext in ["md", "markdown", "mdown"] {
+            let url = URL(fileURLWithPath: "/tmp/doc.\(ext)")
+            XCTAssertEqual(
+                ComposeLanguage.detect(fileURL: url, contents: ""),
+                .markdown,
+                "extension .\(ext) should select markdown"
+            )
+        }
+    }
+
+    func testTextileExtension() {
+        let url = URL(fileURLWithPath: "/tmp/doc.textile")
+        XCTAssertEqual(ComposeLanguage.detect(fileURL: url, contents: ""), .textile)
+    }
+
+    func testCooklangExtensions() {
+        for ext in ["cook", "menu"] {
+            let url = URL(fileURLWithPath: "/tmp/recipe.\(ext)")
+            XCTAssertEqual(
+                ComposeLanguage.detect(fileURL: url, contents: ""),
+                .cooklang,
+                "extension .\(ext) should select cooklang"
+            )
+        }
+    }
+
+    // MARK: - Content sniffing (no extension)
+
+    func testSniffCooklangIngredient() {
+        let text = "Add @salt{1%tsp} and @ground black pepper{} to the pot.\n"
+        XCTAssertEqual(ComposeLanguage.detect(fileURL: nil, contents: text), .cooklang)
+    }
+
+    func testSniffCooklangSection() {
+        let text = "= Stew\n\nSimmer for ~{25%minutes}.\n"
+        XCTAssertEqual(ComposeLanguage.detect(fileURL: nil, contents: text), .cooklang)
+    }
+
+    func testSniffTextileHeading() {
+        XCTAssertEqual(
+            ComposeLanguage.detect(fileURL: nil, contents: "h1. The Title\n\nBody text."),
+            .textile
+        )
+    }
+
+    func testSniffTextileSignature() {
+        XCTAssertEqual(
+            ComposeLanguage.detect(fileURL: nil, contents: "p. A styled paragraph\n\nMore."),
+            .textile
+        )
+    }
+
+    func testSniffMarkdownHeading() {
+        XCTAssertEqual(
+            ComposeLanguage.detect(fileURL: nil, contents: "# Title\n\nSome *body*."),
+            .markdown
+        )
+    }
+
+    func testSniffEmptyFallsBackToMarkdown() {
+        XCTAssertEqual(ComposeLanguage.detect(fileURL: nil, contents: ""), .markdown)
+    }
+
+    func testSniffPlainProseFallsBackToMarkdown() {
+        XCTAssertEqual(ComposeLanguage.detect(fileURL: nil, contents: "Just words."), .markdown)
+    }
+
+    // MARK: - Frontend surface
+
+    func testDisplayNames() {
+        XCTAssertEqual(ComposeLanguage.markdown.displayName, "Markdown")
+        XCTAssertEqual(ComposeLanguage.textile.displayName, "Textile")
+        XCTAssertEqual(ComposeLanguage.cooklang.displayName, "Cooklang")
+    }
+
+    func testConformanceNotesReferenceOliverWalls() {
+        XCTAssertTrue(ComposeLanguage.markdown.conformanceNote.contains("652/652"))
+        XCTAssertTrue(ComposeLanguage.cooklang.conformanceNote.contains("60/60"))
+    }
+
+    func testAllLanguagesSupportFrontmatter() {
+        for language in ComposeLanguage.allCases {
+            XCTAssertTrue(language.supportsFrontmatter)
+        }
+    }
+}

--- a/Tests/ContractTests/ComposePageResolverTests.swift
+++ b/Tests/ContractTests/ComposePageResolverTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+
+final class ComposePageResolverTests: XCTestCase {
+    private let sampleGraphJSON = """
+    {
+      "schemaVersion": "ir-graph-0.3.0",
+      "frozen": true,
+      "nodes": [
+        {
+          "index": 0,
+          "id": "index",
+          "sourcePath": "index.md",
+          "role": "trunk",
+          "parent": null,
+          "parentIndex": null,
+          "title": "Index",
+          "status": null,
+          "tags": [],
+          "bodyOffset": null
+        },
+        {
+          "index": 1,
+          "id": "guides/getting-started",
+          "sourcePath": "guides/getting-started.md",
+          "role": "satellite",
+          "parent": "index",
+          "parentIndex": 0,
+          "title": "Getting Started",
+          "status": "draft",
+          "tags": ["guide"],
+          "bodyOffset": 120
+        }
+      ],
+      "edges": [],
+      "reverseIndex": [],
+      "nav": []
+    }
+    """
+
+    func testGraphURLShape() {
+        let root = URL(fileURLWithPath: "/tmp/proj")
+        XCTAssertEqual(
+            ComposePageResolver.graphURL(workspaceRoot: root).path,
+            "/tmp/proj/.boris/graph.json"
+        )
+    }
+
+    func testFileURLJoinsContentRootAndSourcePath() {
+        let contentRoot = URL(fileURLWithPath: "/tmp/proj/content")
+        XCTAssertEqual(
+            ComposePageResolver.fileURL(contentRoot: contentRoot, sourcePath: "guides/getting-started.md").path,
+            "/tmp/proj/content/guides/getting-started.md"
+        )
+    }
+
+    func testPageLookupById() throws {
+        let graph = try JSONDecoder().decode(Graph.self, from: Data(sampleGraphJSON.utf8))
+        let node = try XCTUnwrap(ComposePageResolver.page(id: "guides/getting-started", in: graph))
+        XCTAssertEqual(node.sourcePath, "guides/getting-started.md")
+        XCTAssertEqual(node.title, "Getting Started")
+        XCTAssertEqual(node.status, "draft")
+    }
+
+    func testPageLookupMissReturnsNil() throws {
+        let graph = try JSONDecoder().decode(Graph.self, from: Data(sampleGraphJSON.utf8))
+        XCTAssertNil(ComposePageResolver.page(id: "no-such-page", in: graph))
+    }
+
+    func testPageLookupThroughGraphFile() throws {
+        let workspaceRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("compose-resolver-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+
+        let boris = workspaceRoot.appendingPathComponent(".boris", isDirectory: true)
+        try FileManager.default.createDirectory(at: boris, withIntermediateDirectories: true)
+        try Data(sampleGraphJSON.utf8).write(to: ComposePageResolver.graphURL(workspaceRoot: workspaceRoot))
+
+        let node = try XCTUnwrap(
+            ComposePageResolver.page(id: "index", workspaceRoot: workspaceRoot)
+        )
+        XCTAssertEqual(node.sourcePath, "index.md")
+    }
+}

--- a/Tests/ContractTests/ComposePreviewTests.swift
+++ b/Tests/ContractTests/ComposePreviewTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+final class ComposePreviewTests: XCTestCase {
+    private func render(_ source: String, language: ComposeLanguage) async throws -> String {
+        try await PlaceholderRenderService().render(
+            source,
+            language: language,
+            options: MarkupRenderOptions()
+        )
+    }
+
+    func testPlaceholderEscapesHTML() async throws {
+        let html = try await render("<b>&\"</b>", language: .markdown)
+        XCTAssertTrue(html.contains("&lt;b&gt;&amp;&quot;&lt;/b&gt;"))
+        XCTAssertFalse(html.contains("<b>"))
+        XCTAssertFalse(html.contains("&amp;lt;")) // no double-escape
+    }
+
+    func testPlaceholderEscapesPerLanguage() async throws {
+        let markdown = try await render("1 < 2", language: .markdown)
+        let textile = try await render("1 < 2", language: .textile)
+        let cooklang = try await render("1 < 2", language: .cooklang)
+        XCTAssertEqual(markdown, textile)
+        XCTAssertEqual(markdown, cooklang)
+        XCTAssertTrue(markdown.contains("&lt;"))
+    }
+
+    func testPlaceholderReplacesNUL() async throws {
+        let html = try await render("a\u{0}b", language: .cooklang)
+        XCTAssertTrue(html.contains("\u{FFFD}"))
+        XCTAssertFalse(html.contains("\u{0}"))
+    }
+
+    func testPlaceholderIgnoresOptions() async throws {
+        var options = MarkupRenderOptions()
+        options.wikilinks = true
+        options.profile = .xhtml
+        let html = try await PlaceholderRenderService().render(
+            "See [[Notes]].",
+            language: .markdown,
+            options: options
+        )
+        XCTAssertTrue(html.contains("[[Notes]]"))
+    }
+}

--- a/Tests/ContractTests/OliverRenderOptionsTests.swift
+++ b/Tests/ContractTests/OliverRenderOptionsTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+final class OliverRenderOptionsTests: XCTestCase {
+    func testDefaultsProduceBareRenderCommand() {
+        let args = OliverRenderOptions().arguments(frontend: .markdown)
+        XCTAssertEqual(args, ["render", "--from", "markdown"])
+    }
+
+    func testFrontendsMapToCLINames() {
+        XCTAssertEqual(OliverRenderOptions().arguments(frontend: .textile).dropFirst(2).first, "textile")
+        XCTAssertEqual(OliverRenderOptions().arguments(frontend: .cooklang).dropFirst(2).first, "cooklang")
+    }
+
+    func testExtensionFlagsEmitOnlyWhenSet() {
+        var options = OliverRenderOptions()
+        options.wikilinks = true
+        options.callouts = true
+        options.smartypants = true
+        options.footnotes = true
+        options.definitionLists = true
+        options.headingAttributes = true
+        options.strikethrough = true
+        options.headingIDs = true
+        options.taskLists = true
+        let args = options.arguments(frontend: .markdown)
+        for flag in [
+            "--wikilinks", "--callouts", "--smartypants", "--footnotes",
+            "--definition-lists", "--heading-attributes", "--strikethrough",
+            "--heading-ids", "--task-lists",
+        ] {
+            XCTAssertTrue(args.contains(flag), "expected \(flag) in \(args)")
+        }
+    }
+
+    func testDefaultRawHTMLAndFrontmatterAreOmitted() {
+        let args = OliverRenderOptions().arguments(frontend: .markdown)
+        XCTAssertFalse(args.contains("--raw-html"))
+        XCTAssertFalse(args.contains("--frontmatter"))
+    }
+
+    func testRawHTMLPolicyEmitsValue() {
+        var options = OliverRenderOptions()
+        options.rawHTML = .escaped
+        let args = options.arguments(frontend: .markdown)
+        XCTAssertEqual(args.suffix(2), ["--raw-html", "escaped"])
+    }
+
+    func testFrontmatterPolicyEmitsValue() {
+        var options = OliverRenderOptions()
+        options.frontmatter = .toml
+        let args = options.arguments(frontend: .markdown)
+        XCTAssertEqual(args.suffix(2), ["--frontmatter", "toml"])
+    }
+
+    func testXHTMLProfileEmitsTo() {
+        var options = OliverRenderOptions()
+        options.profile = .xhtml
+        let args = options.arguments(frontend: .markdown)
+        XCTAssertEqual(args.suffix(2), ["--to", "xhtml"])
+    }
+}

--- a/Tests/ContractTests/OliverRenderServiceTests.swift
+++ b/Tests/ContractTests/OliverRenderServiceTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+final class OliverRenderServiceTests: XCTestCase {
+    // MARK: - Mapping (pure)
+
+    func testFrontendMapping() {
+        XCTAssertEqual(OliverRenderService.frontend(for: .markdown), .markdown)
+        XCTAssertEqual(OliverRenderService.frontend(for: .textile), .textile)
+        XCTAssertEqual(OliverRenderService.frontend(for: .cooklang), .cooklang)
+    }
+
+    func testOptionsMappingPreservesFlags() {
+        var options = MarkupRenderOptions()
+        options.wikilinks = true
+        options.strikethrough = true
+        options.frontmatter = .yaml
+        options.rawHTML = .rejected
+        options.profile = .xhtml
+
+        let engine = OliverRenderService.engineOptions(options)
+        XCTAssertTrue(engine.wikilinks)
+        XCTAssertTrue(engine.strikethrough)
+        XCTAssertFalse(engine.callouts)
+        XCTAssertEqual(engine.frontmatter, .yaml)
+        XCTAssertEqual(engine.rawHTML, .rejected)
+        XCTAssertEqual(engine.profile, .xhtml)
+        XCTAssertEqual(
+            engine.arguments(frontend: .markdown),
+            ["render", "--from", "markdown", "--to", "xhtml", "--wikilinks",
+             "--strikethrough", "--raw-html", "rejected", "--frontmatter", "yaml"]
+        )
+    }
+
+    // MARK: - End to end (skipped in CI without an oliver binary)
+
+    func testRenderMarkdownThroughOliver() async throws {
+        let renderer = try rendererFromEnvironment()
+        let result = try await renderer.render(
+            source: "# Hello *world*",
+            frontend: .markdown,
+            options: OliverRenderOptions()
+        )
+        XCTAssertEqual(result.html.trimmingCharacters(in: .whitespacesAndNewlines), "<h1>Hello <em>world</em></h1>")
+    }
+
+    func testRenderCooklangThroughOliver() async throws {
+        let renderer = try rendererFromEnvironment()
+        let result = try await renderer.render(
+            source: "Add @salt{1%tsp} and simmer ~{25%minutes}.",
+            frontend: .cooklang,
+            options: OliverRenderOptions()
+        )
+        XCTAssertTrue(result.html.contains("<article class=\"recipe\">"))
+        XCTAssertTrue(result.html.contains("data-quantity=\"1\""))
+        XCTAssertTrue(result.html.contains("datetime=\"PT25M\""))
+    }
+
+    func testRenderWithExtensionFlagThroughOliver() async throws {
+        let renderer = try rendererFromEnvironment()
+        var options = OliverRenderOptions()
+        options.wikilinks = true
+        let result = try await renderer.render(
+            source: "See [[Notes]].",
+            frontend: .markdown,
+            options: options
+        )
+        XCTAssertTrue(result.html.contains("<a href=\"Notes\">Notes</a>"))
+    }
+
+    func testServiceRenderReturnsHTMLFragment() async throws {
+        guard let bin = ProcessInfo.processInfo.environment["SOLIPSIST_OLIVER_BIN"], !bin.isEmpty else {
+            throw XCTSkip("SOLIPSIST_OLIVER_BIN not set")
+        }
+        let service = OliverRenderService(renderer: OliverRenderer(binaryURL: URL(fileURLWithPath: bin)))
+        let html = try await service.render("h1. Title", language: .textile, options: MarkupRenderOptions())
+        XCTAssertTrue(html.contains("<h1>Title</h1>"))
+    }
+
+    // MARK: - Helpers
+
+    private func rendererFromEnvironment() throws -> OliverRenderer {
+        guard let bin = ProcessInfo.processInfo.environment["SOLIPSIST_OLIVER_BIN"], !bin.isEmpty else {
+            throw XCTSkip("SOLIPSIST_OLIVER_BIN not set")
+        }
+        return OliverRenderer(binaryURL: URL(fileURLWithPath: bin))
+    }
+}

--- a/agents.md
+++ b/agents.md
@@ -62,4 +62,5 @@ M0 bootstrap ✅ · M1 spike ✅ · M2 chassis ✅ · **P** withdrawn ·
 ship 🔧 ([#78](https://github.com/drawmeanelephant/solipsist/issues/78))
 · **M10** Mail body 📋
 ([#98](https://github.com/drawmeanelephant/solipsist/issues/98) —
-Settings / mailboxes / reading — after #78, never inside it).
+Settings / mailboxes / reading / compose #106 — after #78, never
+inside it).

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -48,12 +48,15 @@ Companion windows (hosted, not authored):
   • Preview   — full site; boris watch --serve in WKWebView
   • Editor    — boris-editor (Svelte) at its session-token URL
   • anything else Boris already built that we will not rewrite
+
+Our chrome (authored):
+  • Compose   — native buffer (`Sources/Compose/`, ⌘⇧C). Oliver
+    renders the preview. Explicit save. Not a hosted companion.
 ```
 
 Mail, not Finder, not Xcode. Accounts in Preferences. Mailboxes on the
 left. Messages in the middle. The letter you picked, readable. Compose
-is a separate surface (the hosted editor now; a native buffer only when
-we name that later).
+is a separate window — the native buffer — not a tab in Play.
 
 ### Settings — the account book
 
@@ -154,14 +157,23 @@ Mail's Activity window is the analog for build/plan/timings if that
 surface ever outgrows its mailbox. It is still *our* chrome if we
 author it; companions are specifically the things we refuse to author.
 
-### Native editor (named later, not M10)
+### Compose — native buffer (M10)
 
-A from-scratch native buffer is **allowed to be later**. It is not a
-v1 gate and it is not a reason to stop hosting `boris-editor`. If it
-lands, it is a buffer + save + problems surface over `sourcePath`. It
-does not parse frontmatter, does not compile, does not invent graph
-semantics, and does not replace `watch --serve`. Until that card is
-cut, Edit means the hosted companion.
+Mail's compose is a separate window. Ours is `Sources/Compose/`: a
+native Markdown / Textile / Cooklang buffer over the selected page's
+`sourcePath`, with Oliver as the language reference and the preview
+renderer. Highlighting is heuristic paint, not a parse. The front
+matter boundary is sniffed, never parsed. Save is explicit and flows
+into the coordinator's validate gate.
+
+This does **not** replace the hosted `boris-editor` companion (#102).
+Edit ▶ still opens that host. Compose ▶ (`⌘⇧C`) opens the native
+buffer. Distinct lanes: `Companions/Editor/` vs `Compose/`.
+
+Oliver is spawned only from `Engine/` (`OliverRenderer` reuses
+`BorisRunner`). Play does not grow a `TextView`. Remaining compose
+depth (span diagnostics, incremental highlight, bundling `oliver`
+next to `boris`) is Later, not the M10 gate.
 
 ---
 
@@ -183,14 +195,15 @@ Sources/
     Local/        message list + reading pane; mailbox contents
   Inspector/      Inspectable sections, no selection ownership
   Companions/     PreviewWindow, EditorWindow (WKWebView hosts)
-  Engine/         existing — the only Process owner
+  Compose/        native buffer + Oliver preview (M10)
+  Engine/         existing — the only Process owner (boris *and* oliver)
   Models/         existing — Codable mirrors, no SwiftUI
 ```
 
 `ContentView.swift` is gone. Chrome is `MainWindow` and empty slots.
 Do not grow `MainWindow` — fill `Play/`, `Inspector/`, `Companions/`,
-`App/Settings/`. Recut `SourceSidebar` into a mailbox tree; do not
-start a second sidebar.
+`Compose/`, `App/Settings/`. Recut `SourceSidebar` into a mailbox
+tree; do not start a second sidebar.
 
 ### Load-bearing types (the seams)
 
@@ -241,7 +254,8 @@ cut wrong — stop and recut.
 | **Settings** (M10) | `Sources/App/Settings/`, Settings scene in `SolipsistApp.swift` | `Commands.swift`, Play, mailbox tree, `Project.yml` | Settings → Sources adds/removes/relocates a local source; same store as File → Open… |
 | **Mailboxes** (M10) | `SourceSidebar.swift`; `WorkspaceSelection` / `WorkspaceStore` / `WorkspacePersistence`; sole `MainWindow.swift` | Settings scene, `Commands.swift`, Play row rendering, Inspector, `Project.yml` | Sidebar is account headers + mailboxes; selecting one writes `selection.mailbox` |
 | **Reading** (M10) | `Sources/Play/Local/`; named recut: `PlayHost` binder, `AppRuntime.previewSession`, `Companions/Preview/` session share + `PreviewURL` helpers | Chrome mailbox construction, `MainWindow.swift`, Engine | Tabs gone; center is message list + reading pane driven by `mailbox` |
-| **Editor wiring** (M10) | `Sources/Companions/Editor/`, File → Edit Page in `Commands.swift` | Native `TextView`, Play list internals, `MainWindow.swift` | File → Edit Page; header shows title + `sourcePath`; merge after Reading |
+| **Editor wiring** (M10) | `Sources/Companions/Editor/`, File → Edit Page in `Commands.swift` | `Sources/Compose/`, Play list internals, `MainWindow.swift` | File → Edit Page; header shows title + `sourcePath`; merge after Reading |
+| **Compose** (M10) | `Sources/Compose/`, `OliverRenderer` / `OliverBinary` in `Engine/`, Compose menu / window | `Companions/Editor/`, Play list internals, `MainWindow.swift` | ⌘⇧C opens the selected page; explicit save; Oliver preview when the binary is present |
 | **Issues** | `docs/issues/` | `Sources/` | Draft fact-checked against afterparty, then filed |
 | **Design** | `docs/*.md` except `issues/` | `Sources/` | Decisions recorded; no silent contradiction with this file |
 
@@ -259,7 +273,8 @@ cut wrong — stop and recut.
    instead of it.** Settings can run next to Mailboxes. Reading follows
    Mailboxes (it consumes `selection.mailbox`). Editor wiring **merges
    after Reading** (it reads `noun.sourcePath` that Reading writes).
-   Native editor is not in this sequence.
+   Compose (#106) keys off the same page noun, owns `Sources/Compose/`
+   + the Oliver engine seam, and does not block #101 or #102.
 
 ### Integration rules
 
@@ -270,9 +285,9 @@ cut wrong — stop and recut.
 - Unknown/newer `schemaVersion` degrades, never crashes (D8).
 - If a feature is not in the menu bar, it is not a feature.
 - If you are about to write a Markdown editor, a graph algorithm, a
-  frontmatter parser, or an HTTP server — stop. That is Boris's job or
-  a companion host. A native buffer is a named later card, not a
-  surprise `TextView` in Play.
+  frontmatter parser, or an HTTP server — stop. That is Boris's job,
+  Oliver's job, or a companion host. The native buffer lives in
+  `Sources/Compose/` (#106). Do not drop a surprise `TextView` in Play.
 
 ---
 
@@ -321,7 +336,8 @@ without picking an M10 card. The live app is still the flatter cut:
 | Left column | Flat source list (`SourceSidebar`) | Account headers + mailboxes |
 | Center | Segmented play tabs (Pages / Outputs / Publish / Plan / Activity) + problems strip | Message list + reading pane, driven by the selected mailbox |
 | Preview | Companion only | Companion (full site) + reading pane (selected page, same watch) |
-| Editor | Companion only; source-scoped, not page-scoped | Companion, opened from the selected page; native buffer later |
+| Editor | Companion only; source-scoped, not page-scoped | Companion, opened from the selected page (#102) |
+| Compose | none | Native buffer window (`⌘⇧C`) over `sourcePath`; Oliver preview (#106) |
 | Selection | `sourceID` + `noun` | `sourceID` + `mailbox` + `noun` |
 
 M10 cards live in [`cards/`](cards/README.md)

--- a/docs/M10-DESIGN.md
+++ b/docs/M10-DESIGN.md
@@ -8,10 +8,10 @@
 | **Status** | Accepted |
 | **Repo** | [drawmeanelephant/solipsist](https://github.com/drawmeanelephant/solipsist) |
 | **Parent issue** | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) |
-| **Children** | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) Settings · [#100](https://github.com/drawmeanelephant/solipsist/issues/100) Mailboxes · [#101](https://github.com/drawmeanelephant/solipsist/issues/101) Reading · [#102](https://github.com/drawmeanelephant/solipsist/issues/102) Editor |
+| **Children** | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) Settings · [#100](https://github.com/drawmeanelephant/solipsist/issues/100) Mailboxes · [#101](https://github.com/drawmeanelephant/solipsist/issues/101) Reading · [#102](https://github.com/drawmeanelephant/solipsist/issues/102) Editor · [#106](https://github.com/drawmeanelephant/solipsist/issues/106) Compose |
 | **Parents** | [`HARNESS.md`](HARNESS.md) §2 (spatial) · [`ROADMAP.md`](ROADMAP.md) §5 M10 · [`Agents.md`](../Agents.md) |
 
-This is the extra planning [#98](https://github.com/drawmeanelephant/solipsist/issues/98) asked for. It is not a restatement of the cards. The four child cards, **HARNESS §4**, and the parent sequence are patched to match this file — **HARNESS wins on where a surface lives; the cards plus this design execute it.**
+This is the extra planning [#98](https://github.com/drawmeanelephant/solipsist/issues/98) asked for. It is not a restatement of the cards. The five child cards, **HARNESS §4**, and the parent sequence are patched to match this file — **HARNESS wins on where a surface lives; the cards plus this design execute it.** #106 / #108 adopted the native compose window into M10 after the original four-card cut.
 
 Implementation stays on new feature branches off `main`, one per card.
 
@@ -23,7 +23,7 @@ M2–M8 shipped a flatter chassis: a flat `SourceSidebar`, a segmented `PlayTab`
 
 The code already has the seams this recut fills. `WorkspaceStore` is the one observable inventory. `WorkspaceSelection` is a value the drawer and companions only read. The Preview companion’s `PreviewSession` (`@State` on `PreviewWindow` today) owns that window’s `WatchServer`; after M10-3 it is lifted and bound to the selected source. `EditorSession` already owns the one `boris-editor` host. None of those need a second process, a second store, or a Swift Markdown renderer.
 
-What is missing is the Mail body: a `mailbox` field on selection, a Settings scene over the same store, a recut sidebar, a reading pane that *observes* the existing watch, and an Edit verb that surfaces `sourcePath` because `boris-editor` has no fact-checked file-open deep link.
+What is missing is the Mail body: a `mailbox` field on selection, a Settings scene over the same store, a recut sidebar, a reading pane that *observes* the existing watch, an Edit verb that surfaces `sourcePath` because `boris-editor` has no fact-checked file-open deep link, and — now in this milestone — the native Compose window over that `sourcePath`.
 
 ---
 
@@ -58,7 +58,7 @@ Settings → Sources (the account book; not a column)
 │ folders under it │ message                     │                  │
 └──────────────────┴─────────────────────────────┴──────────────────┘
 Companions: Preview (full site) · Editor (boris-editor)
-Native buffer: named Later, not this milestone.
+Compose: native buffer window (`Sources/Compose/`, ⌘⇧C) + Oliver preview
 ```
 
 Mail, not Finder, not Xcode. Nested folders under Pages come from `graph.json` `parent` only — and **not in this milestone** (see Key Decisions).
@@ -74,12 +74,13 @@ Mail, not Finder, not Xcode. Nested folders under Pages come from `graph.json` `
 3. Center switches on `selection.mailbox`. Pages is a graph list plus a reading pane. Other mailboxes are the existing full-height panes.
 4. Reading pane loads the selected page's served URL when watch is up; otherwise a contract-backed summary. No `file://`. No Swift Markdown. No second `Process`.
 5. File → Edit Page / toolbar / double-click / Return open the hosted editor and surface title + `sourcePath`. No invented deep link.
-6. Every PR: `SKIP_EMBED_BORIS=1 make build` + `make test` green. One card = one worktree = one PR.
+6. Compose ▶ (`⌘⇧C`) opens the native buffer for the selected page. Explicit save. Oliver preview via `Engine/OliverRenderer`. Not a Swift parse.
+7. Every PR: `SKIP_EMBED_BORIS=1 make build` + `make test` green. One card = one worktree = one PR.
 
 ### Non-Goals
 
 - M9 ship (#78): `scripts/embed-boris.sh`, **all of** `Project.yml` (entitlements *and* target membership), release paths.
-- Native `NSTextView` / `TextEditor` buffer.
+- Compose **depth** (span diagnostics, incremental highlight, bundling `oliver`). The window itself is M10-5 / #106.
 - GitHub as a source.
 - Walking `content/` as a Finder tree; showing `.boris/`, `themes/`, `dist/` as mailboxes.
 - Nested Pages trunk folders in the sidebar (later; see §Mailbox sidebar).
@@ -94,7 +95,7 @@ Mail, not Finder, not Xcode. Nested folders under Pages come from `graph.json` `
 2. Never silently ignore diagnostics or exit codes.
 3. Never mutate the user’s content tree except on an explicit save.
 4. One `Process?` slot in `BorisEngine`. Cancel = `Process.terminationReason == .uncaughtSignal`.
-5. Do not grow `MainWindow`. Fill `Play/`, `Inspector/`, `Companions/`, `App/Settings/`. Recut `SourceSidebar`; do not start a second sidebar.
+5. Do not grow `MainWindow`. Fill `Play/`, `Inspector/`, `Companions/`, `Compose/`, `App/Settings/`. Recut `SourceSidebar`; do not start a second sidebar.
 6. D2: output-changing settings write `boris.json`; machine state writes the plist; Settings and the drawer are views, never a third store.
 7. Unknown/newer `schemaVersion` degrades, never crashes (D8).
 8. Menus first. If it is not in the menu bar, it is not a feature.

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -75,8 +75,9 @@ compiler repo. Solipsist is the complementary **native desktop citizen**:
   [#78](https://github.com/drawmeanelephant/solipsist/issues/78).
   Next **product cut:** M10 Mail body
   ([#98](https://github.com/drawmeanelephant/solipsist/issues/98) —
-  Settings, mailbox sidebar, reading pane). Sequence:
-  [ROADMAP.md](ROADMAP.md) §8.
+  Settings, mailbox sidebar, reading pane, native compose
+  [#106](https://github.com/drawmeanelephant/solipsist/issues/106)).
+  Sequence: [ROADMAP.md](ROADMAP.md) §8.
 - **Engine baseline:** afterparty `boris/0.8.1`. Kit pin `b82e9e2`.
   A3/A4/A13/A1/A14/A7 have merged after that pin — bump when we vendor
   a newer kit (#78).
@@ -91,6 +92,6 @@ Settings → it appears as an account with mailboxes → the reading place
 shows the graph as messages and a pane for the selected page → the
 drawer shows the profile and that page → Plan / Validate / Build
 surface every diagnostic → Preview reloads through `watch --serve` →
-Edit hosts `boris-editor` → publish to GitHub Pages, Standard.site, or
+Edit hosts `boris-editor` → Compose is the native buffer → publish to GitHub Pages, Standard.site, or
 Nostr with the Proof Pack attached. All of it driven by the compiler's
 contracts; none of it by scraped prose or reimplemented logic.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -141,6 +141,12 @@ proof (#91/#93). Remaining **ship** card is
 M10 is the next product cut after ship; it does not expand #78. Do
 not grow `MainWindow`.
 
+The compose lane ([`docs/cards/COMPOSE-EDITOR.md`](cards/COMPOSE-EDITOR.md))
+is a separate depth direction: a native Markdown / Textile / Cooklang
+compose element, built standalone in `Sources/Compose/` with Oliver as the
+language reference. It amends the §3 "no from-scratch editor" line for
+that lane only, in writing, in the card.
+
 ---
 
 ## 5. Milestones

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,7 +27,7 @@ Settings → Sources (the account book; not a column)
 │ folders under it │ message                     │                  │
 └──────────────────┴─────────────────────────────┴──────────────────┘
 Companion windows we host: Preview (full site) · Editor (boris-editor)
-Native buffer: named later, not a v1 gate.
+Compose window we author: native buffer (`⌘⇧C`) + Oliver preview (#106)
 ```
 
 M2–M8 shipped a flatter cut (source list + tabbed play). M10 is the
@@ -76,6 +76,7 @@ No scraped prose. No homegrown graph. No third settings store.
 | Diagnostics as a place | `html-build-report` / IR `build-report` / check findings, clickable |
 | Engine-owned preview | Companion; `watch --serve` + SSE; no app HTTP server |
 | Hosted editor | Companion; `boris-editor` token URL; opened from the selected page; link-out fallback |
+| Native compose | `Sources/Compose/`; Oliver preview; explicit save → validate |
 | Outputs fan-out | Every profile target and edition, isolated, reported |
 | Publication console | GH Pages evidence (Boris-owned workflow + audit), Standard.site, Nostr — secrets on stdin |
 | Proof Pack visible | `boris-package` evidence, read-only |
@@ -85,7 +86,8 @@ No scraped prose. No homegrown graph. No third settings store.
 ### v1 must not
 
 - A frontmatter parser, a graph algorithm, or a homegrown Markdown
-  renderer in Swift
+  renderer in Swift (Compose sniffs Oliver's boundary and paints
+  tokens; Oliver/Boris parse)
 - A Finder clone of the content tree in the sidebar
 - An app-side HTTP server or `file://` preview
 - Cloudflare / Vercel / Netlify as *in-app* deploy adapters or a
@@ -94,15 +96,13 @@ No scraped prose. No homegrown graph. No third settings store.
 - Theme *authoring* (selection only)
 - Migration labs as runtime
 - iOS
-- A native editor *instead of* hosting `boris-editor` (see Later)
 
 ### Later (named so they stay later)
 
-- A **native editor**: buffer + save + problems over `sourcePath`.
-  Still no frontmatter parser. Still no compile. Still hosts
-  `watch --serve` for preview. Cut a card only when the hosted
-  Svelte shell is the wrong Mac citizen, not because Play looks
-  empty.
+- Compose **depth**: span diagnostics from Oliver, incremental
+  highlight, front-matter form, Cooklang autocomplete, bundling
+  `oliver` next to `boris`. The M10 gate is the window + save +
+  preview seam (#106 / #108), not those.
 - GitHub as a second **source** (account header + its own mailboxes;
   we do not have full GitHub access; Pages as a *target* does not
   require it)
@@ -130,7 +130,7 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M7** Outputs | ✅ gate — Build this / Build all fan-out (#76, #81) |
 | **M8** Publish | ✅ gate — stdin secrets, Standard.site / Nostr buttons (#77, #82/#84) |
 | **M9** Ship | 🔧 pipeline exists; clean-Mac proof + credentials + pin open (#78) |
-| **M10** Mail body | 📋 Settings for sources; mailbox sidebar; reading pane; editor from the selected page ([#98](https://github.com/drawmeanelephant/solipsist/issues/98)) |
+| **M10** Mail body | 📋 Settings, mailboxes, reading pane, hosted Edit, native Compose ([#98](https://github.com/drawmeanelephant/solipsist/issues/98), [#106](https://github.com/drawmeanelephant/solipsist/issues/106)) |
 
 **Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
 batch then landed: first-run and problem→page (#88/#94), graph filter /
@@ -139,13 +139,10 @@ activity / plan document (#89/#96), profile 1:1 + execution knobs +
 proof (#91/#93). Remaining **ship** card is
 [#78](https://github.com/drawmeanelephant/solipsist/issues/78) (M9).
 M10 is the next product cut after ship; it does not expand #78. Do
-not grow `MainWindow`.
-
-The compose lane ([`docs/cards/COMPOSE-EDITOR.md`](cards/COMPOSE-EDITOR.md))
-is a separate depth direction: a native Markdown / Textile / Cooklang
-compose element, built standalone in `Sources/Compose/` with Oliver as the
-language reference. It amends the §3 "no from-scratch editor" line for
-that lane only, in writing, in the card.
+not grow `MainWindow`. Native compose is an M10 child
+([#106](https://github.com/drawmeanelephant/solipsist/issues/106),
+PR [#108](https://github.com/drawmeanelephant/solipsist/pull/108)),
+not a side lane.
 
 ---
 
@@ -360,8 +357,8 @@ folder, plan, validate, build, preview.
 
 **Goal.** The window is Mail, not a tabbed workbench. Sources live in
 Settings. The left pane is a mailbox tree. The center is messages plus
-a reading pane. Edit still hosts `boris-editor`; a native buffer stays
-Later.
+a reading pane. Edit hosts `boris-editor` from the selected page.
+Compose is the native buffer (`⌘⇧C`) over that page's `sourcePath`.
 
 This is a chrome recut, not a new compiler surface. Contracts,
 coordinator verbs, publish flows, and the subprocess boundary do not
@@ -375,6 +372,7 @@ does not grow to absorb this.
 | Reading place | Message list of the selected mailbox + reading pane for the selected page (watch URL if up; contract summary if not) |
 | Full-site Preview | Companion, unchanged |
 | Editor | Companion, opened from the selected page; link-out fallback |
+| Compose | Native window (`Sources/Compose/`); Oliver preview; explicit save → validate |
 | Drawer | Still minutiae of the selection, not the account book |
 
 **Gate.** Settings → Sources adds a local folder that also appears as
@@ -382,17 +380,19 @@ an account header. Selecting Pages shows the graph as a message list.
 Selecting a page shows a reading pane (watch URL or summary — never
 `file://`, never a Swift Markdown renderer). Outputs / Publish / Plan
 / Activity are mailboxes, not tabs. Edit ▶ on a selected page opens
-the hosted editor. `SKIP_EMBED_BORIS=1 make build` + `make test`
-green.
+the hosted editor. Compose ▶ opens the native buffer and saves
+through the coordinator. `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.
 
-**Lanes.** Settings, Mailboxes, Reading, Editor wiring — paths in
-[`HARNESS.md`](HARNESS.md) §4. Tracker
+**Lanes.** Settings, Mailboxes, Reading, Editor wiring, Compose —
+paths in [`HARNESS.md`](HARNESS.md) §4. Tracker
 [#98](https://github.com/drawmeanelephant/solipsist/issues/98);
+compose [#106](https://github.com/drawmeanelephant/solipsist/issues/106);
 cards in [`cards/`](cards/README.md). Implementation design:
 [`M10-DESIGN.md`](M10-DESIGN.md).
 
-**Not this milestone.** Native editor. GitHub as a source. Finder
-sidebar. In-app HTTP server. Growing #78.
+**Not this milestone.** Compose depth (diagnostics, bundle `oliver`).
+GitHub as a source. Finder sidebar. In-app HTTP server. Growing #78.
 
 ---
 
@@ -419,6 +419,7 @@ here, it is not a v1 promise.
 | `init` | M4 | File → New Project… |
 | `recipe-scale` | M6 | Drawer, cook corpora only |
 | `boris-editor` | M6, M10 | Companion (A14); M10 opens it from the selected page |
+| Oliver (`oliver render`) | M10 | Compose preview; Engine-owned subprocess; not a Swift parse |
 | GitHub Pages + audit | M8 | In-app evidence; Boris workflow owns push; we are not the GH operator |
 | `hosts/cloudflare-worker` + `compileBundle` Wasm | **P (now)** | This project’s subdomain. Free-tier host glue. Not in-app |
 | `boris-job-runner` / CF Containers (#300) | parked | Different host (native binary in a container), not the Free Wasm path |
@@ -456,7 +457,7 @@ or beside ship, never inside it.
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
 | 1 | Ship | [#78](https://github.com/drawmeanelephant/solipsist/issues/78) | Credentials, clean-Mac proof, pin bump, testdata. |
-| 2 | Mail body | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) ([#99](https://github.com/drawmeanelephant/solipsist/issues/99)–[#102](https://github.com/drawmeanelephant/solipsist/issues/102)) | Sources in Settings; left pane is folders; center is messages + reading; Edit from the selected page. |
+| 2 | Mail body | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) ([#99](https://github.com/drawmeanelephant/solipsist/issues/99)–[#102](https://github.com/drawmeanelephant/solipsist/issues/102), [#106](https://github.com/drawmeanelephant/solipsist/issues/106)) | Settings, mailboxes, reading, hosted Edit, native Compose. |
 
 #78 stays build-lane only (`scripts/embed-boris.sh`, `Project.yml`,
 entitlements, release workflow, `docs/SHIP-HARDENING.md`). Do not
@@ -486,9 +487,9 @@ Named in this file and **not** a product surface yet: browser OAuth,
 `github-pages-audit`.
 
 Out of v1 (unchanged): GitHub as a source, content-audit, source-rag,
-migration labs, Wasm in the app, `validate --watch` until A5 + pin,
-a from-scratch native editor (named Later; M10 still hosts
-`boris-editor`).
+migration labs, Wasm in the app, `validate --watch` until A5 + pin.
+Compose **depth** (diagnostics, bundle `oliver`) stays Later; the
+M10 compose window is #106 / #108.
 
 #30 is a pr-cop dump, not a card.
 

--- a/docs/cards/COMPOSE-EDITOR.md
+++ b/docs/cards/COMPOSE-EDITOR.md
@@ -1,0 +1,204 @@
+# Card COMPOSE-1 — Native compose editor element (Markdown / Textile / Cooklang)
+
+**Milestone:** depth (post-M9) · **Lane:** compose (new) · **Reference:**
+[Oliver](https://github.com/drawmeanelephant/oliver) · **Issue:**
+[#106](https://github.com/drawmeanelephant/solipsist/issues/106) (filed as
+off-roadmap "Later" per the M10 parent #98) · **Branch suggestion:**
+`compose/editor-element`
+
+**Status:** ✅ phase 1 (the element) landed — `Sources/Compose/` builds
+into the app and `make test` covers language detection, the front-matter
+boundary, per-language paint, and the render seam. ✅ **hook-in landed** —
+a `Compose` window (`⌘⇧C`, `ComposeWindow.swift`) is registered, sourced
+from the selected page via the published graph contract, saves under the
+source's security-scoped bookmark, and flows each successful save into the
+coordinator's save→validate gate (`noteSave()`). ✅ **Oliver-backed preview
+landed** — `OliverRenderer` (Engine lane, reuses `BorisRunner`, so only the
+Engine spawns processes) renders buffers through `oliver render --from …`
+with options mirroring Oliver's `ParseOptions`; the compose preview is
+debounced, cancellation-terminates the child, and surfaces render errors
+(renderer not found → actionable message). End-to-end render tests run when
+`SOLIPSIST_OLIVER_BIN` is set and skip in CI. Remaining phases below
+(diagnostics mapping, depth) are future cards.
+
+**One sentence:** build a full-featured Markdown / Textile / Cooklang
+compose surface as a **standalone element** (`Sources/Compose/`), with
+Oliver — the rendering engine behind Boris — as the language reference, and
+hook it into the app in a later card. It is a big undertaking; this card is
+phase 1 (the element itself) and the record of the whole shape.
+
+## Why this card exists — and what it amends
+
+`HARNESS.md` and `ROADMAP.md` carry the rule "if you are about to write a
+Markdown editor, a graph algorithm, a frontmatter parser, or an HTTP server —
+stop" and "v1 must not: a from-scratch native editor or frontmatter parser."
+This card **amends both, in writing, for this lane only**:
+
+- The compose window is **authoring chrome** — Mail's compose analog, the
+  one surface Boris's hosted `boris-editor` (a browser surface) does not give
+  us as a native Mac citizen. We are not reimplementing compiler semantics;
+  we are authoring a buffer and previewing it.
+- **Oliver pins the language contract.** Every behavior the editor touches
+  (block/inline syntax, extensions, front matter boundary, diagnostics) is
+  already decided, tested, and documented in Oliver. We mirror that surface;
+  we never invent a grammar. Highlighting is heuristic paint, explicitly not
+  a parse — the parse stays in Oliver/Boris.
+- **The element is built standalone first.** Nothing in phase 1 wires it into
+  `SolipsistApp`, `MainWindow`, menus, or the selection store. The "one
+  window" posture is untouched until the hook-in card lands.
+
+## Reference — Oliver's language support (reviewed 2026-08-18)
+
+Oliver is a clean-room Zig markup library: Markdown / Textile → a normalized
+typed document → deterministic HTML/XHTML; Cooklang → its own typed `Recipe`
+model → an Oliver-owned HTML policy. Filesystem, templates, site graphs, and
+publication do not live there — consumers (Boris) build around it.
+
+### Frontends at a glance
+
+| Frontend | Parses into | Oliver entry | Conformance wall |
+|----------|-------------|--------------|------------------|
+| Markdown | shared `document.Document` | `oliver.parse(…, .markdown, …)` | CommonMark 0.31.2 — **652/652** byte-for-byte |
+| Textile | shared `document.Document` | `oliver.parse(…, .textile, …)` | Textile fixture wall fully green (`TEXTILE-PARITY.md`) |
+| Cooklang | typed `Recipe` (own model) | `oliver.cooklang.parse(…)` | canonical corpus **60/60** (`docs/COOKLANG.md`) |
+
+### Markdown — full CommonMark 0.31.2 plus Oliver's opt-in extensions
+
+- **Blocks:** paragraphs, ATX + Setext headings, thematic breaks, fenced and
+  indented code blocks (tab-stop indentation, literal content), all seven HTML
+  block types, block quotes, tight/loose lists with nesting, link reference
+  definitions (§4.7, full/collapsed/shortcut resolution), GFM pipe tables.
+- **Inlines:** the complete emphasis/strong rule set (mod-3, openers_bottom),
+  code spans (run-length matching), inline + reference links and images,
+  URI/email autolinks, raw HTML, hard/soft line breaks, backslash escapes,
+  full WHATWG entity table (§2.5).
+- **Extensions (all off by default):** Pandoc footnotes, definition lists,
+  heading attribute lists + GFM auto heading ids, strikethrough, task lists,
+  Obsidian `[[wikilinks]]`, `> [!note]` callouts, smart typography.
+- **Front matter:** shared pre-pass (`src/frontmatter.zig`) — YAML `---` /
+  TOML `+++` sniffed at index 0, stripped before dispatch, parsed into a
+  bounded subset or kept raw with a `frontmatter-parse-unsupported`
+  diagnostic. An unclosed opener passes through with
+  `unclosed-frontmatter` — never faked.
+
+### Textile — the documented Textile 2 surface
+
+- **Blocks:** `p.`/`h1.`–`h6.`/`bq.` signatures with the full block-attribute
+  set (`{style}[lang](class#id)` alignment/padding), `bc.`/`pre.` code blocks,
+  `*`/`#` lists with nesting, `dl.` definition lists, `|a|b|` tables with cell
+  modifiers/colspan/rowspan and `table<mods>.` signatures, footnotes (`[N]` +
+  `fnN.`), `clear.`, `==` escaping, `notextile.` raw passthrough, extended
+  `bq..`/`bc..`/`pre..` blocks, line attributes (`|mods|.`), `bq.:URL` citations.
+- **Inlines:** the phrase family (`_x_ *x* __x__ **x** -x- +x+ ^x^ ~x~ %x%
+  ++x++ --x-- ??x?? ABC(def)`) with phrase attributes on every operator,
+  `@code@`, links (`"text":url`, titles, the bracket trick, link aliases),
+  images (`!url!` with alt/title/alignment/size modifiers), `==…==` inline
+  escaping, the character replacements (curly quotes, dashes, ellipsis,
+  symbols, `{...}` character macros), Unicode boundary rules.
+- **Front matter:** same shared pre-pass as Markdown.
+
+### Cooklang — a typed Recipe, not prose markup
+
+- **Model:** ingredients (`@name`, `@multi word{quantity%unit}`, shorthand
+  preparations), cookware (`#name{…}`), timers (named/unnamed, quantity+units
+  kept as source text), steps with forced line breaks, `--` / `[- -]`
+  comments, `> ` notes, `= ` sections, recipe references (`@./path`, parsed
+  never resolved), YAML front-matter boundary (raw payload, never faked).
+- **Derived operations** (Boris/Boris's consumers own these; the editor's
+  future recipe-scale pane mirrors them): canonical serialize, exact-rational
+  scale by factor/servings, `.menu` day/meal view, deterministic HTML policy
+  (ingredients index, `<time>` timers, section-aware layout).
+- **Diagnostics:** structured, exact source spans — the compose problems seam
+  maps to this shape.
+
+### What the review means for the editor
+
+1. **Three distinct language surfaces** — the element must own three
+   highlighters, not one grammar with flags (Cooklang is not Markdown with
+   `@`).
+2. **The front matter boundary is a first-class construct** in all three —
+   sniffed at index 0, never parsed, never content.
+3. **Diagnostics carry exact spans** — the problems seam is a
+   span-based model, not a line list.
+4. **Extensions are opt-in per profile** — the compose window can expose the
+   extension surface (wikilinks/callouts/smartypants/…) the way Oliver's
+   `ParseOptions` does, so authors see exactly what their profile renders.
+
+## Owns
+
+- `Sources/Compose/**` — new lane (language model, buffer, highlighter,
+  editor element, render seam). Lane is single-owner: one worktree, one PR.
+- `Project.yml` — add the lane to the app target; add the three
+  Foundation-only files (`ComposeLanguage.swift`, `ComposeDocument.swift`,
+  `ComposeHighlighter.swift`) to `ContractTests`.
+- `Tests/ContractTests/Compose{Language,Document,Highlighter,Preview}Tests.swift`.
+
+## Do (phase 1 — the element, standalone)
+
+1. **`ComposeLanguage`** — markdown / textile / cooklang with extension
+   detection, advisory content sniffing, and the Oliver conformance notes.
+   Language is auto-detected until pinned; the picker's choice is never
+   overridden mid-session.
+2. **`ComposeDocument`** — observable buffer (text, language, `fileURL`,
+   dirty flag), the front-matter boundary scanner (Oliver's sniff-then-strip
+   rule; unclosed openers are not front matter), and an **explicit-only**
+   `save()` seam (boundary 4: nothing writes to disk but an explicit save).
+3. **`ComposeHighlighter`** — `NSAttributedString` token paint per language,
+   rule tables derived from Oliver's documented surface (see review). Painted
+   last: regions (fenced/indented code) and front matter, so data stays gray
+   and code stays code. Comments paint over tokens in Cooklang. Heuristic by
+   contract — documented as not-a-parse in the file header.
+4. **`ComposeEditorView`** — the element: `NSTextView` host with live
+   highlighting (repaint-on-edit, typing attributes restored), language
+   picker, preview split, explicit Save (⌘S, disabled when clean), and a
+   span-based diagnostics seam.
+5. **`ComposePreview`** — the `MarkupRenderService` protocol + placeholder
+   (HTML-escaped, NUL → U+FFFD, same escape policy as Oliver's text writer).
+   The Oliver-backed implementation is **not** phase 1: Solipsist's Engine
+   lane owns subprocesses, so it lands with the hook-in card as an Engine
+   seam (`renderMarkup`) or a C-ABI embed decision.
+6. **Tests** — pin detection, front-matter boundary, per-language paint, and
+   render escaping, in the house contract-test style.
+
+## Do not (phase 1)
+
+- Wire into `SolipsistApp.swift`, `MainWindow`, `Commands.swift`, the
+  selection store, or any menu (that is the hook-in card).
+- Touch `Sources/Engine/**`, `Sources/Companions/**`, `Sources/Chrome/**`,
+  `Sources/Play/**`, `Sources/Inspector/**`, `Sources/Workspace/**`.
+- Spawn any process. The Engine lane owns `Process`.
+- Implement parse semantics or a frontmatter parser — Oliver is the
+  reference; we highlight and buffer, we do not compile.
+- Use `WKWebView` in the element. The preview is a sandboxed HTML fragment
+  view; the `watch --serve` companion posture belongs to the hook-in card.
+- Touch the `boris` repo or `docs/issues/`.
+
+## Later — hook-in phases (own cards, do not start)
+
+1. **Hook-in** ✅ landed: `ComposeWindow` registers the window, sources the
+   buffer from the selected `page` noun (file resolved via `graph.json`,
+   `ComposePageResolver`), reads/writes under the local source's
+   security-scoped bookmark, and calls `coordinator.noteSave()` after an
+   explicit save so the debounced validate gate runs — the same posture as
+   the hosted editor's save. Dirty-buffer page switches confirm before
+   discarding.
+2. **Oliver-backed preview** ✅ landed: `OliverRenderer` in the Engine lane
+   (subprocess via `BorisRunner`, cancellation-terminates the child),
+   located via `SOLIPSIST_OLIVER_BIN` → app bundle `Resources/oliver` →
+   sibling of the boris binary → dev checkouts. Extension flags, `--to
+   xhtml`, `--raw-html`, and `--frontmatter` mirror Oliver's `ParseOptions`;
+   the compose window's Render Options menu exposes them. Bundling `oliver`
+   next to `boris` (embed script) and a C-ABI embed decision remain open.
+3. **Diagnostics:** map Oliver's span-based diagnostics into the problems
+   seam; click-to-line.
+4. **Depth:** incremental (visible-range) highlighting, selection-aware
+   paint, front-matter form editor, Cooklang ingredient autocomplete /
+   recipe-scale pane, find & replace, per-profile extension surface.
+
+## Gate
+
+`SKIP_EMBED_BORIS=1 make build` + `make test` green. The element compiles
+into the app target (it is not shown anywhere yet); the tests cover language
+detection, the front-matter boundary, per-language highlight paint, and the
+render seam for all three frontends. Card body = this file; no silent
+contradiction with HARNESS — the amendment is written here.

--- a/docs/cards/COMPOSE-EDITOR.md
+++ b/docs/cards/COMPOSE-EDITOR.md
@@ -1,10 +1,12 @@
 # Card COMPOSE-1 — Native compose editor element (Markdown / Textile / Cooklang)
 
-**Milestone:** depth (post-M9) · **Lane:** compose (new) · **Reference:**
+**Milestone:** M10 · **Lane:** compose · **Reference:**
 [Oliver](https://github.com/drawmeanelephant/oliver) · **Issue:**
-[#106](https://github.com/drawmeanelephant/solipsist/issues/106) (filed as
-off-roadmap "Later" per the M10 parent #98) · **Branch suggestion:**
-`compose/editor-element`
+[#106](https://github.com/drawmeanelephant/solipsist/issues/106)
+(M10-5, parent
+[#98](https://github.com/drawmeanelephant/solipsist/issues/98)) ·
+**PR:** [#108](https://github.com/drawmeanelephant/solipsist/pull/108)
+· **Branch:** `compose/editor-element`
 
 **Status:** ✅ phase 1 (the element) landed — `Sources/Compose/` builds
 into the app and `make test` covers language detection, the front-matter
@@ -21,18 +23,18 @@ debounced, cancellation-terminates the child, and surfaces render errors
 `SOLIPSIST_OLIVER_BIN` is set and skip in CI. Remaining phases below
 (diagnostics mapping, depth) are future cards.
 
-**One sentence:** build a full-featured Markdown / Textile / Cooklang
-compose surface as a **standalone element** (`Sources/Compose/`), with
-Oliver — the rendering engine behind Boris — as the language reference, and
-hook it into the app in a later card. It is a big undertaking; this card is
-phase 1 (the element itself) and the record of the whole shape.
+**One sentence:** M10's native compose window (`Sources/Compose/`,
+`⌘⇧C`) — Markdown / Textile / Cooklang buffer over the selected page,
+Oliver as the language reference and preview renderer, explicit save
+into the coordinator. Remaining phases (diagnostics, depth, bundle
+`oliver`) are Later, not the M10 gate.
 
 ## Why this card exists — and what it amends
 
-`HARNESS.md` and `ROADMAP.md` carry the rule "if you are about to write a
-Markdown editor, a graph algorithm, a frontmatter parser, or an HTTP server —
-stop" and "v1 must not: a from-scratch native editor or frontmatter parser."
-This card **amends both, in writing, for this lane only**:
+This started as the off-roadmap Later buffer. It is now **M10-5**.
+`HARNESS.md` and `ROADMAP.md` still refuse a frontmatter parser, a
+graph algorithm, and a surprise `TextView` in Play. This card is the
+named exception for a native compose *window*:
 
 - The compose window is **authoring chrome** — Mail's compose analog, the
   one surface Boris's hosted `boris-editor` (a browser surface) does not give

--- a/docs/cards/M10-editor-wiring.md
+++ b/docs/cards/M10-editor-wiring.md
@@ -23,7 +23,9 @@ Design: [`docs/M10-DESIGN.md`](../M10-DESIGN.md).
 - `Sources/Chrome/MainWindow.swift` (Editor toolbar is #100)
 - `Sources/Engine/**` beyond existing `editorStart`
 - `Sources/Inspector/**` (PageSection already opens the companion)
-- A native `NSTextView` / SwiftUI `TextEditor` buffer
+- `Sources/Compose/` ([#106](https://github.com/drawmeanelephant/solipsist/issues/106)
+  / [#108](https://github.com/drawmeanelephant/solipsist/pull/108) —
+  that is the native buffer; this card hosts `boris-editor`)
 - Preview companion internals
 - `docs/issues/` (do not draft an editor-open-file issue)
 

--- a/docs/cards/M10-mail-body.md
+++ b/docs/cards/M10-mail-body.md
@@ -1,6 +1,6 @@
 # M10 — Mail body (tracker)
 
-**Milestone:** M10 · **Lane:** design (this file) + four child cards.
+**Milestone:** M10 · **Lane:** design (this file) + five child cards.
 Does **not** own `Sources/`. Children do.
 
 Parent issue:
@@ -18,7 +18,7 @@ Edit. That is the M2–M8 chassis. It is not Mail's body.
 [`HARNESS.md`](../HARNESS.md) §2 is now the destination: Settings for
 the account book, mailboxes on the left, messages + reading pane in
 the middle, drawer for minutiae, companions for the full site and
-`boris-editor`. A native buffer is named Later, not this milestone.
+`boris-editor`, and a native Compose window over the selected page.
 
 ## Children
 
@@ -33,11 +33,12 @@ Reading follows Mailboxes. Editor wiring **merges after Reading**
 | [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | Sidebar is account headers + mailboxes; writes `selection.mailbox` |
 | [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | Reading | Tabs gone; list + reading pane; no `file://`, no Swift Markdown |
 | [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | File → Edit Page; header shows title + `sourcePath` |
+| [M10-5 Compose](COMPOSE-EDITOR.md) | [#106](https://github.com/drawmeanelephant/solipsist/issues/106) | Compose | `⌘⇧C` opens the selected page; explicit save; Oliver preview |
 
 ## Not this tracker
 
 - #78 ship (build lane)
-- A native `TextView` / from-scratch editor
+- Compose **depth** (span diagnostics, incremental highlight, bundle `oliver`)
 - GitHub as a source
 - Walking the content directory as a Finder tree
 - An app-side HTTP server or `file://` preview
@@ -71,3 +72,7 @@ Existing `WorkspaceNoun.kind` values (`page`, `profile`, `target`,
 3. M10-4 **merges after M10-3**. It may be *developed* after M10-2
    (`sourcePath` on the type) but must not touch `LocalPlay.swift`
    or `MainWindow.swift`.
+4. M10-5 Compose keys off `noun.kind == "page"`, owns
+   `Sources/Compose/` + the Oliver engine seam, and does not block
+   #101 or #102. PR
+   [#108](https://github.com/drawmeanelephant/solipsist/pull/108).

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -72,6 +72,25 @@ editor from the selected page. Native editor stays Later.
 
 #78 stays build-lane only. Do not pick an M10 card by growing ship.
 
+## New lane — compose editor element (#106, the Later native buffer)
+
+[COMPOSE-EDITOR.md](COMPOSE-EDITOR.md) is the depth lane M10 explicitly
+defers ("Native editor stays Later" above; #98's do-not list): a native
+Markdown / Textile / Cooklang compose surface, built in `Sources/Compose/`
+with Oliver as the language reference. It deliberately amends the "no
+from-scratch editor" lines in HARNESS/ROADMAP for that lane only — the
+amendment is recorded in the card and issue
+[#106](https://github.com/drawmeanelephant/solipsist/issues/106).
+
+Landed: **phase 1** (the element: language model, buffer, highlighter,
+editor view, render seam), the **hook-in** (a `Compose` window (`⌘⇧C`)
+sourced from the selected page, open/save under the source's
+security-scoped bookmark, save → coordinator validate gate), and the
+**Oliver-backed preview** (`OliverRenderer` in the Engine lane renders
+buffers through the oliver CLI; options mirror Oliver's `ParseOptions`;
+render tests run when `SOLIPSIST_OLIVER_BIN` is set). Remaining phases
+(diagnostics mapping, depth) are not pickable yet.
+
 ## Do not start yet
 
 GitHub as a source. Wasm in the app. The fart app. A native

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -60,42 +60,25 @@ preview) in the entitlements matrix.
 ## M10 — Mail body (after #78, not instead of it)
 
 Spatial recut. Settings for sources, mailbox sidebar, reading pane,
-editor from the selected page. Native editor stays Later.
+hosted Edit from the selected page, native Compose.
 
 | Card | Issue | Lane | Parallel with | Gate |
 |------|-------|------|----------------|------|
 | [M10 tracker](M10-mail-body.md) | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) | design | — | children filed; [`M10-DESIGN.md`](../M10-DESIGN.md) + HARNESS §2 |
-| [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | Settings | #100 | Settings → Sources adds/removes/relocates |
-| [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | #99 | account headers + mailboxes; writes `mailbox` |
+| [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | Settings | #100 | Settings → Sources adds/removes/relocates ✅ |
+| [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | #99 | account headers + mailboxes; writes `mailbox` ✅ |
 | [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | Reading | — (after #100) | tabs gone; list + reading pane |
 | [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | — (merge after #101) | File → Edit Page; header `sourcePath` |
+| [M10-5 Compose](COMPOSE-EDITOR.md) | [#106](https://github.com/drawmeanelephant/solipsist/issues/106) | Compose | #101, #102 | `⌘⇧C` on a selected page; Oliver preview; PR [#108](https://github.com/drawmeanelephant/solipsist/pull/108) |
 
 #78 stays build-lane only. Do not pick an M10 card by growing ship.
 
-## New lane — compose editor element (#106, the Later native buffer)
-
-[COMPOSE-EDITOR.md](COMPOSE-EDITOR.md) is the depth lane M10 explicitly
-defers ("Native editor stays Later" above; #98's do-not list): a native
-Markdown / Textile / Cooklang compose surface, built in `Sources/Compose/`
-with Oliver as the language reference. It deliberately amends the "no
-from-scratch editor" lines in HARNESS/ROADMAP for that lane only — the
-amendment is recorded in the card and issue
-[#106](https://github.com/drawmeanelephant/solipsist/issues/106).
-
-Landed: **phase 1** (the element: language model, buffer, highlighter,
-editor view, render seam), the **hook-in** (a `Compose` window (`⌘⇧C`)
-sourced from the selected page, open/save under the source's
-security-scoped bookmark, save → coordinator validate gate), and the
-**Oliver-backed preview** (`OliverRenderer` in the Engine lane renders
-buffers through the oliver CLI; options mirror Oliver's `ParseOptions`;
-render tests run when `SOLIPSIST_OLIVER_BIN` is set). Remaining phases
-(diagnostics mapping, depth) are not pickable yet.
-
 ## Do not start yet
 
-GitHub as a source. Wasm in the app. The fart app. A native
-`TextView` editor. Preview, editor host, and publish already have
-gates — M10 wires them into Mail's shape; it does not rebuild them.
+GitHub as a source. Wasm in the app. The fart app. Compose **depth**
+(diagnostics, bundle `oliver`). Preview, editor host, and publish
+already have gates — M10 wires them into Mail's shape; it does not
+rebuild them.
 
 ## Shared noun kinds (play writes, inspector reads)
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -47,6 +47,7 @@ Every menu verb and keyboard shortcut:
 | Show/Hide Inspector | `⌥⌘0` | Toggle the Inspector drawer on the right. |
 | Preview | `⌘⇧P` | Open the Preview companion window (live preview via `watch --serve` with loopback URL validation). |
 | Editor | `⌘⇧E` | Open the Editor companion window (token-isolated host for `boris-editor`). |
+| Compose | `⌘⇧C` | Open the Compose window (native Markdown / Textile / Cooklang editor for the selected page; Oliver-powered preview; Save flows into the coordinator's validate gate). |
 
 ### Help
 
@@ -58,5 +59,6 @@ Every menu verb and keyboard shortcut:
 
 - **Preview Companion (`⌘⇧P`)**: Live preview powered by `watch --serve` with loopback URL validation.
 - **Editor Companion (`⌘⇧E`)**: Token-isolated companion host for `boris-editor`.
+- **Compose Window (`⌘⇧C`)**: Native compose surface for the selected page's source file — Markdown / Textile / Cooklang editing with heuristic highlighting, an Oliver-rendered preview split (live, debounced; Render Options mirror Oliver's `ParseOptions` — wikilinks, callouts, smart typography, footnotes, task lists, frontmatter policy, raw-HTML policy, XHTML profile), and save-triggered validate through the coordinator. The renderer binary is located via `SOLIPSIST_OLIVER_BIN` → app bundle → sibling of `boris` → dev checkouts. Language is auto-detected from the file; the picker overrides it per session.
 
 For architecture and roadmap details, see [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -24,7 +24,7 @@ a mailbox sidebar, a reading pane.
 | Usability | landed — first-run, status, problem → page |
 | Play / inspector / publish depth | landed |
 | M9 Ship | open — notarized DMG on a clean Mac |
-| M10 Mail body | planned — Settings, mailboxes, reading pane ([#98](https://github.com/drawmeanelephant/solipsist/issues/98)) |
+| M10 Mail body | planned — Settings, mailboxes, reading pane, native compose ([#98](https://github.com/drawmeanelephant/solipsist/issues/98), [#106](https://github.com/drawmeanelephant/solipsist/issues/106)) |
 
 ## v1 must
 
@@ -36,6 +36,7 @@ a mailbox sidebar, a reading pane.
 - Diagnostics as a place: clickable reports, not monospaced dumps
 - Engine-owned preview via `watch --serve` + SSE
 - A hosted editor: `boris-editor` in a companion window, opened from the selected page
+- A native compose window over that page (`⌘⇧C`), previewed through Oliver
 - Outputs fan-out: every profile target and edition, isolated, reported
 - A publication console: GitHub Pages, Standard.site, Nostr — secrets on stdin
 - Sandboxed, bundled, pinned engine
@@ -44,7 +45,7 @@ a mailbox sidebar, a reading pane.
 
 - A frontmatter parser, a graph algorithm, or a homegrown Markdown renderer
 - A Finder clone of the content tree
-- A native editor *instead of* hosting `boris-editor` (named later: buffer + save + problems)
+- A frontmatter parser or Swift Markdown renderer (Compose paints; Oliver/Boris parse)
 - An app-side HTTP server or `file://` preview
 - Cloudflare / Vercel / Netlify as *in-app* deploy adapters
 - Wasm or `compileBundle` *inside* Solipsist — subprocess isolation stays
@@ -52,6 +53,6 @@ a mailbox sidebar, a reading pane.
 
 ## The north star
 
-Open a folder of Boris content → it is a **source** in Settings → it appears as an account with mailboxes → the reading place shows the graph as messages and a pane for the selected page → the drawer shows the profile and that page → Plan / Validate / Build surface every diagnostic → Preview reloads through `watch --serve` → Edit opens `boris-editor` → Publish runs GitHub Pages evidence, Standard.site, or Nostr with the Proof Pack attached.
+Open a folder of Boris content → it is a **source** in Settings → it appears as an account with mailboxes → the reading place shows the graph as messages and a pane for the selected page → the drawer shows the profile and that page → Plan / Validate / Build surface every diagnostic → Preview reloads through `watch --serve` → Edit opens `boris-editor` → Compose is the native buffer → Publish runs GitHub Pages evidence, Standard.site, or Nostr with the Proof Pack attached.
 
 This project’s own public face is a Cloudflare subdomain on Boris’s official Worker + Wasm embed host — stood up early, on the Free tier, not as an in-app engine. Full detail lives in the repository [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).


### PR DESCRIPTION
Closes #106 — **M10-5**, the native compose window. Parent is the Mail-body tracker [#98](https://github.com/drawmeanelephant/solipsist/issues/98). This is no longer the off-roadmap Later exception.

Sibling of [#102](https://github.com/drawmeanelephant/solipsist/issues/102) (hosted `boris-editor`). Same `noun.kind == "page"` selection; distinct lanes (`Companions/Editor` vs `Sources/Compose/`).

## What this is

A native **Markdown / Textile / Cooklang compose window**, with
**Oliver** — the rendering engine behind Boris
([drawmeanelephant/oliver](https://github.com/drawmeanelephant/oliver)) — as
the language reference.

**Reviewers, start here:** [`docs/cards/COMPOSE-EDITOR.md`](https://github.com/drawmeanelephant/solipsist/blob/compose/editor-element/docs/cards/COMPOSE-EDITOR.md)

## Landed

- **Element** (`Sources/Compose/`): language model + detection, observable buffer with Oliver's front-matter boundary rule, per-language heuristic highlighter (not a parse), `NSTextView` editor, render seam.
- **Hook-in**: `ComposeWindow` (`⌘⇧C`) from the selected page via `ComposePageResolver`; open/save under the source bookmark; save → coordinator `noteSave()`.
- **Oliver-backed preview**: `OliverRenderer` reuses `BorisRunner` (Engine is the only Process owner). Options mirror Oliver's `ParseOptions`.
- **Board recut**: HARNESS / ROADMAP / #98 treat Compose as an M10 child. Remaining depth (diagnostics, bundle `oliver`) stays Later.

## Gate

`SKIP_EMBED_BORIS=1 make build` + `make test` green. Compose opens from a selected page, Save validates, preview renders when `SOLIPSIST_OLIVER_BIN` is set.