### PR TITLE
ci(m9): run spike against a built boris

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Same pin as release-notarize.yml (D7). #109 will advance both.
+      # Same pin as #116 / release-notarize.yml (afterparty, boris#648).
       - name: Checkout pinned Boris engine
         uses: actions/checkout@v7
         with:
           repository: drawmeanelephant/boris
           path: boris
-          ref: b82e9e2eace74d9ca61df23dffc1329d2a2fe628
+          ref: 6b930b7bd35a1803b365a073c226df22631dc3f7
 
       - name: Install Zig
         uses: mlugg/setup-zig@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,34 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
-      - name: Generate project and compile spike
-        run: make spike
-      # Running the spike needs a boris binary. We do not vendor that.
+
+      # Same pin as release-notarize.yml (D7). #109 will advance both.
+      - name: Checkout pinned Boris engine
+        uses: actions/checkout@v7
+        with:
+          repository: drawmeanelephant/boris
+          path: boris
+          ref: b82e9e2eace74d9ca61df23dffc1329d2a2fe628
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      # Host-only (macos-15 is arm64). Release still cross-builds fat slices.
+      - name: Build host Boris
+        run: |
+          cd boris
+          zig build -Doptimize=ReleaseFast
+
+      - name: Generate project, compile, and run spike
+        env:
+          SOLIPSIST_BORIS_BIN: ${{ github.workspace }}/boris/zig-out/bin/boris
+        run: |
+          set -euo pipefail
+          test -x "$SOLIPSIST_BORIS_BIN"
+          make run-spike SPIKE_CONTENT="${{ github.workspace }}/boris/content" | tee "$RUNNER_TEMP/spike.out"
+          grep -q "SPIKE OK" "$RUNNER_TEMP/spike.out"
 
   app:
     name: app

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ zig-out/
 # Transport binaries — never GitHub
 SUPPORT-NOT-FOR-GITHUB/
 /boris-agent-kit/
+/boris/
 *.tar.gz
 
 # Stunt harvest leftovers

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 
 XCODEGEN := .tools/xcodegen/xcodegen/bin/xcodegen
 PROJECT  := Solipsist.xcodeproj
+# Empty SPIKE_CONTENT = spike default ../boris/content.
+SPIKE_CONTENT ?=
 
 .PHONY: tools generate build spike run-spike test lint harvest-fixtures site check-site clean fart
 
@@ -32,7 +34,7 @@ spike: generate
 		-derivedDataPath build build
 
 run-spike: spike
-	build/Build/Products/Debug/boris-spike
+	build/Build/Products/Debug/boris-spike $(SPIKE_CONTENT)
 
 test: generate
 	xcodebuild -project $(PROJECT) -scheme ContractTests -configuration Debug \

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Run `make test` to execute contract decoding tests against checked-in fixtures, 
 
 ## CI
 
-PRs to `main` run GitHub Actions (`spike` compile, `app` compile, `fixtures` contract tests, and `lint`).
-There is no boris binary in CI, so the spike is compile-only and the
-app embeds nothing. A `fart` job is reserved and disabled.
+PRs to `main` run GitHub Actions (`spike` against a pin-built boris,
+`app` compile, `fixtures` contract tests, and `lint`). The app job
+still sets `SKIP_EMBED_BORIS=1` — no engine binary is vendored. A
+`fart` job is reserved and disabled.
 
 ## Boundaries
 


### PR DESCRIPTION
Closes #112

The `spike` job checks out pinned `boris` at `6b930b7bd35a1803b365a073c226df22631dc3f7` (same pin as #116 / afterparty merge of boris#648), host-builds it with Zig 0.16.0, and runs:

```
SOLIPSIST_BORIS_BIN=$GITHUB_WORKSPACE/boris/zig-out/bin/boris \
  make run-spike SPIKE_CONTENT=$GITHUB_WORKSPACE/boris/content
```

The step uses `set -o pipefail`, does not swallow the spike's exit code, and `grep -q "SPIKE OK"` so a missing `SPIKE OK` line fails the job even if something else exited 0.

No engine binary is vendored (`/boris/` is gitignored). The `app` job still sets `SKIP_EMBED_BORIS=1`. `make test` / the `fixtures` job still decode checked-in contracts and need no binary.

This PR no longer waits on #109 — it already uses the new pin. `release-notarize.yml` stays owned by #115/#116.