### PR TITLE
fix(ci): release workflow fails validation on secrets.* in steps.if (#110)

### DIFF
--- a/.github/workflows/release-notarize.yml
+++ b/.github/workflows/release-notarize.yml
@@ -20,6 +20,16 @@ jobs:
   build-and-notarize:
     name: Build, Sign & Notarize Universal macOS App
     runs-on: macos-15
+    # Repo default GITHUB_TOKEN is read-only; softprops/action-gh-release needs write.
+    permissions:
+      contents: write
+    # secrets.* is illegal in steps.if and GitHub rejects the whole workflow at
+    # startup (empty jobs, "workflow file issue"). Job-level env is the documented
+    # gate; an unset secret is an empty string and the step is skipped.
+    env:
+      APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+      CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}
 
     steps:
       - name: Checkout repository
@@ -62,7 +72,7 @@ jobs:
           make generate
 
       - name: Set up Signing Keychain
-        if: ${{ secrets.APPLE_CERTIFICATE_BASE64 != '' }}
+        if: ${{ env.APPLE_CERTIFICATE_BASE64 != '' }}
         env:
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -105,14 +115,14 @@ jobs:
             "$DMG_PATH"
 
       - name: Sign DMG
-        if: ${{ secrets.CODE_SIGN_IDENTITY != '' && secrets.CODE_SIGN_IDENTITY != '-' }}
+        if: ${{ env.CODE_SIGN_IDENTITY != '' && env.CODE_SIGN_IDENTITY != '-' }}
         env:
           CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}
         run: |
           codesign --force --sign "$CODE_SIGN_IDENTITY" --timestamp dist/Solipsist.dmg
 
       - name: Notarize App & DMG
-        if: ${{ inputs.skip_notarize != true && secrets.APPLE_API_KEY_BASE64 != '' }}
+        if: ${{ inputs.skip_notarize != true && env.APPLE_API_KEY_BASE64 != '' }}
         env:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -148,7 +158,7 @@ jobs:
       # Hard Gatekeeper gate for real releases (a Developer ID is configured).
       # Ad-hoc/dev builds skip: spctl cannot pass without a Developer ID root.
       - name: Verify Gatekeeper assessment
-        if: ${{ secrets.CODE_SIGN_IDENTITY != '' && secrets.CODE_SIGN_IDENTITY != '-' }}
+        if: ${{ env.CODE_SIGN_IDENTITY != '' && env.CODE_SIGN_IDENTITY != '-' }}
         run: |
           APP_PATH="build/Build/Products/Release/Solipsist.app"
           echo "==> spctl --assess -vvv (app-bundle invocation)"

--- a/docs/SHIP-HARDENING.md
+++ b/docs/SHIP-HARDENING.md
@@ -91,10 +91,14 @@ phase lipo-merges a fat engine (no `GITHUB_ACTIONS` skip — that opt-out is
 now explicit `SKIP_EMBED_BORIS=1`, set by the PR compile job only), pins
 `ARCHS="arm64 x86_64"` for the app build, and **fails** if
 `Contents/Resources/boris` is missing from the release bundle. Signing and
-notarization steps are gated on `secrets.*` (not step-level `env.*`, which
-is invisible to `if:`), and `spctl --assess -vvv` on the app bundle is a
+notarization steps are gated on **job-level** `env.*` mapped from
+`secrets.*` (`secrets` is illegal in `steps.if` and GitHub rejects the
+workflow at startup; step-level `env.*` is invisible to that step's
+`if:`), and `spctl --assess -vvv` on the app bundle is a
 **hard** gate when a Developer ID is configured (skipped only for ad-hoc
-dev builds, where it cannot pass).
+dev builds, where it cannot pass). The publish step sets
+`permissions: contents: write` because this repo's default `GITHUB_TOKEN`
+is read-only.
 
 ---
 


### PR DESCRIPTION
## Card

ops(m9) / #110 — Apple signing secrets and first notarized `v*` release

## What

`release-notarize.yml` never starts. `secrets.*` in `steps.if` is illegal ([context availability](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability): `jobs.<job_id>.steps.if` may see `env`, not `secrets`). GitHub rejects the file at startup: empty `jobs: []`, banner *"This run likely failed because of a workflow file issue."* Example on `main`: https://github.com/drawmeanelephant/solipsist/actions/runs/32135794257

A `v*` tag would fail the same way **after** Apple secrets land. The #78 switch from step-level `env` to `secrets.*` in `if:` is the wrong half of the right diagnosis: step-level `env` is invisible to that step's `if:`; **job-level** `env` is the documented gate.

This PR:

- Maps `APPLE_CERTIFICATE_BASE64`, `APPLE_API_KEY_BASE64`, and `CODE_SIGN_IDENTITY` to job-level `env` and gates the four steps on `env.*`
- Sets `permissions: contents: write` — repo `default_workflow_permissions` is `read`, so `softprops/action-gh-release` would 403 after a successful notarize
- Corrects the same sentence in `docs/SHIP-HARDENING.md` so the illegal pattern is not put back

Did not cut a `v*` tag. Did not invent secrets. `gh secret list` is still only `CLOUDFLARE_*`.

## Gate

- [x] Did not touch `Sources/**`, `boris/`, or `SUPPORT-NOT-FOR-GITHUB/`
- [x] `actionlint` no longer reports `secrets` context in `steps.if` (pre-existing shellcheck on the keychain script unchanged)
- [ ] CI `spike` + `app` green
- [ ] After merge + Apple secrets: tag `v0.1.0` (`Project.yml` `MARKETING_VERSION`) and confirm stapled `Solipsist.dmg` + hard `spctl --assess -vvv`

Operator steps are on #110.