### PR TITLE
feat(m10): reading pane — messages plus the selected letter (#101)

### DIFF
--- a/Sources/App/AppRuntime.swift
+++ b/Sources/App/AppRuntime.swift
@@ -1,8 +1,9 @@
 import Foundation
 import Observation
 
-/// Process-wide runtime: the engine identity, not the workspace.
-/// Companions and the status bar read this; they do not spawn `boris`.
+/// Process-wide runtime: engine identity, coordinator, and the one
+/// preview watch session (lifted from the companion so Play can observe
+/// it). Companions and Play ask this type; they do not spawn `boris`.
 @MainActor
 @Observable
 final class AppRuntime {
@@ -12,6 +13,7 @@ final class AppRuntime {
     private(set) var engineVersion: String
     let coordinator = Coordinator()
     let credentials = PublishCredentialManager()
+    let previewSession = PreviewSession()
 
     init() {
         if let url = BorisBinary.locate() {

--- a/Sources/Chrome/PlayHost.swift
+++ b/Sources/Chrome/PlayHost.swift
@@ -2,8 +2,13 @@ import SwiftUI
 
 /// Middle slot. Dispatches to the play surface for the selected source kind.
 /// New kinds add a case here (one line) and a folder under `Sources/Play/`.
+///
+/// Also binds the shared `PreviewSession` to the selected source so the
+/// reading pane can observe the watch when the companion is closed. Does
+/// not auto-start from idle.
 struct PlayHost: View {
     @Environment(WorkspaceStore.self) private var store
+    @Environment(AppRuntime.self) private var runtime
 
     var body: some View {
         Group {
@@ -29,5 +34,34 @@ struct PlayHost: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { syncPreviewSession() }
+        .onChange(of: store.selection.sourceID) { syncPreviewSession() }
+        .onChange(of: store.selectedSource?.isAvailable) { syncPreviewSession() }
+    }
+
+    private func syncPreviewSession() {
+        let session = runtime.previewSession
+        guard
+            case .local(let local) = store.selectedSource,
+            local.isAvailable,
+            let content = try? local.contentRoot(),
+            let project = try? local.workspaceRoot()
+        else {
+            if session.phase != .idle { session.stop() }
+            return
+        }
+        switch session.phase {
+        case .idle, .failed:
+            return
+        case .starting, .serving:
+            if !session.isBound(to: content) {
+                session.start(
+                    contentRoot: content,
+                    projectRoot: project,
+                    engine: runtime.engine,
+                    coordinator: runtime.coordinator
+                )
+            }
+        }
     }
 }

--- a/Sources/Companions/Preview/PreviewSession.swift
+++ b/Sources/Companions/Preview/PreviewSession.swift
@@ -28,6 +28,13 @@ final class PreviewSession {
         return nil
     }
 
+    /// Content-root path this session last started, if any.
+    var boundRootPath: String? { rootPath }
+
+    func isBound(to contentRoot: URL) -> Bool {
+        boundRootPath == contentRoot.standardizedFileURL.path
+    }
+
     var isFailure: Bool {
         if case .failed = phase { return true }
         return false

--- a/Sources/Companions/Preview/PreviewURL.swift
+++ b/Sources/Companions/Preview/PreviewURL.swift
@@ -12,4 +12,25 @@ public enum PreviewURL {
         guard let host = url.host?.lowercased() else { return false }
         return host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]"
     }
+
+    /// Site origin from the helper URL `http://127.0.0.1:PORT/__boris/`.
+    public static func siteOrigin(fromHelper helper: URL) -> URL? {
+        guard isLoopback(helper) else { return nil }
+        var components = URLComponents(url: helper, resolvingAgainstBaseURL: false)
+        let path = components?.path ?? ""
+        if path == "/__boris" || path.hasPrefix("/__boris/") {
+            components?.path = "/"
+        }
+        components?.fragment = nil
+        components?.query = nil
+        return components?.url
+    }
+
+    /// `GET /{pageID}.html` on the served tree. `pageID` is `GraphNode.id`.
+    public static func pageURL(helper: URL, pageID: String) -> URL? {
+        guard let origin = siteOrigin(fromHelper: helper) else { return nil }
+        let trimmed = pageID.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !trimmed.isEmpty else { return nil }
+        return URL(string: trimmed + ".html", relativeTo: origin)?.absoluteURL
+    }
 }

--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -7,16 +7,19 @@ import WebKit
 /// window and leaves it closed; the Preview lane owns this file.
 ///
 /// When a source is selected the window starts a `WatchServer` for its
-/// content root via `PreviewSession`; the served helper URL (`…/__boris/`)
-/// is loaded into the web view, where the helper page owns the iframe + SSE
-/// auto-reload. The toolbar keeps the manual loopback-paste escape hatch.
+/// content root via the shared `AppRuntime.previewSession`; the served
+/// helper URL (`…/__boris/`) is loaded into the web view, where the helper
+/// page owns the iframe + SSE auto-reload. Closing this window does not
+/// stop the watch — Play's reading pane reuses it. The toolbar keeps the
+/// manual loopback-paste escape hatch.
 struct PreviewWindow: View {
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
 
     @State private var model = PreviewWebModel()
     @State private var urlText = ""
-    @State private var session = PreviewSession()
+
+    private var session: PreviewSession { runtime.previewSession }
 
     var body: some View {
         Group {
@@ -47,9 +50,6 @@ struct PreviewWindow: View {
             } else {
                 model.loadBlank()
             }
-        }
-        .onDisappear {
-            session.stop()
         }
     }
 

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -1,60 +1,36 @@
 import SwiftUI
 
-/// Play surface for a local folder: the publication as a Mail-style list.
+/// Play surface for a local folder: mailbox contents plus, for Pages, a
+/// reading pane for the selected letter.
 ///
 /// Reads `<source>/.boris/graph.json` when present; otherwise asks
 /// `BorisEngine.buildIR` to produce it. Selection is written to
-/// `WorkspaceStore` as `noun.kind == "page"` — the drawer only reads it.
+/// `WorkspaceStore` as `noun.kind == "page"` with `sourcePath` — the
+/// drawer and companions only read it.
 struct LocalPlay: PlaySurface {
     let source: LocalSource
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
-
-    enum PlayTab: String, CaseIterable, Identifiable {
-        case pages = "Pages"
-        case outputs = "Outputs"
-        case publish = "Publish"
-        case plan = "Plan"
-        case activity = "Activity"
-
-        var id: String { rawValue }
-    }
+    @Environment(\.openWindow) private var openWindow
 
     @State private var state: LoadState = .idle
     @State private var searchText = ""
-
-    private var selectedTab: Binding<PlayTab> {
-        Binding(
-            get: { PlayTab(mailbox: store.selection.mailbox) },
-            set: { store.select(mailbox: $0.mailboxKey) }
-        )
-    }
+    @State private var loadGeneration = 0
 
     var body: some View {
-        VStack(spacing: 0) {
-            Picker("View", selection: selectedTab) {
-                ForEach(PlayTab.allCases) { tab in
-                    Text(tab.rawValue).tag(tab)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-
-            Divider()
-
-            switch selectedTab.wrappedValue {
-            case .pages:
-                pagesContent
-            case .outputs:
+        Group {
+            switch WorkspaceMailbox.display(store.selection.mailbox) {
+            case WorkspaceMailbox.outputs:
                 OutputsPane(source: source)
-            case .publish:
+            case WorkspaceMailbox.publish:
                 PublishPane(source: source)
-            case .plan:
+            case WorkspaceMailbox.plan:
                 PlanPane(source: source)
-            case .activity:
+            case WorkspaceMailbox.activity:
                 ActivityPane()
+            default:
+                pagesMailbox
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -78,8 +54,17 @@ struct LocalPlay: PlaySurface {
         return []
     }
 
+    private var selectedPlayPage: PlayPage? {
+        guard
+            let noun = store.selection.noun,
+            noun.kind == "page",
+            case .ready(let pages) = state
+        else { return nil }
+        return pages.first(where: { $0.id == noun.id })
+    }
+
     @ViewBuilder
-    private var pagesContent: some View {
+    private var pagesMailbox: some View {
         switch state {
         case .idle, .reading, .building:
             ProgressView(progressTitle)
@@ -113,7 +98,16 @@ struct LocalPlay: PlaySurface {
                 Button("Try Again") { reload() }
             }
         case .ready(let pages):
-            pageList(pages)
+            VSplitView {
+                pageList(pages)
+                    .frame(minHeight: 120)
+                ReadingPane(
+                    page: selectedPlayPage,
+                    source: source,
+                    loadGeneration: loadGeneration
+                )
+                .frame(minHeight: 160)
+            }
         }
     }
 
@@ -128,8 +122,17 @@ struct LocalPlay: PlaySurface {
                 List(filtered, selection: selectedPageID) { page in
                     PageRow(page: page, findings: runtime.coordinator.checkFindings)
                         .tag(page.id)
+                        .simultaneousGesture(TapGesture(count: 2).onEnded {
+                            selectPage(page)
+                            openWindow(id: CompanionID.editor)
+                        })
                 }
                 .listStyle(.inset(alternatesRowBackgrounds: true))
+                .onKeyPress(.return) {
+                    guard store.selection.canEditPage else { return .ignored }
+                    openWindow(id: CompanionID.editor)
+                    return .handled
+                }
             }
         }
         .searchable(text: $searchText, prompt: "Filter by title, id, tag, or status…")
@@ -142,6 +145,10 @@ struct LocalPlay: PlaySurface {
                 return noun?.kind == "page" ? noun?.id : nil
             },
             set: { newID in
+                let currentID = store.selection.noun?.kind == "page" ? store.selection.noun?.id : nil
+                if newID != nil, newID == currentID {
+                    loadGeneration += 1
+                }
                 guard
                     let newID,
                     case .ready(let pages) = state,
@@ -150,10 +157,19 @@ struct LocalPlay: PlaySurface {
                     store.select(noun: nil)
                     return
                 }
-                store.select(
-                    noun: WorkspaceNoun(kind: "page", id: page.id, title: page.title)
-                )
+                selectPage(page)
             }
+        )
+    }
+
+    private func selectPage(_ page: PlayPage) {
+        store.select(
+            noun: WorkspaceNoun(
+                kind: "page",
+                id: page.id,
+                title: page.title,
+                sourcePath: page.sourcePath
+            )
         )
     }
 
@@ -246,6 +262,27 @@ struct LocalPlay: PlaySurface {
         }
         let pages = LocalPlayGraph.pages(from: graph)
         state = pages.isEmpty ? .empty : .ready(pages)
+        refreshNoun(against: pages)
+    }
+
+    /// Keep the page noun honest after a graph reload: rewrite title +
+    /// `sourcePath` when the id still exists, otherwise drop the letter.
+    private func refreshNoun(against pages: [PlayPage]) {
+        guard store.selection.noun?.kind == "page", let id = store.selection.noun?.id else {
+            return
+        }
+        if let page = pages.first(where: { $0.id == id }) {
+            store.select(
+                noun: WorkspaceNoun(
+                    kind: "page",
+                    id: page.id,
+                    title: page.title,
+                    sourcePath: page.sourcePath
+                )
+            )
+        } else {
+            store.select(noun: nil)
+        }
     }
 
     private func unknownSchemaMessage(_ version: String) -> String {
@@ -267,28 +304,6 @@ struct LocalPlay: PlaySurface {
         case empty
         case ready([PlayPage])
         case failed(String)
-    }
-}
-
-extension LocalPlay.PlayTab {
-    var mailboxKey: String {
-        switch self {
-        case .pages: return WorkspaceMailbox.pages
-        case .outputs: return WorkspaceMailbox.outputs
-        case .publish: return WorkspaceMailbox.publish
-        case .plan: return WorkspaceMailbox.plan
-        case .activity: return WorkspaceMailbox.activity
-        }
-    }
-
-    init(mailbox: String?) {
-        switch WorkspaceMailbox.display(mailbox) {
-        case WorkspaceMailbox.outputs: self = .outputs
-        case WorkspaceMailbox.publish: self = .publish
-        case WorkspaceMailbox.plan: self = .plan
-        case WorkspaceMailbox.activity: self = .activity
-        default: self = .pages
-        }
     }
 }
 

--- a/Sources/Play/Local/ProblemsPane.swift
+++ b/Sources/Play/Local/ProblemsPane.swift
@@ -71,7 +71,23 @@ struct ProblemsPane: View {
 
                 switch resolution {
                 case .page(let pageID, let pageTitle):
-                    store.select(noun: WorkspaceNoun(kind: "page", id: pageID, title: pageTitle))
+                    store.select(mailbox: WorkspaceMailbox.pages)
+                    if let page = pages.first(where: { $0.id == pageID })
+                        ?? LocalPlayGraph.resolvePage(forSourcePath: path, in: pages)
+                    {
+                        store.select(
+                            noun: WorkspaceNoun(
+                                kind: "page",
+                                id: page.id,
+                                title: page.title,
+                                sourcePath: page.sourcePath
+                            )
+                        )
+                    } else {
+                        store.select(
+                            noun: WorkspaceNoun(kind: "page", id: pageID, title: pageTitle)
+                        )
+                    }
                 case .revealFile(let url):
                     NSWorkspace.shared.activateFileViewerSelecting([url])
                 }

--- a/Sources/Play/Local/ReadingPane.swift
+++ b/Sources/Play/Local/ReadingPane.swift
@@ -1,0 +1,362 @@
+import AppKit
+import SwiftUI
+
+/// The letter under the Pages list. Loads the selected page from the shared
+/// preview watch when that session is bound to this source; otherwise a
+/// contract-backed summary. Never `file://`, never a Markdown renderer.
+struct ReadingPane: View {
+    let page: PlayPage?
+    let source: LocalSource
+    let loadGeneration: Int
+
+    @Environment(AppRuntime.self) private var runtime
+    @Environment(\.openWindow) private var openWindow
+
+    @State private var model = ReadingWebModel()
+    @State private var relations: [CompletionRelation] = []
+
+    var body: some View {
+        Group {
+            if let page {
+                letter(for: page)
+            } else {
+                ContentUnavailableView {
+                    Label("No Page Selected", systemImage: "envelope.open")
+                } description: {
+                    Text("Select a page to read it.")
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
+        .task(id: letterIdentity) {
+            await refreshLetter()
+        }
+        .task(id: completionIdentity) {
+            relations = Self.loadRelations(source: source, pageID: page?.id)
+        }
+    }
+
+    // MARK: - Letter
+
+    private func letter(for page: PlayPage) -> some View {
+        VStack(spacing: 0) {
+            header(for: page)
+            Divider()
+            bodyStack(for: page)
+        }
+    }
+
+    private func header(for page: PlayPage) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: page.role == .trunk ? "doc.text" : "doc")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(page.title)
+                    .font(.title2.weight(.semibold))
+                    .lineLimit(1)
+                    .textSelection(.enabled)
+                Text(headerCaption(for: page))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+
+            Spacer(minLength: 12)
+
+            if isShowingServedPage {
+                servedBadge
+            }
+
+            Button {
+                openWindow(id: CompanionID.preview)
+            } label: {
+                Label("Preview", systemImage: "safari")
+            }
+            .help("Open the full-site Preview companion")
+
+            Button {
+                openWindow(id: CompanionID.editor)
+            } label: {
+                Label("Edit", systemImage: "square.and.pencil")
+            }
+            .help("Open the hosted editor for this page")
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .labelStyle(.titleAndIcon)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.bar)
+    }
+
+    private func bodyStack(for page: PlayPage) -> some View {
+        ZStack {
+            switch letterBody {
+            case .starting:
+                ProgressView("Starting preview…")
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .loading:
+                ProgressView("Loading page…")
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .served:
+                ReadingWebView(model: model)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .summary(let caption):
+                summary(for: page, caption: caption)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func summary(for page: PlayPage, caption: String?) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                if let caption {
+                    Label(caption, systemImage: "exclamationmark.triangle")
+                        .font(.callout)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button("Try Again") {
+                        retryServedPage(for: page)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+
+                memoRow("ID", page.id)
+                memoRow("Status", display(page.status))
+                memoRow("Role", page.role == .trunk ? "Trunk" : "Satellite")
+                memoRow("Path", display(page.sourcePath))
+
+                if !page.tags.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Tags")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        FlowTags(tags: page.tags)
+                    }
+                }
+
+                if !relations.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Relations")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        ForEach(Array(relations.enumerated()), id: \.offset) { _, relation in
+                            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                Text(relation.kind)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .frame(minWidth: 72, alignment: .leading)
+                                Text(relation.target)
+                                    .textSelection(.enabled)
+                            }
+                            .font(.callout)
+                        }
+                    }
+                }
+
+                if caption == nil, !isBoundToThisSource || !isServing {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "safari")
+                            .foregroundStyle(.tertiary)
+                        Text("Preview is not running. Open Preview to read the served page here.")
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .font(.callout)
+                    .padding(.top, 4)
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: 640, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func memoRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(label)
+                .foregroundStyle(.secondary)
+                .frame(width: 64, alignment: .trailing)
+            Text(value)
+                .textSelection(.enabled)
+            Spacer(minLength: 0)
+        }
+        .font(.callout)
+    }
+
+    private var servedBadge: some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(Color.green)
+                .frame(width: 7, height: 7)
+            Text("Served")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+        }
+        .help("This page is loaded from the running preview watch.")
+        .padding(.trailing, 4)
+    }
+
+    // MARK: - Watch / load
+
+    private var session: PreviewSession { runtime.previewSession }
+
+    private var isBoundToThisSource: Bool {
+        guard let root = try? source.contentRoot() else { return false }
+        return session.isBound(to: root)
+    }
+
+    private var isServing: Bool {
+        if case .serving = session.phase { return true }
+        return false
+    }
+
+    private var isShowingServedPage: Bool {
+        if case .served = letterBody { return true }
+        return false
+    }
+
+    private enum LetterBody: Equatable {
+        case starting
+        case loading
+        case served
+        case summary(caption: String?)
+    }
+
+    private var letterBody: LetterBody {
+        guard page != nil else { return .summary(caption: nil) }
+        if isBoundToThisSource {
+            switch session.phase {
+            case .starting:
+                return .starting
+            case .serving:
+                switch model.outcome {
+                case .idle, .loading:
+                    return .loading
+                case .loaded:
+                    return .served
+                case .unavailable(let caption), .failed(let caption):
+                    return .summary(caption: caption)
+                }
+            case .idle, .failed:
+                return .summary(caption: nil)
+            }
+        }
+        return .summary(caption: nil)
+    }
+
+    private var letterIdentity: String {
+        let phaseKey: String
+        switch session.phase {
+        case .idle:
+            phaseKey = "idle"
+        case .starting:
+            phaseKey = "starting"
+        case .serving(let url):
+            phaseKey = "serving:\(url.absoluteString)"
+        case .failed:
+            phaseKey = "failed"
+        }
+        return "\(loadGeneration)|\(page?.id ?? "")|\(phaseKey)|\(isBoundToThisSource)"
+    }
+
+    private var completionIdentity: String {
+        "\(source.id.raw.uuidString)|\(page?.id ?? "")"
+    }
+
+    @MainActor
+    private func refreshLetter() async {
+        guard let page else {
+            model.reset()
+            return
+        }
+        guard isBoundToThisSource else {
+            model.reset()
+            return
+        }
+        switch session.phase {
+        case .serving(let helper):
+            guard let url = PreviewURL.pageURL(helper: helper, pageID: page.id) else {
+                model.fail("Could not derive a served URL for this page.")
+                return
+            }
+            model.load(url: url)
+        case .starting, .idle, .failed:
+            model.reset()
+        }
+    }
+
+    private func retryServedPage(for page: PlayPage) {
+        guard
+            isBoundToThisSource,
+            case .serving(let helper) = session.phase,
+            let url = PreviewURL.pageURL(helper: helper, pageID: page.id)
+        else { return }
+        model.retry(url: url)
+    }
+
+    private func headerCaption(for page: PlayPage) -> String {
+        var parts: [String] = []
+        let path = page.sourcePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !path.isEmpty { parts.append(path) }
+        if !page.status.isEmpty { parts.append(page.status) }
+        parts.append(page.role == .trunk ? "Trunk" : "Satellite")
+        return parts.joined(separator: "  ·  ")
+    }
+
+    private func display(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "—" : trimmed
+    }
+
+    /// Decode `.boris/completion.json` the same way Play reads `graph.json`.
+    /// Failure omits relations (D8). Does not import Inspector.
+    private static func loadRelations(source: LocalSource, pageID: String?) -> [CompletionRelation] {
+        guard
+            let pageID,
+            source.isAvailable,
+            let root = try? source.resolve().url
+        else { return [] }
+        let url = root
+            .appendingPathComponent(".boris", isDirectory: true)
+            .appendingPathComponent("completion.json")
+        guard
+            FileManager.default.fileExists(atPath: url.path),
+            let data = try? Data(contentsOf: url),
+            let completion = try? JSONDecoder().decode(Completion.self, from: data),
+            let entity = completion.entities.first(where: { $0.id == pageID })
+        else { return [] }
+        return entity.relations
+    }
+}
+
+/// Compact wrapping chips for graph tags.
+private struct FlowTags: View {
+    let tags: [String]
+
+    var body: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 52), spacing: 6, alignment: .leading)],
+            alignment: .leading,
+            spacing: 6
+        ) {
+            ForEach(tags, id: \.self) { tag in
+                Text(tag)
+                    .font(.caption2.weight(.medium))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.quaternary, in: Capsule())
+            }
+        }
+    }
+}

--- a/Sources/Play/Local/ReadingWebView.swift
+++ b/Sources/Play/Local/ReadingWebView.swift
@@ -1,0 +1,139 @@
+import Observation
+import SwiftUI
+import WebKit
+
+/// Navigation outcome for the reading-pane web view. 404 and transport
+/// failure fall back to the contract summary; the model never loads `file://`.
+enum ReadingLoadOutcome: Equatable {
+    case idle
+    case loading
+    case loaded
+    case unavailable(String)
+    case failed(String)
+}
+
+/// Owns the letter's `WKWebView`. Main-actor confined; Play is the only client.
+@MainActor
+@Observable
+final class ReadingWebModel: NSObject {
+    let webView: WKWebView
+    private(set) var outcome: ReadingLoadOutcome = .idle
+
+    override init() {
+        webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        super.init()
+        webView.navigationDelegate = self
+        webView.allowsMagnification = true
+    }
+
+    func load(url: URL) {
+        guard PreviewURL.isAllowed(url) else {
+            outcome = .failed("Only loopback URLs are allowed.")
+            return
+        }
+        outcome = .loading
+        webView.stopLoading()
+        webView.load(URLRequest(url: url))
+    }
+
+    func reset() {
+        outcome = .idle
+        webView.stopLoading()
+    }
+
+    func retry(url: URL) {
+        load(url: url)
+    }
+
+    func fail(_ message: String) {
+        outcome = .failed(message)
+    }
+
+    private func handleHTTPFailure(_ status: Int) {
+        let caption: String
+        if status == 404 {
+            caption = "This page is not at the served URL yet. Build HTML or wait for watch."
+        } else {
+            caption = "The served page returned HTTP \(status)."
+        }
+        outcome = status == 404 ? .unavailable(caption) : .failed(caption)
+    }
+
+    private func handleTransportFailure(_ error: Error) {
+        if case .unavailable = outcome { return }
+        if case .failed = outcome { return }
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            return
+        }
+        outcome = .failed(error.localizedDescription)
+    }
+}
+
+extension ReadingWebModel: WKNavigationDelegate {
+    nonisolated func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        let url = navigationAction.request.url
+        let allowed = url.map { PreviewURL.isAllowed($0) } ?? false
+        decisionHandler(allowed ? .allow : .cancel)
+    }
+
+    nonisolated func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        let status = (navigationResponse.response as? HTTPURLResponse)?.statusCode
+        if navigationResponse.isForMainFrame, let status, status >= 400 {
+            decisionHandler(.cancel)
+            Task { @MainActor in
+                self.handleHTTPFailure(status)
+            }
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    nonisolated func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        Task { @MainActor in
+            self.handleTransportFailure(error)
+        }
+    }
+
+    nonisolated func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        Task { @MainActor in
+            self.handleTransportFailure(error)
+        }
+    }
+
+    nonisolated func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        Task { @MainActor in
+            guard self.outcome == .loading else { return }
+            self.outcome = .loaded
+        }
+    }
+}
+
+/// Hosts `ReadingWebModel.webView`. Navigation stays on the model.
+struct ReadingWebView: NSViewRepresentable {
+    let model: ReadingWebModel
+
+    func makeNSView(context: Context) -> WKWebView {
+        model.webView
+    }
+
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        // No-op: the model owns all navigation.
+    }
+}

