### PR TITLE
fix(ci): drop hardcoded Xcode.app from release workflow

### DIFF
--- a/.github/workflows/release-notarize.yml
+++ b/.github/workflows/release-notarize.yml
@@ -48,7 +48,11 @@ jobs:
 
       - name: Set up Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          # xcode-27 runners ship Xcode at a versioned path (e.g.
+          # /Applications/Xcode_27_beta_4.app) with no /Applications/Xcode.app
+          # symlink, and already default xcode-select to it — nothing to
+          # switch. Verify the active toolchain instead.
+          xcode-select -p
           xcodebuild -version
 
       - name: Install Zig


### PR DESCRIPTION
## What

The release workflow's `Set up Xcode` step ran `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`. The `xcode-27` runner has no `/Applications/Xcode.app` — it ships Xcode at a versioned path (e.g. `/Applications/Xcode_27_beta_4.app`) and already defaults `xcode-select` to it, so this step would have failed before the build started.

## Change

Replace the hardcoded switch with a verification-only step (`xcode-select -p` + `xcodebuild -version`), matching how `ci.yml` already runs on `xcode-27` with no setup step.

## Verification

- YAML parses cleanly.
- PR CI (app/lint/fixtures/spike) runs on the same `xcode-27` image without any Xcode setup step and passes.
