### PR TITLE
feat(m11): Help and empty states match the Mail-body window

### DIFF
--- a/Sources/Chrome/InspectorDrawer.swift
+++ b/Sources/Chrome/InspectorDrawer.swift
@@ -49,7 +49,7 @@ struct InspectorDrawer: View {
             {
                 PageSection(source: source, noun: noun)
             } else {
-                Text("Select a page in the play place.")
+                Text("Select a page in the reading place.")
                     .foregroundStyle(.secondary)
             }
         case InspectorSectionID.target:

--- a/Sources/Chrome/PlayHost.swift
+++ b/Sources/Chrome/PlayHost.swift
@@ -21,7 +21,7 @@ struct PlayHost: View {
                 EmptyStateView(
                     title: "No Sources",
                     systemImage: "folder.badge.plus",
-                    message: "Open a folder with boris.json (e.g. Stunts/happy) to begin.",
+                    message: "Add a folder with boris.json from Settings → Sources or File → Open… (for example Stunts/happy).",
                     actionTitle: "Open…",
                     action: { store.presentOpenPanel() }
                 )
@@ -29,7 +29,7 @@ struct PlayHost: View {
                 EmptyStateView(
                     title: "No Source Selected",
                     systemImage: "sidebar.left",
-                    message: "Select a source from the sidebar to view its publication."
+                    message: "Select an account in the mailbox sidebar, or add one from Settings → Sources or File → Open…."
                 )
             }
         }

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -14,6 +14,7 @@ struct SourceSidebar: View {
                             systemImage: WorkspaceMailbox.symbolName(box)
                         )
                         .tag(MailboxRowID(sourceID: item.id, mailbox: box))
+                        .accessibilityLabel("\(item.title), \(WorkspaceMailbox.displayName(box))")
                         .contextMenu { sourceMenu(item) }
                     }
                 } header: {
@@ -33,7 +34,7 @@ struct SourceSidebar: View {
                 EmptyStateView(
                     title: "No Sources",
                     systemImage: "folder.badge.plus",
-                    message: "Open a folder with boris.json (e.g. Stunts/happy) to get started.",
+                    message: "Add a folder with boris.json from Settings → Sources or File → Open… (for example Stunts/happy).",
                     actionTitle: "Open…",
                     action: { store.presentOpenPanel() }
                 )
@@ -111,6 +112,16 @@ private struct SourceAccountHeader: View {
             item.isAvailable
                 ? (item.detailLine ?? item.title)
                 : "Unreachable — Relocate / Remove"
+        )
+        .accessibilityLabel(
+            item.isAvailable
+                ? item.title
+                : "\(item.title), unreachable"
+        )
+        .accessibilityHint(
+            item.isAvailable
+                ? "Select this account"
+                : "Unreachable. Relocate or remove this source."
         )
     }
 }

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -73,8 +73,9 @@ struct LocalPlay: PlaySurface {
         case .unavailable:
             ContentUnavailableView {
                 Label(source.title, systemImage: "folder")
+                    .accessibilityLabel("\(source.title), unreachable")
             } description: {
-                Text("This folder is unreachable. Relocate it or remove it from the sidebar.")
+                Text("This folder is unreachable. Relocate it from File → Relocate Source… or Settings → Sources, or remove it.")
             } actions: {
                 Button("Relocate…") {
                     store.presentRelocatePanel(for: source.id)
@@ -87,8 +88,11 @@ struct LocalPlay: PlaySurface {
             ContentUnavailableView {
                 Label("No Pages", systemImage: "doc.text")
             } description: {
-                Text("The graph for this folder has no pages. Open a folder with boris.json (e.g. Stunts/happy) to view pages.")
+                Text("This source has no pages. Add Stunts/happy from Settings → Sources or File → Open… to see a working publication.")
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("No Pages")
+            .accessibilityHint("Add Stunts/happy from Settings → Sources or File → Open… to see a working publication.")
         case .failed(let message):
             ContentUnavailableView {
                 Label("Graph Unavailable", systemImage: "exclamationmark.triangle")

--- a/Sources/Play/Local/ReadingPane.swift
+++ b/Sources/Play/Local/ReadingPane.swift
@@ -25,6 +25,9 @@ struct ReadingPane: View {
                 } description: {
                     Text("Select a page to read it.")
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("No Page Selected")
+                .accessibilityHint("Select a page from the list to read it.")
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -325,21 +325,14 @@ Landed. Goals from here: [`ROADMAP.md`](ROADMAP.md) M3+.
 
 ---
 
-## 7. What ships today (M2–M8), vs M10
+## 7. What ships today
 
-Do not "fix" the shipping chrome back onto this file's destination
-without picking an M10 card. The live app is still the flatter cut:
+M10 landed. The live app is the Mail body in §2: Settings → Sources,
+mailbox sidebar, reading place, drawer, Preview / Editor companions,
+Compose window. Help and first-run / empty-state copy match that
+window.
 
-| Surface | Ships today | M10 destination |
-|---------|-------------|-----------------|
-| Account book | File → Open… / sidebar plus / Remove Source | Settings → Sources (same `WorkspaceStore`) |
-| Left column | Flat source list (`SourceSidebar`) | Account headers + mailboxes |
-| Center | Segmented play tabs (Pages / Outputs / Publish / Plan / Activity) + problems strip | Message list + reading pane, driven by the selected mailbox |
-| Preview | Companion only | Companion (full site) + reading pane (selected page, same watch) |
-| Editor | Companion only; source-scoped, not page-scoped | Companion, opened from the selected page (#102) |
-| Compose | none | Native buffer window (`⌘⇧C`) over `sourcePath`; Oliver preview (#106) |
-| Selection | `sourceID` + `noun` | `sourceID` + `mailbox` + `noun` |
-
-M10 cards live in [`cards/`](cards/README.md)
-([#98](https://github.com/drawmeanelephant/solipsist/issues/98)).
-#78 stays build-lane only.
+Do not expand Apple-account ship
+([#110](https://github.com/drawmeanelephant/solipsist/issues/110),
+[#111](https://github.com/drawmeanelephant/solipsist/issues/111))
+into this chrome. #78 is closed.

--- a/docs/help.md
+++ b/docs/help.md
@@ -4,11 +4,12 @@ Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeane
 
 ## Spatial Layout
 
-Solipsist organizes its workspace into a three-column spatial model:
+Accounts live in Settings. The main window is mailboxes, a reading place, and a drawer. Companion windows host surfaces Solipsist does not rewrite.
 
-- **Sources (Left)**: Switch between opened Boris publication folders (`File → Open…` or `⌘O`) and dogfood test corpora under `Stunts/`.
-- **Play (Center)**: Pages, Outputs, and Publish tabs. The problems list under play is where every coordinator job reports its exit and diagnostics.
-- **Inspector Drawer (Right)**: Inspect publication configuration (`boris.json`), page frontmatter completion index (`completion.json`), and execution options.
+- **Settings → Sources**: The account book. Add, relocate, and remove local folders (`Solipsist → Settings…`). A source is a folder of Boris content, not a file tree. `File → Open…` (`⌘O`) and Open Recent write the same store. Try `Stunts/happy` first.
+- **Mailboxes (Left)**: Each source is an account header. Under it: Pages, Outputs, Publish, Plan, and Activity. Selecting a header opens that source's Pages mailbox.
+- **Reading (Center)**: The message list of the selected mailbox, plus a reading pane for the selected message. On Pages, pick a page to read it as a letter (the served page when Preview is up; a contract summary when it is not). The problems list under the reading place is where every coordinator job reports its exit and diagnostics.
+- **Inspector Drawer (Right)**: Options, profile keys, page fields, and execution knobs of the current selection.
 
 ## Menu Reference
 
@@ -19,10 +20,11 @@ Every menu verb and keyboard shortcut:
 | Verb | Shortcut | Description |
 | --- | --- | --- |
 | New Project… | `⌘N` | Initialize a new Boris project in a folder (`boris init`) and add it as a source. |
-| Open… | `⌘O` | Open a Boris publication folder as a source. |
-| Open Recent | — | Re-open a folder from the system recent-documents list. |
-| Relocate Source… | — | Point an unreachable source at its new folder (enabled when the selected source is stale). |
-| Remove Source | — | Remove the currently selected source from the workspace (enabled when a source is selected). |
+| Open… | `⌘O` | Open a Boris publication folder as a source. Same store as Settings → Sources. |
+| Open Recent | — | Re-open a folder from the system recent-documents list. Shows No Recent Folders when empty. Clear Menu wipes the list. |
+| Relocate Source… | — | Point an unreachable source at its new folder (enabled when the selected source is stale). Also in Settings → Sources. |
+| Remove Source | — | Remove the currently selected source from the workspace (enabled when a source is selected). Also in Settings → Sources. |
+| Edit Page | — | Open the hosted Editor companion against the selected page (enabled when a page is selected). |
 
 ### Boris
 
@@ -33,18 +35,25 @@ Every menu verb and keyboard shortcut:
 | Build IR | `⌘B` | Compile documents into the deterministic IR graph. |
 | Build HTML | `⌘⇧B` | Build the HTML distribution from the IR graph. |
 | Build All | `⌘⇧U` | Fan out every HTML target and edition in the publication profile. |
-| Build This | — | Build the selected HTML target or edition (Outputs tab). |
+| Build This | — | Build the selected HTML target or edition (Outputs mailbox). |
 | Check | — | Run static documentation intelligence and reference checks. |
 | Impact | — | Analyze ripple effects of node changes across the graph (enabled when a page is selected). |
+| Recipe Scale | — | Scale the selected Cooklang page (`boris recipe-scale`; enabled when a page is selected). |
 | Publish to Standard.site | — | Prompt for an app password (stdin), `login --app-password`, then `publish`. Optional Keychain remember. |
+| Verify Standard.site | — | Verify the current Standard.site publication (`boris standard-site verify`). |
+| Standard.site Records | — | List Standard.site records for the publication profile. |
+| Standard.site Sessions | — | List Standard.site login sessions. |
+| Standard.site Smoke Test | — | Run the Standard.site smoke check. |
+| Logout Standard.site | — | End the Standard.site session. |
 | Publish to Nostr… | — | Prompt for nsec/hex (stdin), then `nostr plan` → `sign --key-stdin` → `publish`. Optional Keychain remember. |
+| Package Archive | — | Build a `boris package` archive (`packages/`, checksums, machine-readable version). |
 | Stop | `⌘.` | Cancel the running job (SIGTERM, then SIGKILL after 2s). With no job, stops preview watch. Tree-writing jobs freeze watch until they finish. |
 
 ### View
 
 | Verb | Shortcut | Description |
 | --- | --- | --- |
-| Show/Hide Inspector | `⌥⌘0` | Toggle the Inspector drawer on the right. |
+| Show Inspector, Hide Inspector | `⌥⌘0` | Toggle the Inspector drawer on the right. |
 | Preview | `⌘⇧P` | Open the Preview companion window (live preview via `watch --serve` with loopback URL validation). |
 | Editor | `⌘⇧E` | Open the Editor companion window (token-isolated host for `boris-editor`). |
 | Compose | `⌘⇧C` | Open the Compose window (native Markdown / Textile / Cooklang editor for the selected page; Oliver-powered preview; Save flows into the coordinator's validate gate). |
@@ -57,8 +66,8 @@ Every menu verb and keyboard shortcut:
 
 ## Companion Windows
 
-- **Preview Companion (`⌘⇧P`)**: Live preview powered by `watch --serve` with loopback URL validation.
-- **Editor Companion (`⌘⇧E`)**: Token-isolated companion host for `boris-editor`.
+- **Preview Companion (`⌘⇧P`)**: Live preview of the full site, powered by `watch --serve` with loopback URL validation. The reading pane reuses this same watch for the selected page; it does not start a second one.
+- **Editor Companion (`⌘⇧E`)**: Token-isolated companion host for `boris-editor`. File → Edit Page opens it against the selected page.
 - **Compose Window (`⌘⇧C`)**: Native compose surface for the selected page's source file — Markdown / Textile / Cooklang editing with heuristic highlighting, an Oliver-rendered preview split (live, debounced; Render Options mirror Oliver's `ParseOptions` — wikilinks, callouts, smart typography, footnotes, task lists, frontmatter policy, raw-HTML policy, XHTML profile), and save-triggered validate through the coordinator. The renderer binary is located via `SOLIPSIST_OLIVER_BIN` → app bundle → sibling of `boris` → dev checkouts. Language is auto-detected from the file; the picker overrides it per session.
 
 For architecture and roadmap details, see [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).


### PR DESCRIPTION
## Card

M11-1 Chrome — [#124](https://github.com/drawmeanelephant/solipsist/issues/124)

## What

Help and empty states still described the M3 window (source list + play tabs). This recuts the copy to the Mail body that ships.

- `docs/help.md` spatial section is now Settings → Sources, mailbox sidebar, reading place, drawer, Preview / Editor / Compose.
- Every `Commands.swift` verb and shortcut has a Help row, including File → Edit Page, Compose `⌘⇧C`, Recipe Scale, the Standard.site family, and Package Archive.
- First-run / No Sources / No Pages / unreachable copy points at Settings or Open… and `Stunts/happy`. No play-tab language.
- VoiceOver labels on mailbox rows (account + mailbox) and reading / empty-graph states.
- `docs/HARNESS.md` §7 records that M10 shipped and that Help now matches.

Did not add EventSource on the letter, a wide split, or any new surface.

## Gate

- [x] `SKIP_EMBED_BORIS=1 make build` locally
- [x] `make test` — 205 tests, 4 skipped, 0 failures
- [x] `make lint` — 0 violations
- [ ] CI `spike` + `app` green
- [x] Did not touch `boris/` or commit `SUPPORT-NOT-FOR-GITHUB/`

Closes #124