### PR TITLE
fix(site): align home hero with the article column

### DIFF
--- a/site/themes/boris/assets/css/boris.css
+++ b/site/themes/boris/assets/css/boris.css
@@ -618,12 +618,11 @@ a:hover { color: var(--accent-strong); }
 
 /* ---------- Home ---------- */
 
-.app-main--home { display: flex; flex-direction: column; }
 .app-main--home .site-hero {
   width: 100%;
-  max-width: 48rem;
-  margin-block: auto;
-  padding: clamp(2rem, 5vw, 3.5rem);
+  max-width: var(--article-w);
+  margin-inline: auto;
+  padding: clamp(1.5rem, 4vw, 2.75rem);
   background:
     radial-gradient(60rem 22rem at 12% -4%, color-mix(in srgb, var(--accent) 12%, transparent), transparent 60%),
     linear-gradient(180deg, var(--surface), var(--surface));
@@ -778,8 +777,6 @@ a:hover { color: var(--accent-strong); }
   }
 
   .app-main { overflow: visible; padding: 1.2rem 1rem 2rem; }
-  .app-main--home { display: block; }
-  .app-main--home .site-hero { margin-block: 0; }
 
   .app-drawer {
     overflow: visible;


### PR DESCRIPTION
## Card

other (site theme follow-up to #107)

## What

#107 was merged before the follow-up fix landed. The index hero was vertically centered, 48rem wide, and padded differently from the article cards on inner pages. It now shares the article's `--article-w` column, top alignment, and card padding.

Pixel-verified at 1440x900: both cards span x 366→1101; the only residual vertical offset is the breadcrumb row inner pages render above the article — the root page correctly omits it.

## Gate

- [x] `boris/0.8.1` build ok, `check-site-links.py` ok
- [x] Pixel-sampled screenshots: hero and article columns identical
- [x] Did not touch `boris/` or commit `SUPPORT-NOT-FOR-GITHUB/`