### PR TITLE
test(m11): letter-URL verbatim pin + mailbox display() completion (#125)

### DIFF
--- a/Tests/ContractTests/CompanionURLTests.swift
+++ b/Tests/ContractTests/CompanionURLTests.swift
@@ -212,6 +212,21 @@ final class CompanionURLTests: XCTestCase {
         XCTAssertEqual(cook.absoluteString, "http://127.0.0.1:49152/recipe/soup.html")
     }
 
+    func testPreviewURLPageURLUsesGraphIDVerbatimNotSourcePathStemSwap() throws {
+        // The letter URL is `/{GraphNode.id}.html` — the id is used
+        // verbatim. A slashed or extension-bearing id must never be
+        // derived from (or stem-swapped against) the page's sourcePath.
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:49152/__boris/"))
+        let slashed = try XCTUnwrap(PreviewURL.pageURL(helper: helper, pageID: "recipe/soup"))
+        XCTAssertEqual(slashed.absoluteString, "http://127.0.0.1:49152/recipe/soup.html")
+        // A sourcePath-shaped id keeps its own prefix: no `content/` injection.
+        let pathShaped = try XCTUnwrap(PreviewURL.pageURL(helper: helper, pageID: "content/recipe/soup"))
+        XCTAssertEqual(pathShaped.absoluteString, "http://127.0.0.1:49152/content/recipe/soup.html")
+        // An extension is appended, never swapped for `.html`.
+        let withExtension = try XCTUnwrap(PreviewURL.pageURL(helper: helper, pageID: "recipe/soup.md"))
+        XCTAssertEqual(withExtension.absoluteString, "http://127.0.0.1:49152/recipe/soup.md.html")
+    }
+
     func testPreviewURLPageURLTrimsSlashes() throws {
         let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:8080/__boris/"))
         let url = try XCTUnwrap(PreviewURL.pageURL(helper: helper, pageID: "/guides/getting-started/"))

--- a/Tests/ContractTests/WorkspaceSelectionTests.swift
+++ b/Tests/ContractTests/WorkspaceSelectionTests.swift
@@ -19,8 +19,13 @@ final class WorkspaceSelectionTests: XCTestCase {
         XCTAssertEqual(WorkspaceMailbox.display(nil), WorkspaceMailbox.pages)
         XCTAssertEqual(WorkspaceMailbox.display("trunk:guides"), WorkspaceMailbox.pages)
         XCTAssertEqual(WorkspaceMailbox.display("guides/overview"), WorkspaceMailbox.pages)
-        XCTAssertEqual(WorkspaceMailbox.display(WorkspaceMailbox.activity), WorkspaceMailbox.activity)
-        XCTAssertEqual(WorkspaceMailbox.display(WorkspaceMailbox.pages), WorkspaceMailbox.pages)
+        // Every known token round-trips through display unchanged.
+        for token in WorkspaceMailbox.all {
+            XCTAssertEqual(WorkspaceMailbox.display(token), token)
+        }
+        // Unknown and nil both display as Pages without being written back
+        // (display is a view value; persist keeps the raw string).
+        XCTAssertEqual(WorkspaceMailbox.display(""), WorkspaceMailbox.pages)
 
         XCTAssertFalse(WorkspaceMailbox.isKnown(nil))
         XCTAssertFalse(WorkspaceMailbox.isKnown("trunk:guides"))


### PR DESCRIPTION
Supersedes the earlier duplicate of #127: the Help-vs-Commands audit landed there, so this PR carries only the two assertions #127 deliberately skipped. The letter-URL case the issue's Do-1 names — a slashed id must not become a stem-swap of `sourcePath` — is now pinned explicitly, and `WorkspaceMailbox.display` coverage is completed.

## What

- **`Tests/ContractTests/CompanionURLTests.swift`**: pins the letter URL as `/{GraphNode.id}.html` used verbatim — a slashed id (`recipe/soup`) or an extension-bearing id (`recipe/soup.md`) is never a stem-swap of `sourcePath` (no `content/` injection, no extension swap). #127's audit noted the plain slashed case already shipped; this makes the verbatim contract explicit per #125's Do-1.
- **`Tests/ContractTests/WorkspaceSelectionTests.swift`**: completes `WorkspaceMailbox.display` coverage — all five known tokens round-trip unchanged; unknown / nil / empty display as Pages without rewriting the persisted raw string.

No XCUI, no new target, no boris, no network.

## Gate

- [x] `make test` green
- [x] `SKIP_EMBED_BORIS=1 make build` green
- [x] `swiftformat --lint` + `swiftlint --strict` — 0 violations
