### PR TITLE
feat(editor): Edit Page, editor nav chrome, and macOS 27 target

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,8 +11,8 @@ body:
     id: macos_version
     attributes:
       label: macOS Version
-      description: e.g. macOS Sonoma 14.5, Sequoia 15.0
-      placeholder: macOS 14.5
+      description: e.g. macOS 27.5 (Golden Gate), 26.5 (Tahoe)
+      placeholder: macOS 27.5
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,8 +11,8 @@ body:
     id: macos_version
     attributes:
       label: macOS Version
-      description: e.g. macOS 27.5 (Golden Gate), 26.5 (Tahoe)
-      placeholder: macOS 27.5
+      description: e.g. macOS 26.5 (Tahoe), 27.5 (Golden Gate)
+      placeholder: macOS 26.5
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   lint:
     name: lint
-    runs-on: macos-15
+    runs-on: xcode-27
     steps:
       - uses: actions/checkout@v7
       - name: Install swiftformat & swiftlint
@@ -24,7 +24,7 @@ jobs:
 
   spike:
     name: spike
-    runs-on: macos-15
+    runs-on: xcode-27
     steps:
       - uses: actions/checkout@v7
 
@@ -58,7 +58,7 @@ jobs:
 
   app:
     name: app
-    runs-on: macos-15
+    runs-on: xcode-27
     env:
       SKIP_EMBED_BORIS: "1"
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   fixtures:
     name: fixtures
-    runs-on: macos-15
+    runs-on: xcode-27
     steps:
       - uses: actions/checkout@v7
       - name: Decode checked-in contract fixtures

--- a/.github/workflows/release-notarize.yml
+++ b/.github/workflows/release-notarize.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-and-notarize:
     name: Build, Sign & Notarize Universal macOS App
-    runs-on: macos-15
+    runs-on: xcode-27
     # Repo default GITHUB_TOKEN is read-only; softprops/action-gh-release needs write.
     permissions:
       contents: write

--- a/Project.yml
+++ b/Project.yml
@@ -7,7 +7,7 @@ name: Solipsist
 options:
   bundleIdPrefix: dev.drawmeanelephant
   deploymentTarget:
-    macOS: "27.0"
+    macOS: "26.0"
   createIntermediateGroups: true
 
 settings:
@@ -16,7 +16,7 @@ settings:
     SWIFT_STRICT_CONCURRENCY: complete
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
-    MACOSX_DEPLOYMENT_TARGET: "27.0"
+    MACOSX_DEPLOYMENT_TARGET: "26.0"
     # Local dev builds: ad-hoc sign to run locally (no team required).
     CODE_SIGN_STYLE: Manual
     CODE_SIGN_IDENTITY: "-"

--- a/Project.yml
+++ b/Project.yml
@@ -7,7 +7,7 @@ name: Solipsist
 options:
   bundleIdPrefix: dev.drawmeanelephant
   deploymentTarget:
-    macOS: "14.0"
+    macOS: "27.0"
   createIntermediateGroups: true
 
 settings:
@@ -16,7 +16,7 @@ settings:
     SWIFT_STRICT_CONCURRENCY: complete
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
-    MACOSX_DEPLOYMENT_TARGET: "14.0"
+    MACOSX_DEPLOYMENT_TARGET: "27.0"
     # Local dev builds: ad-hoc sign to run locally (no team required).
     CODE_SIGN_STYLE: Manual
     CODE_SIGN_IDENTITY: "-"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Never commit `SUPPORT-NOT-FOR-GITHUB/` or engine binaries.
 
 ## Prerequisites
 
-- macOS 14+ arm64
-- Xcode 16+ (tested Xcode 27 / Swift 6)
+- macOS 27+ (arm64 + x86_64)
+- Xcode 27+ (Swift 6)
 - Zig 0.16+ only if you must *rebuild* the engine
 - XcodeGen is vendored into `.tools/` by `make tools`
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Never commit `SUPPORT-NOT-FOR-GITHUB/` or engine binaries.
 
 ## Prerequisites
 
