### PR TITLE
fix(editor): project-root DIR + A15-ready open= fragment

### DIFF
--- a/Sources/Companions/Editor/EditorSession.swift
+++ b/Sources/Companions/Editor/EditorSession.swift
@@ -78,7 +78,6 @@ final class EditorSession {
         do {
             let server = try engine.editorStart(
                 editorBinary: editorBinary,
-                contentRoot: contentRoot,
                 workingDirectory: projectRoot,
                 port: 0
             )

--- a/Sources/Companions/Editor/EditorURL.swift
+++ b/Sources/Companions/Editor/EditorURL.swift
@@ -1,6 +1,14 @@
 import Foundation
 
 /// Helper parser for Boris editor token launch lines.
+///
+/// The afterparty Svelte shell reads the fragment with `URLSearchParams`
+/// and takes only `token`. Extra keys are ignored today. A15
+/// ([boris#649](https://github.com/drawmeanelephant/boris/issues/649))
+/// proposes an optional `open=<project-relative path>` key that the
+/// shell would feed to its own `openFile`. This parser matches that
+/// `URLSearchParams` shape so a second fragment key is not rejected,
+/// and `opening(_:sourcePath:)` is how the companion appends `open=`.
 public enum EditorURL {
     public enum ParseError: LocalizedError, Equatable {
         case empty
@@ -26,6 +34,7 @@ public enum EditorURL {
     }
 
     /// Parses a `BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=<hex>` line or raw URL.
+    /// Extra fragment keys (`&open=…`) are allowed; `token` must still be hex.
     public static func parse(_ raw: String) throws -> URL {
         var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("BORIS_EDITOR_URL=") {
@@ -43,14 +52,74 @@ public enum EditorURL {
         guard let host = components.host?.lowercased(), host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]" else {
             throw ParseError.notLoopback
         }
-        guard let fragment = components.fragment, fragment.hasPrefix("token=") else {
+        guard let token = fragmentItems(components.fragment).first(where: { $0.name == "token" })?.value else {
             throw ParseError.missingTokenFragment
         }
-        let token = String(fragment.dropFirst("token=".count))
-        guard !token.isEmpty, token.allSatisfy({ $0.isHexDigit }) else {
+        guard !token.isEmpty, token.allSatisfy(\.isHexDigit) else {
             throw ParseError.invalidTokenHex
         }
 
         return url
+    }
+
+    /// Appends or replaces `open=` with the author-owned project path for
+    /// a graph `sourcePath`. Returns `url` unchanged when the path is
+    /// missing or would fail `file_api.validatePath`.
+    public static func opening(_ url: URL, sourcePath: String?) -> URL {
+        guard let project = projectPath(fromSourcePath: sourcePath) else { return url }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var items = fragmentItems(components.fragment).filter { $0.name != "open" }
+        items.append(URLQueryItem(name: "open", value: project))
+        components.fragment = encodedFragment(items)
+        return components.url ?? url
+    }
+
+    /// Maps a graph `sourcePath` (content-root relative) onto the
+    /// project-relative path `boris-editor` accepts. Matches the Svelte
+    /// shell's `projectPathForProblem`: `content/` / `themes/` / `boris.json`
+    /// pass through; everything else is prefixed with `content/`.
+    public static func projectPath(fromSourcePath sourcePath: String?) -> String? {
+        guard let raw = sourcePath?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+        let normalized = raw.replacingOccurrences(of: "\\", with: "/")
+        if normalized.hasPrefix("/") { return nil }
+        let project: String
+        if normalized == "boris.json" || normalized.hasPrefix("content/") || normalized.hasPrefix("themes/") {
+            project = normalized
+        } else {
+            project = "content/" + normalized.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        }
+        return isAuthorOwned(project) ? project : nil
+    }
+
+    // MARK: - Fragment (URLSearchParams)
+
+    private static func fragmentItems(_ fragment: String?) -> [URLQueryItem] {
+        guard let fragment, !fragment.isEmpty else { return [] }
+        var components = URLComponents()
+        components.percentEncodedQuery = fragment
+        return components.queryItems ?? []
+    }
+
+    private static func encodedFragment(_ items: [URLQueryItem]) -> String {
+        var components = URLComponents()
+        components.queryItems = items
+        return components.percentEncodedQuery ?? ""
+    }
+
+    /// afterparty `editor/src/file_api.zig` `validatePath`: no leading `/`,
+    /// no empty/`.`/`..` segments, author-owned roots only.
+    private static func isAuthorOwned(_ path: String) -> Bool {
+        if path.isEmpty || path.count > 4096 { return false }
+        if path.hasPrefix("/") { return false }
+        if path.contains("\\") || path.contains("\0") { return false }
+        let segments = path.split(separator: "/", omittingEmptySubsequences: false)
+        for segment in segments {
+            if segment.isEmpty || segment == "." || segment == ".." { return false }
+        }
+        return path == "boris.json"
+            || path.hasPrefix("content/")
+            || path.hasPrefix("themes/")
     }
 }

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -6,10 +6,12 @@ import WebKit
 /// Companion host for `boris-editor` (Svelte). Chassis registers the window
 /// and leaves it closed; the editor opens against the selected page.
 ///
-/// The window starts an `EditorSession` for the selected source's content
-/// root, then loads the tokenized `BORIS_EDITOR_URL=` into the web view. The
-/// header names the selected page and its `sourcePath`. Manual URL paste and
-/// "Open in Browser" stay as the loopback fallback.
+/// The window starts an `EditorSession` for the selected source's project
+/// root, then loads the tokenized `BORIS_EDITOR_URL=` into the web view
+/// with `open=` set from the page `sourcePath` (A15 / boris#649; ignored
+/// by today's shell). The header names the selected page and its
+/// `sourcePath`. Manual URL paste and "Open in Browser" stay as the
+/// loopback fallback.
 struct EditorWindow: View {
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
@@ -44,7 +46,9 @@ struct EditorWindow: View {
         .navigationTitle("Editor")
         .onChange(of: session.editorURL) { _, newURL in
             if let newURL {
-                model.load(url: newURL)
+                let targeted = EditorURL.opening(newURL, sourcePath: pageSourcePath)
+                urlText = targeted.absoluteString
+                model.load(url: targeted)
             }
         }
         .onDisappear {
@@ -133,10 +137,18 @@ struct EditorWindow: View {
     }
 
     private func headerSubtitle(for source: SourceItem) -> String? {
-        if let noun = store.selection.noun, noun.kind == "page", let path = noun.sourcePath, !path.isEmpty {
+        if let path = pageSourcePath {
             return path
         }
         return source.detailLine
+    }
+
+    /// Graph `sourcePath` when the editor was opened from a page.
+    private var pageSourcePath: String? {
+        guard let noun = store.selection.noun, noun.kind == "page",
+              let path = noun.sourcePath, !path.isEmpty
+        else { return nil }
+        return path
     }
 
     private var toolbar: some View {

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -553,10 +553,10 @@ public actor BorisEngine {
 
     // MARK: Editor (M6)
 
-    /// Starts `boris-editor` for `contentRoot` (A14) and returns the live host server.
+    /// Starts `boris-editor` for the project at `workingDirectory` (A14).
+    /// DIR is the project folder (must contain `content/`), not the content tree.
     public nonisolated func editorStart(
         editorBinary: URL,
-        contentRoot: URL,
         workingDirectory: URL,
         uiDir: URL? = nil,
         port: Int = 0
@@ -564,8 +564,7 @@ public actor BorisEngine {
         let server = EditorServer(
             editorBinary: editorBinary,
             engineBinary: binaryURL,
-            contentRoot: contentRoot,
-            workingDirectory: workingDirectory,
+            projectRoot: workingDirectory,
             uiDir: uiDir,
             port: port
         )

--- a/Sources/Engine/EditorServer.swift
+++ b/Sources/Engine/EditorServer.swift
@@ -9,8 +9,11 @@ public struct EditorExit: Sendable {
 
 /// The M6 author companion host (A14 / #75): a long-lived `boris-editor` subprocess.
 ///
-/// Runs `boris-editor <contentRoot> --boris <engineBinary> --port 0` with
-/// `cwd = workingDirectory`. The startup line on stderr:
+/// Runs `boris-editor <projectRoot> --boris <engineBinary> --port 0` with
+/// `cwd = projectRoot`. DIR must be the project folder (the one that
+/// contains `content/`) — afterparty `project.discover` rejects a
+/// content-tree path with "has no content directory". The startup line
+/// on stderr:
 ///
 ///     BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=<32 hex chars>
 ///
@@ -31,15 +34,14 @@ public final class EditorServer: @unchecked Sendable {
     public init(
         editorBinary: URL,
         engineBinary: URL,
-        contentRoot: URL,
-        workingDirectory: URL,
+        projectRoot: URL,
         uiDir: URL? = nil,
         port: Int = 0
     ) {
         let process = Process()
         process.executableURL = editorBinary
         var args = [
-            contentRoot.path,
+            projectRoot.path,
             "--boris", engineBinary.path,
             "--port", String(port),
         ]
@@ -47,7 +49,7 @@ public final class EditorServer: @unchecked Sendable {
             args.append(contentsOf: ["--ui-dir", uiDir.path])
         }
         process.arguments = args
-        process.currentDirectoryURL = workingDirectory
+        process.currentDirectoryURL = projectRoot
         process.standardOutput = FileHandle.nullDevice
         process.standardError = stderrPipe
         self.process = process

--- a/Tests/ContractTests/CompanionURLTests.swift
+++ b/Tests/ContractTests/CompanionURLTests.swift
@@ -87,6 +87,57 @@ final class CompanionURLTests: XCTestCase {
         }
     }
 
+    func testEditorURLAcceptsExtraFragmentKeys() throws {
+        let input = "http://127.0.0.1:49152/#token=0123456789abcdef&open=content/index.md"
+        let url = try EditorURL.parse(input)
+        XCTAssertEqual(url.host, "127.0.0.1")
+        XCTAssertEqual(url.fragment, "token=0123456789abcdef&open=content/index.md")
+    }
+
+    func testEditorURLTokenNeedNotBeFirstFragmentKey() throws {
+        let input = "http://127.0.0.1:8080/#open=content/index.md&token=feedface"
+        let url = try EditorURL.parse(input)
+        XCTAssertEqual(url.host, "127.0.0.1")
+    }
+
+    func testEditorURLOpeningAppendsAuthorOwnedPath() throws {
+        let base = try EditorURL.parse("http://127.0.0.1:8080/#token=abcd")
+        let opened = EditorURL.opening(base, sourcePath: "guides/getting-started.md")
+        XCTAssertEqual(opened.fragment, "token=abcd&open=content/guides/getting-started.md")
+        let parsed = try EditorURL.parse(opened.absoluteString)
+        XCTAssertEqual(parsed.fragment, opened.fragment)
+    }
+
+    func testEditorURLOpeningReplacesExistingOpen() throws {
+        let base = try EditorURL.parse("http://127.0.0.1:8080/#token=abcd&open=content/old.md")
+        let opened = EditorURL.opening(base, sourcePath: "index.md")
+        XCTAssertEqual(opened.fragment, "token=abcd&open=content/index.md")
+    }
+
+    func testEditorURLOpeningLeavesInvalidSourcePathAlone() throws {
+        let base = try EditorURL.parse("http://127.0.0.1:8080/#token=abcd")
+        XCTAssertEqual(EditorURL.opening(base, sourcePath: nil).fragment, "token=abcd")
+        XCTAssertEqual(EditorURL.opening(base, sourcePath: "").fragment, "token=abcd")
+        XCTAssertEqual(EditorURL.opening(base, sourcePath: "../secret").fragment, "token=abcd")
+        XCTAssertEqual(EditorURL.opening(base, sourcePath: "/etc/passwd").fragment, "token=abcd")
+        XCTAssertEqual(EditorURL.opening(base, sourcePath: "content/../secret").fragment, "token=abcd")
+    }
+
+    func testEditorURLProjectPathFromGraphSourcePath() {
+        XCTAssertEqual(EditorURL.projectPath(fromSourcePath: "index.md"), "content/index.md")
+        XCTAssertEqual(EditorURL.projectPath(fromSourcePath: "guides/getting-started.md"), "content/guides/getting-started.md")
+        XCTAssertEqual(EditorURL.projectPath(fromSourcePath: "content/index.md"), "content/index.md")
+        XCTAssertEqual(EditorURL.projectPath(fromSourcePath: "themes/boris/layouts/main.html"), "themes/boris/layouts/main.html")
+        XCTAssertEqual(EditorURL.projectPath(fromSourcePath: "boris.json"), "boris.json")
+        XCTAssertEqual(EditorURL.projectPath(fromSourcePath: "dist/index.html"), "content/dist/index.html")
+        XCTAssertNil(EditorURL.projectPath(fromSourcePath: nil))
+        XCTAssertNil(EditorURL.projectPath(fromSourcePath: "  "))
+        XCTAssertNil(EditorURL.projectPath(fromSourcePath: "../secret"))
+        XCTAssertNil(EditorURL.projectPath(fromSourcePath: "content/../secret"))
+        XCTAssertNil(EditorURL.projectPath(fromSourcePath: "/content/index.md"))
+        XCTAssertNil(EditorURL.projectPath(fromSourcePath: "/etc/passwd"))
+    }
+
     // MARK: - PreviewURL Tests
 
     func testPreviewURLLoopbackRules() throws {

--- a/docs/M10-DESIGN.md
+++ b/docs/M10-DESIGN.md
@@ -936,9 +936,9 @@ Fact-checked against the tree (not against a live afterparty checkout — we do 
 | Source | What it pins |
 |--------|----------------|
 | `docs/issues/boris-A14-editor-launch-contract.md` | Launch line `BORIS_EDITOR_URL=http://127.0.0.1:<port>/#token=<32 hex>`. Flags: `[DIR] [--boris PATH] [--ui-dir DIR] [--port PORT]`. Token in the **fragment**, not query. Non-goals: no NDJSON, no WKWebView-specific behavior. |
-| `docs/issues/README.md` | "M10 editor wiring (#102) may later need an open-file deep link on `boris-editor`; do not draft it until it is fact-checked against afterparty. Do not invent a query/fragment." |
-| `Sources/Companions/Editor/EditorURL.swift` | Accepts only loopback `http` + `#token=<hex>`. No `file`, `path`, or `sourcePath` parameter. A second fragment key would fail `hasPrefix("token=")`. |
-| `Sources/Engine/EditorServer.swift` | Args: `contentRoot --boris <engine> --port 0`. No file argument. |
+| `docs/issues/README.md` | A15 ([boris#649](https://github.com/drawmeanelephant/boris/issues/649)) filed after the afterparty fact-check. Solipsist appends `#token=…&open=` from `sourcePath`; do not invent a different query/fragment. |
+| `Sources/Companions/Editor/EditorURL.swift` | Loopback `http` + `#token=<hex>`. Extra fragment keys allowed (`URLSearchParams` shape). `opening(_:sourcePath:)` appends `open=` for an author-owned project path. |
+| `Sources/Engine/EditorServer.swift` | Args: `projectRoot --boris <engine> --port 0`. DIR is the project folder (must contain `content/`), not the content tree. |
 | `docs/cards/parallel/editor-shell.md` | "Do not put the token into query or logs." |
 
 There is no proven query or fragment the Svelte shell honors for a file. **Do not invent one. Do not draft `docs/issues/boris-A*-editor-open-file.md` in M10.** Surface `sourcePath` in chrome and stop.

--- a/docs/cards/queue/close-102-verification.md
+++ b/docs/cards/queue/close-102-verification.md
@@ -1,94 +1,39 @@
-# Close #102 — verify the editor gate, then close
+# Close #102 — verification findings
 
 **Issue:** [#102](https://github.com/drawmeanelephant/solipsist/issues/102) (M10-4 "editor from the selected page")
-**Status:** code merged (PR #118) · CI green · **hands-on Gate NOT yet verified**
-**Blocked on:** a live `boris` engine binary — none exists in this checkout.
+**Status:** closed · code merged (PR #118) · follow-up in `feat/editor-open-page`
 
-## Context (what is already done)
+The live Gate was blocked on a `boris` + `boris-editor` pair in this
+checkout. Fact-check against afterparty `editor/` (same pin as
+`vendor/boris-agent-kit/MANIFEST.json`) found two leftovers the Gate
+would have hit.
 
-- `File → Edit Page` (enabled when `store.selection.canEditPage`) — merged.
-- Editor header shows the selected page title + `sourcePath` — merged.
-- Editor nav chrome (back/forward/reload, phase indicator, Restart Host) — merged.
-- Double-click / Return gestures + `noun.sourcePath` write — landed via **#101** (PR #113).
-- Toolbar page-gating — landed via #100.
-- Build + `make test` (199 tests) green on `main`.
+## Findings
 
-**What remains is the card Gate, run live, then the close ceremony.** Do not change code unless the Gate reveals a real bug — if it does, stop and report it (the queue's forbidden paths are `Sources/Play/`, `Inspector/`, `Engine/`, `Models/`, `Commands.swift`, `MainWindow.swift`, `Workspace/`, `embed-boris.sh`).
+1. **DIR was the content tree.** `EditorServer` launched
+   `boris-editor <contentRoot>`. Afterparty `project.discover` requires
+   a `content/` directory *under* DIR, so `Stunts/happy/content` fails
+   with "has no content directory". DIR is now the project folder
+   (`workingDirectory`).
+2. **`EditorURL.parse` rejected a second fragment key.** The Svelte
+   shell reads the hash with `URLSearchParams` and takes only `token`;
+   extra keys are ignored. A15 ([boris#649](https://github.com/drawmeanelephant/boris/issues/649))
+   proposes `#token=…&open=<project-relative path>`. The parser now
+   matches `URLSearchParams`, and Edit Page appends `open=` from the
+   selected `sourcePath` (`index.md` → `content/index.md`, same rules
+   as `file_api.validatePath`). Today's shell ignores `open=`; when A15
+   ships, Edit Page lands on the file.
 
-## Prerequisites
-
-macOS 26+ host (dev box is macOS 27) · Xcode 26/27 · Zig 0.16+ · node/npm (for the Svelte shell).
-
-## Step 1 — Build the engine + editor host at the pinned commit
-
-Pin: `6b930b7bd35a1803b365a073c226df22631dc3f7` (also in `vendor/boris-agent-kit/MANIFEST.json`).
-
-```bash
-git clone https://github.com/drawmeanelephant/boris.git ../boris
-cd ../boris
-git checkout 6b930b7bd35a1803b365a073c226df22631dc3f7
-zig build                                  # engine  -> zig-out/bin/boris
-zig build --build-file editor/build.zig    # host    -> boris-editor binary
-cd editor/ui && npm ci && npm run build    # Svelte shell
-cd ../..
-```
-
-Both binaries should end up in `../boris/zig-out/bin/` (siblings), so the app finds
-`boris-editor` next to `boris`. If the editor host lands elsewhere, set
-`SOLIPSIST_BORIS_EDITOR_BIN` to its absolute path.
-
-## Step 2 — Build and launch the app
-
-```bash
-SKIP_EMBED_BORIS=1 make build
-SOLIPSIST_BORIS_BIN=$PWD/../boris/zig-out/bin/boris \
-SOLIPSIST_BORIS_EDITOR_BIN=$PWD/../boris/zig-out/bin/boris-editor \
-  open build/Build/Products/Debug/Solipsist.app
-```
-
-Engine search order: `SOLIPSIST_BORIS_BIN` → app bundle → `SUPPORT-NOT-FOR-GITHUB/…`
-→ `../boris/zig-out/bin/boris`. Editor binary: `SOLIPSIST_BORIS_EDITOR_BIN` →
-sibling of the engine → app bundle.
-
-## Step 3 — Verify the Gate (from `docs/cards/M10-editor-wiring.md`)
-
-1. **File → Open…** `Stunts/happy`. Pages render (engine builds the graph).
-2. **Select a page** →
-   - `File → Edit Page` opens the editor companion window.
-   - The window header shows the page **title** and its **sourcePath**.
-   - **Double-click** a row and press **Return** also open the editor (#101 behavior).
-3. **No page selected / no source** → `Edit Page` is disabled.
-4. Inside the editor:
-   - link-out still works (WKWebView/CSP fallback).
-   - paste-`BORIS_EDITOR_URL=` fallback still connects.
-   - **Restart Host** re-spawns the host and reconnects.
-5. Close the editor → the host process is SIGTERM'd.
-
-## Step 4 — Close out
-
-Post a comment on #102 summarizing the final lane split, then close it if the Gate
-passed:
+## Lane split (close-out)
 
 - **#100** — toolbar gate + `sourcePath` on the noun type
 - **#101** — double-click / Return gestures + `noun.sourcePath` write (PR #113)
 - **#102** — `File → Edit Page` verb + editor header (title + sourcePath) + nav chrome (PR #118)
-- **A15** — editor open-file deep link deliberately **not** drafted per M10-4; `boris#649`
-  filed upstream for a later milestone.
+- **A15** — `boris#649` filed upstream; Solipsist consumes `open=` and
+  does not invent a different query/fragment
 
-## Acceptance checklist
+## Still true from the original Gate
 
-- [ ] `../boris` at pin builds; `boris` + `boris-editor` binaries exist
-- [ ] App launches against `Stunts/happy` and Pages render
-- [ ] `Edit Page` opens the editor with page title + `sourcePath` in the header
-- [ ] `Edit Page` disabled when no page is selected
-- [ ] double-click and Return open the editor
-- [ ] link-out, paste fallback, and Restart Host behave
-- [ ] `SKIP_EMBED_BORIS=1 make build` + `make test` green on the final tree
-- [ ] #102 closed with the summary comment
-
-## Gotchas
-
-- First `zig build` takes a few minutes.
-- If the pinned commit fails to build with the local Zig, report the exact error —
-  **do not patch boris** (draft `docs/issues/boris-A<N>-*.md` instead).
-- macOS floor is **26.0** (Liquid Glass); the `xcode-27` CI runner is macOS 26.5.2.
+Link-out, paste-`BORIS_EDITOR_URL=`, Restart Host, and SIGTERM on
+close are unchanged. `SKIP_EMBED_BORIS=1 make build` + `make test`
+must stay green on the follow-up.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -16,9 +16,11 @@ PR against boris from this repo.
 
 - A5 [boris#647](https://github.com/drawmeanelephant/boris/issues/647) — RFC, filed as an issue (Discussions disabled on the repo). Still open; no fixing PR yet.
 
-**File next:** none. M10 editor wiring (#102) may later need an
-open-file deep link on `boris-editor`; do not draft it until it is
-fact-checked against afterparty. Do not invent a query/fragment.
+**Filed (2026-08-18):**
+
+- A15 [boris#649](https://github.com/drawmeanelephant/boris/issues/649) — optional `#token=…&open=<project-relative path>` fragment. Afterparty's Svelte shell still reads only `token` (`URLSearchParams` on the hash) and opens files via `POST /api/files/open`. Extra fragment keys are ignored today. Solipsist appends `open=` from the selected page's `sourcePath` (mapped `index.md` → `content/index.md`, same rules as `file_api.validatePath`) so Edit Page lands on the file when A15 ships. Do not invent a different query/fragment.
+
+**File next:** none.
 
 Do not ask: unifying `compiler` field names, library mode, relaxing
 editor token/CSP, shipping `boris-editor` in the agent-pack.


### PR DESCRIPTION
## What

Follow-up to [#102](https://github.com/drawmeanelephant/solipsist/issues/102) / the close-out card in [#120](https://github.com/drawmeanelephant/solipsist/pull/120). Closes [#121](https://github.com/drawmeanelephant/solipsist/issues/121).

- **DIR is the project folder.** `boris-editor` was launched against `contentRoot`. Afterparty `project.discover` requires a `content/` directory *under* DIR, so `Stunts/happy` failed with "has no content directory". Launch line is now `boris-editor <projectRoot> --boris <engine> --port 0`.
- **Parser matches the Svelte shell.** `EditorURL.parse` used to treat everything after `token=` as hex, so `#token=…&open=…` would fail. Fragment is now `URLSearchParams` (`token` required hex; extra keys allowed).
- **Edit Page appends `open=`.** Graph `sourcePath` (`index.md`) maps to the author-owned project path (`content/index.md`) with the same rules as `file_api.validatePath`. Today's shell ignores the extra key. When [A15 / boris#649](https://github.com/drawmeanelephant/boris/issues/649) ships, Edit Page lands on the file.

Did not invent a different query/fragment. Did not patch boris. Did not touch Play, Compose, or Oliver.

## Verification

- `SKIP_EMBED_BORIS=1 make build` ✅
- `make test` — 205 tests, 0 failures ✅
- `make lint` — 0 violations ✅