--- a/Sources/Play/Local/ReadingWebView.swift
+++ b/Sources/Play/Local/ReadingWebView.swift
@@ -71,7 +71,7 @@ final class ReadingWebModel: NSObject {
 }
 
 extension ReadingWebModel: WKNavigationDelegate {
-    nonisolated func webView(
+    func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
@@ -81,7 +81,7 @@ extension ReadingWebModel: WKNavigationDelegate {
         decisionHandler(allowed ? .allow : .cancel)
     }
 
-    nonisolated func webView(
+    func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
@@ -89,39 +89,27 @@ extension ReadingWebModel: WKNavigationDelegate {
         let status = (navigationResponse.response as? HTTPURLResponse)?.statusCode
         if navigationResponse.isForMainFrame, let status, status >= 400 {
             decisionHandler(.cancel)
-            Task { @MainActor in
-                self.handleHTTPFailure(status)
-            }
+            handleHTTPFailure(status)
             return
         }
         decisionHandler(.allow)
     }
 
-    nonisolated func webView(
-        _ webView: WKWebView,
-        didFail navigation: WKNavigation!,
-        withError error: Error
-    ) {
-        Task { @MainActor in
-            self.handleTransportFailure(error)
-        }
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        handleTransportFailure(error)
     }
 
-    nonisolated func webView(
+    func webView(
         _ webView: WKWebView,
         didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: Error
     ) {
-        Task { @MainActor in
-            self.handleTransportFailure(error)
-        }
+        handleTransportFailure(error)
     }
 
-    nonisolated func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        Task { @MainActor in
-            guard self.outcome == .loading else { return }
-            self.outcome = .loaded
-        }
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard outcome == .loading else { return }
+        outcome = .loaded
     }
 }
 

--- a/Tests/ContractTests/CompanionURLTests.swift
+++ b/Tests/ContractTests/CompanionURLTests.swift
@@ -123,4 +123,65 @@ final class CompanionURLTests: XCTestCase {
         XCTAssertFalse(PreviewURL.isLoopback(file))
         XCTAssertFalse(PreviewURL.isAllowed(file))
     }
+
+    func testPreviewURLSiteOriginFromHelper() throws {
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/__boris/"))
+        let origin = try XCTUnwrap(PreviewURL.siteOrigin(fromHelper: helper))
+        XCTAssertEqual(origin.scheme, "http")
+        XCTAssertEqual(origin.host, "127.0.0.1")
+        XCTAssertEqual(origin.port, 8080)
+        XCTAssertEqual(origin.path, "/")
+        XCTAssertNil(origin.query)
+        XCTAssertNil(origin.fragment)
+    }
+
+    func testPreviewURLSiteOriginWithoutTrailingSlash() throws {
+        let helper = try XCTUnwrap(URL(string: "http://localhost:3000/__boris"))
+        let origin = try XCTUnwrap(PreviewURL.siteOrigin(fromHelper: helper))
+        XCTAssertEqual(origin.host, "localhost")
+        XCTAssertEqual(origin.port, 3000)
+        XCTAssertEqual(origin.path, "/")
+    }
+
+    func testPreviewURLSiteOriginStripsQueryAndFragment() throws {
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/__boris/?x=1#frag"))
+        let origin = try XCTUnwrap(PreviewURL.siteOrigin(fromHelper: helper))
+        XCTAssertEqual(origin.path, "/")
+        XCTAssertNil(origin.query)
+        XCTAssertNil(origin.fragment)
+    }
+
+    func testPreviewURLPageURLFromGraphIDs() throws {
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:49152/__boris/"))
+        let index = try XCTUnwrap(PreviewURL.pageURL(helper: helper, pageID: "index"))
+        XCTAssertEqual(index.absoluteString, "http://127.0.0.1:49152/index.html")
+        let nested = try XCTUnwrap(PreviewURL.pageURL(helper: helper, pageID: "guides/getting-started"))
+        XCTAssertEqual(nested.absoluteString, "http://127.0.0.1:49152/guides/getting-started.html")
+        let cook = try XCTUnwrap(PreviewURL.pageURL(helper: helper, pageID: "recipe/soup"))
+        XCTAssertEqual(cook.absoluteString, "http://127.0.0.1:49152/recipe/soup.html")
+    }
+
+    func testPreviewURLPageURLTrimsSlashes() throws {
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/__boris/"))
+        let url = try XCTUnwrap(PreviewURL.pageURL(helper: helper, pageID: "/guides/getting-started/"))
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:8080/guides/getting-started.html")
+    }
+
+    func testPreviewURLPageURLRejectsEmptyID() throws {
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/__boris/"))
+        XCTAssertNil(PreviewURL.pageURL(helper: helper, pageID: ""))
+        XCTAssertNil(PreviewURL.pageURL(helper: helper, pageID: "///"))
+    }
+
+    func testPreviewURLSiteOriginRejectsNonLoopback() throws {
+        let remote = try XCTUnwrap(URL(string: "http://example.com/__boris/"))
+        XCTAssertNil(PreviewURL.siteOrigin(fromHelper: remote))
+        XCTAssertNil(PreviewURL.pageURL(helper: remote, pageID: "index"))
+    }
+
+    func testPreviewURLPageURLRejectsFile() throws {
+        let file = try XCTUnwrap(URL(string: "file:///tmp/index.html"))
+        XCTAssertNil(PreviewURL.siteOrigin(fromHelper: file))
+        XCTAssertNil(PreviewURL.pageURL(helper: file, pageID: "index"))
+    }
 }


### PR DESCRIPTION
Closes #101.

Mail's middle is now the selected mailbox's contents plus, for Pages, the letter.

**Pages.** Graph list above, reading pane below (`VSplitView`). Click a page: if the shared preview watch is up and bound to this source, the letter loads `GET /{GraphNode.id}.html`. Otherwise a contract summary (title, id, status, role, path, tags, relations from `completion.json`) with Preview / Edit. 404 and load failure fall back to that summary in-pane. Double-click or Return opens the hosted editor.

**Other mailboxes.** Outputs / Publish / Plan / Activity stay the existing full-height panes. The tab picker is gone. Problems stay under the reading place.

**One watch.** `PreviewSession` lives on `AppRuntime`. `PlayHost` binds it to the selected source (retarget if serving, stop if no source, never auto-start from idle). Closing Preview does not stop the watch. A foreign-root serve is treated as idle.

**Not this PR.** No `file://`. No Swift Markdown. No second `Process`. `MainWindow`, Engine, Inspector, and the sidebar are untouched.

**Verify.** `SKIP_EMBED_BORIS=1 make build` and `make test` are green. Hand-gate on `Stunts/happy`: select Pages, click a page → summary (and the served page if Preview is already running for that source). Select Outputs → outputs pane, no tab bar.