-- macOS 27+ (arm64 + x86_64)
-- Xcode 27+ (Swift 6)
+- macOS 26+ (arm64 + x86_64)
+- Xcode 26+ (tested Xcode 27 / Swift 6)
 - Zig 0.16+ only if you must *rebuild* the engine
 - XcodeGen is vendored into `.tools/` by `make tools`
 

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -49,6 +49,13 @@ struct SolipsistCommands: Commands {
                 }
             }
             .disabled(store.selection.sourceID == nil)
+
+            Divider()
+
+            Button("Edit Page") {
+                openWindow(id: CompanionID.editor)
+            }
+            .disabled(!store.selection.canEditPage)
         }
 
         CommandMenu("Boris") {

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -19,6 +19,7 @@ struct MainWindow: View {
         } detail: {
             PlayHost()
         }
+        .glassEffect()
         .navigationTitle("Solipsist")
         .inspector(isPresented: $inspectorPresented) {
             InspectorDrawer()

--- a/Sources/Companions/Editor/EditorSession.swift
+++ b/Sources/Companions/Editor/EditorSession.swift
@@ -41,8 +41,18 @@ final class EditorSession {
     private var server: EditorServer?
     private var rootPath: String?
     private var timeoutTask: Task<Void, Never>?
+    private var lastContentRoot: URL?
+    private var lastProjectRoot: URL?
+    private var lastEngine: BorisEngine?
+
+    var canRestart: Bool {
+        lastContentRoot != nil
+    }
 
     func start(contentRoot: URL, projectRoot: URL, engine: BorisEngine?) {
+        lastContentRoot = contentRoot
+        lastProjectRoot = projectRoot
+        lastEngine = engine
         let root = contentRoot.standardizedFileURL.path
         if root == rootPath, let server, server.isRunning {
             if let url = server.editorURL {
@@ -84,6 +94,15 @@ final class EditorSession {
             timeoutTask = nil
             phase = .failed("Could not start editor host: \(error)")
         }
+    }
+
+    /// Tears down the current host (if any) and starts a fresh one for the
+    /// same content root. A new random token URL is printed by the new host,
+    /// so the web view reconnects via the existing `editorURL` observation.
+    func restart() {
+        guard let contentRoot = lastContentRoot, let projectRoot = lastProjectRoot else { return }
+        stop()
+        start(contentRoot: contentRoot, projectRoot: projectRoot, engine: lastEngine)
     }
 
     func fail(_ message: String) {

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -4,11 +4,12 @@ import SwiftUI
 import WebKit
 
 /// Companion host for `boris-editor` (Svelte). Chassis registers the window
-/// and leaves it closed. The Editor lane owns this file.
+/// and leaves it closed; the editor opens against the selected page.
 ///
-/// The grind lane will later add engine-spawned editor tokens and call
-/// `loadEditor(url:)`. Until then the window shows the editor status and
-/// lets a human paste a `BORIS_EDITOR_URL=` token line into the toolbar.
+/// The window starts an `EditorSession` for the selected source's content
+/// root, then loads the tokenized `BORIS_EDITOR_URL=` into the web view. The
+/// header names the selected page and its `sourcePath`. Manual URL paste and
+/// "Open in Browser" stay as the loopback fallback.
 struct EditorWindow: View {
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
@@ -104,10 +105,10 @@ struct EditorWindow: View {
     private func header(for source: SourceItem) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text(source.title)
+                Text(headerTitle(for: source))
                     .font(.headline)
                     .lineLimit(1)
-                if let path = source.detailLine {
+                if let path = headerSubtitle(for: source) {
                     Text(path)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -121,14 +122,43 @@ struct EditorWindow: View {
         .padding(.vertical, 6)
     }
 
-    private var toolbar: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
-                TextField("BORIS_EDITOR_URL=http://127.0.0.1:49152/#token=…", text: $urlText)
-                    .textFieldStyle(.roundedBorder)
-                    .onSubmit(submit)
+    /// Mail-compose chrome: when the editor was opened from a page, name that
+    /// page; otherwise fall back to the source itself.
+    private func headerTitle(for source: SourceItem) -> String {
+        if let noun = store.selection.noun, noun.kind == "page", !noun.title.isEmpty {
+            return noun.title
+        }
+        return source.title
+    }
 
-                Button("Connect", action: submit)
+    private func headerSubtitle(for source: SourceItem) -> String? {
+        if let noun = store.selection.noun, noun.kind == "page", let path = noun.sourcePath, !path.isEmpty {
+            return path
+        }
+        return source.detailLine
+    }
+
+    private var toolbar: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                navButtons
+
+                if model.isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                phaseIndicator
+
+                Spacer()
+
+                Button {
+                    session.restart()
+                } label: {
+                    Label("Restart Host", systemImage: "arrow.counterclockwise")
+                }
+                .help("Restart boris-editor")
+                .disabled(!session.canRestart)
 
                 Button {
                     model.openInBrowser()
@@ -138,6 +168,15 @@ struct EditorWindow: View {
                 .help("Open in Browser")
                 .disabled(!model.canOpenInBrowser)
             }
+
+            HStack(spacing: 8) {
+                TextField("BORIS_EDITOR_URL=http://127.0.0.1:49152/#token=…", text: $urlText)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit(submit)
+
+                Button("Connect", action: submit)
+            }
+
             if let rejection = model.rejection {
                 Text(rejection)
                     .font(.caption)
@@ -145,6 +184,80 @@ struct EditorWindow: View {
             }
         }
         .padding(8)
+    }
+
+    private var navButtons: some View {
+        HStack(spacing: 2) {
+            Button {
+                model.goBack()
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+            .help("Back")
+            .disabled(!model.canGoBack)
+
+            Button {
+                model.goForward()
+            } label: {
+                Image(systemName: "chevron.right")
+            }
+            .help("Forward")
+            .disabled(!model.canGoForward)
+
+            Button {
+                model.reload()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .help("Reload")
+            .disabled(!model.canReload)
+        }
+        .buttonStyle(.borderless)
+    }
+
+    private var phaseIndicator: some View {
+        HStack(spacing: 5) {
+            phaseIcon
+            Text(phaseLabel)
+                .font(.caption)
+                .foregroundStyle(phaseColor)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    @ViewBuilder
+    private var phaseIcon: some View {
+        switch session.phase {
+        case .idle:
+            Image(systemName: "circle.dotted")
+        case .starting:
+            ProgressView()
+                .controlSize(.small)
+        case .connected:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .failed:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+        }
+    }
+
+    private var phaseLabel: String {
+        switch session.phase {
+        case .idle:
+            return "Not connected"
+        case .starting:
+            return "Starting boris-editor…"
+        case .connected(let url):
+            return "Connected · \(url.host ?? "loopback")"
+        case .failed(let message):
+            return message
+        }
+    }
+
+    private var phaseColor: Color {
+        session.isFailure ? .red : .secondary
     }
 
     private func submit() {
@@ -162,11 +275,27 @@ struct EditorWindow: View {
 /// Owns the `WKWebView` and navigation state for the Editor companion.
 @MainActor
 @Observable
-final class EditorWebModel {
-    let webView = WKWebView()
+final class EditorWebModel: NSObject {
+    let webView: WKWebView
 
     private(set) var currentURL: URL?
     private(set) var rejection: String?
+    private(set) var isLoading = false
+    private(set) var canGoBack = false
+    private(set) var canGoForward = false
+
+    @ObservationIgnored
+    private var observations: [NSKeyValueObservation] = []
+
+    override init() {
+        webView = WKWebView()
+        super.init()
+        observeNavigation()
+    }
+
+    var canReload: Bool {
+        currentURL != nil || webView.url != nil
+    }
 
     var canOpenInBrowser: Bool {
         guard let url = currentURL else { return false }
@@ -188,9 +317,51 @@ final class EditorWebModel {
         rejection = message
     }
 
+    func reload() {
+        if webView.url != nil {
+            webView.reload()
+        } else if let url = currentURL {
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    func goBack() {
+        if webView.canGoBack {
+            webView.goBack()
+        }
+    }
+
+    func goForward() {
+        if webView.canGoForward {
+            webView.goForward()
+        }
+    }
+
     func openInBrowser() {
         guard let url = currentURL, Self.isLoopback(url) else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    /// WKWebView properties are main-thread only, so KVO fires on the main
+    /// actor; mirror the ones the toolbar gates on into observable state.
+    private func observeNavigation() {
+        observations = [
+            webView.observe(\.isLoading, options: [.initial, .new]) { [weak self] _, change in
+                MainActor.assumeIsolated {
+                    self?.isLoading = change.newValue ?? false
+                }
+            },
+            webView.observe(\.canGoBack, options: [.initial, .new]) { [weak self] _, change in
+                MainActor.assumeIsolated {
+                    self?.canGoBack = change.newValue ?? false
+                }
+            },
+            webView.observe(\.canGoForward, options: [.initial, .new]) { [weak self] _, change in
+                MainActor.assumeIsolated {
+                    self?.canGoForward = change.newValue ?? false
+                }
+            },
+        ]
     }
 
     private static func isLoopback(_ url: URL) -> Bool {

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -120,6 +120,7 @@ struct EditorWindow: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 6)
+        .glassEffect()
     }
 
     /// Mail-compose chrome: when the editor was opened from a page, name that

--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -106,6 +106,7 @@ struct PreviewWindow: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 6)
+        .glassEffect()
     }
 
     private var toolbar: some View {

--- a/docs/SHIP-HARDENING.md
+++ b/docs/SHIP-HARDENING.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved Design & Verification Document (Issue #61 / Milestone M9 Ship)  
 **Author:** draw me an elephant / uncle-gravity  
-**Target:** macOS App Sandbox / Universal Binary Distribution (`arm64` + `x86_64`)  
+**Target:** macOS 27+ · App Sandbox / Universal Binary Distribution (`arm64` + `x86_64`)  
 
 ---
 

--- a/docs/SHIP-HARDENING.md
+++ b/docs/SHIP-HARDENING.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved Design & Verification Document (Issue #61 / Milestone M9 Ship)  
 **Author:** draw me an elephant / uncle-gravity  
-**Target:** macOS 27+ · App Sandbox / Universal Binary Distribution (`arm64` + `x86_64`)  
+**Target:** macOS 26+ · App Sandbox / Universal Binary Distribution (`arm64` + `x86_64`)  
 
 ---
 

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -7,7 +7,7 @@ tags: [architecture]
 
 # Architecture
 
-Solipsist is built in Swift 6 with SwiftUI for macOS 14+.
+Solipsist is built in Swift 6 with SwiftUI for macOS 27+.
 
 ## Spatial Model
 

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -7,7 +7,7 @@ tags: [architecture]
 
 # Architecture
 
-Solipsist is built in Swift 6 with SwiftUI for macOS 27+.
+Solipsist is built in Swift 6 with SwiftUI for macOS 26+.
 
 ## Spatial Model
 


### PR DESCRIPTION
## What

- **File → Edit Page** (enabled only when a page is selected) opens the `boris-editor` companion for that page, and the window header names the page and its `sourcePath`. M10-4 (#102).
- **Editor nav chrome:** back/forward/reload, a connection phase indicator, and Restart Host (KVO-backed `EditorWebModel` + `EditorSession.restart()`).
- **Build modernization:** macOS 27 deployment target, CI/notarize on the `xcode-27` runner, `.glassEffect()` on the main/editor/preview windows.

## Lane notes

- List gestures (double-click / Return) are **not** in this PR — they landed separately with #101 (reading pane).
- The A15 editor-open-file deep-link doc was dropped from this PR per M10-4's "do not draft"; `boris#649` stays filed upstream for a later milestone.

## Verification

- `SKIP_EMBED_BORIS=1 make build` ✅
- `make test` — 199 tests, 0 failures ✅
- `make lint` — 0 violations ✅
