### PR TITLE
fix(chrome): ghost list rows, compact letter split, Compose in toolbar

### DIFF
--- a/Sources/App/Settings/SourcesSettingsPane.swift
+++ b/Sources/App/Settings/SourcesSettingsPane.swift
@@ -13,7 +13,9 @@ struct SourcesSettingsPane: View {
             } else {
                 sourceList
                 actionBar
-                Text("A source is a folder of Boris content.")
+                Text(
+                    "A source is a place content lives. Local folders now. GitHub — and other remotes — later, in this same list."
+                )
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -42,7 +44,8 @@ struct SourcesSettingsPane: View {
                     .tag(item.id)
             }
         }
-        .listStyle(.bordered(alternatesRowBackgrounds: true))
+        .listStyle(.inset)
+        .frame(maxHeight: max(72, CGFloat(store.sources.count) * 56 + 12))
     }
 
     private var actionBar: some View {
@@ -72,7 +75,7 @@ struct SourcesSettingsPane: View {
                 .foregroundStyle(.secondary)
             Text("No Sources")
                 .font(.headline)
-            Text("A source is a folder of Boris content — an account, not a file tree. Add a folder that contains `boris.json` (for example `Stunts/happy`) to get started.")
+            Text("A source is a place content lives — an account, not a file tree. Local folders now (a folder with `boris.json`, for example `Stunts/happy`). GitHub and other remotes later, in this same list.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -27,45 +27,7 @@ struct MainWindow: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
-                Button {
-                    runtime.coordinator.run(.validate, store: store, runtime: runtime)
-                } label: {
-                    Label("Validate", systemImage: "checkmark.circle")
-                }
-                .help("Validate")
-                .disabled(store.selectedSource == nil || !runtime.coordinator.canRunVerb)
-
-                Button {
-                    runtime.coordinator.run(.buildIR, store: store, runtime: runtime)
-                } label: {
-                    Label("Build IR", systemImage: "hammer")
-                }
-                .help("Build IR")
-                .disabled(store.selectedSource == nil || !runtime.coordinator.canRunVerb)
-
-                Button {
-                    runtime.coordinator.stop(runtime: runtime)
-                } label: {
-                    Label("Stop", systemImage: "stop.fill")
-                }
-                .help("Stop")
-                .disabled(!runtime.coordinator.canStop)
-
-                Button {
-                    openWindow(id: CompanionID.preview)
-                } label: {
-                    Label("Preview", systemImage: "safari")
-                }
-                .help("Open Preview")
-                .disabled(store.selectedSource == nil)
-
-                Button {
-                    openWindow(id: CompanionID.editor)
-                } label: {
-                    Label("Editor", systemImage: "square.and.pencil")
-                }
-                .help("Open Editor")
-                .disabled(!store.selection.canEditPage)
+                mainToolbar
             }
         }
         .onAppear {
@@ -98,6 +60,61 @@ struct MainWindow: View {
             Text(store.lastError ?? "")
         }
         .frame(minWidth: 800, minHeight: 480)
+    }
+
+    @ViewBuilder
+    private var mainToolbar: some View {
+        let hasSource = store.selectedSource != nil
+        let canRun = hasSource && runtime.coordinator.canRunVerb
+        let canEdit = store.selection.canEditPage
+
+        Button {
+            runtime.coordinator.run(.validate, store: store, runtime: runtime)
+        } label: {
+            Label("Validate", systemImage: "checkmark.circle")
+        }
+        .help("Validate")
+        .disabled(!canRun)
+
+        Button {
+            runtime.coordinator.run(.buildIR, store: store, runtime: runtime)
+        } label: {
+            Label("Build IR", systemImage: "hammer")
+        }
+        .help("Build IR")
+        .disabled(!canRun)
+
+        Button {
+            runtime.coordinator.stop(runtime: runtime)
+        } label: {
+            Label("Stop", systemImage: "stop.fill")
+        }
+        .help("Stop")
+        .disabled(!runtime.coordinator.canStop)
+
+        Button {
+            openWindow(id: CompanionID.preview)
+        } label: {
+            Label("Preview", systemImage: "safari")
+        }
+        .help("Open Preview")
+        .disabled(!hasSource)
+
+        Button {
+            openWindow(id: CompanionID.editor)
+        } label: {
+            Label("Editor", systemImage: "square.and.pencil")
+        }
+        .help("Open Editor")
+        .disabled(!canEdit)
+
+        Button {
+            openWindow(id: CompanionID.compose)
+        } label: {
+            Label("Compose", systemImage: "pencil")
+        }
+        .help("Compose")
+        .disabled(!canEdit)
     }
 
     private var statusBar: some View {

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -95,12 +95,6 @@ private struct SourceAccountHeader: View {
                         .font(.caption)
                         .foregroundStyle(.orange)
                         .lineLimit(1)
-                } else if let detail = item.detailLine {
-                    Text(detail)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
                 }
             }
         } icon: {

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -36,11 +36,7 @@ struct LocalPlay: PlaySurface {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle(source.title)
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            VStack(spacing: 0) {
-                Divider()
-                ProblemsPane(pages: loadedPages)
-                    .frame(minHeight: 88, idealHeight: 148, maxHeight: 220)
-            }
+            ProblemsPane(pages: loadedPages)
         }
         .task(id: source.id) {
             await load()
@@ -104,7 +100,11 @@ struct LocalPlay: PlaySurface {
         case .ready(let pages):
             VSplitView {
                 pageList(pages)
-                    .frame(minHeight: 120)
+                    .frame(
+                        minHeight: 88,
+                        idealHeight: listIdealHeight(pages.count),
+                        maxHeight: listIdealHeight(pages.count) + 24
+                    )
                 ReadingPane(
                     page: selectedPlayPage,
                     source: source,
@@ -119,19 +119,38 @@ struct LocalPlay: PlaySurface {
 
     private func pageList(_ pages: [PlayPage]) -> some View {
         let filtered = LocalPlayGraph.filter(pages: pages, query: searchText)
+        let selectedID = store.selection.noun?.kind == "page" ? store.selection.noun?.id : nil
         return Group {
             if filtered.isEmpty, !searchText.isEmpty {
                 ContentUnavailableView.search(text: searchText)
             } else {
-                List(filtered, selection: selectedPageID) { page in
-                    PageRow(page: page, findings: runtime.coordinator.checkFindings)
-                        .tag(page.id)
-                        .simultaneousGesture(TapGesture(count: 2).onEnded {
-                            selectPage(page)
-                            openWindow(id: CompanionID.editor)
-                        })
+                // ScrollView, not List: macOS List paints empty zebra slots
+                // for leftover height. Mail's message list is only as tall
+                // as its rows.
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(filtered) { page in
+                            PageRow(page: page, findings: runtime.coordinator.checkFindings)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background {
+                                    if page.id == selectedID {
+                                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                            .fill(Color.accentColor.opacity(0.18))
+                                    }
+                                }
+                                .contentShape(Rectangle())
+                                .onTapGesture { selectPage(page) }
+                                .simultaneousGesture(TapGesture(count: 2).onEnded {
+                                    selectPage(page)
+                                    openWindow(id: CompanionID.editor)
+                                })
+                        }
+                    }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 4)
                 }
-                .listStyle(.inset(alternatesRowBackgrounds: true))
                 .onKeyPress(.return) {
                     guard store.selection.canEditPage else { return .ignored }
                     openWindow(id: CompanionID.editor)
@@ -139,31 +158,16 @@ struct LocalPlay: PlaySurface {
                 }
             }
         }
-        .searchable(text: $searchText, prompt: "Filter by title, id, tag, or status…")
+        .searchable(
+            text: $searchText,
+            placement: .toolbar,
+            prompt: "Filter by title, id, tag, or status…"
+        )
     }
 
-    private var selectedPageID: Binding<String?> {
-        Binding(
-            get: {
-                let noun = store.selection.noun
-                return noun?.kind == "page" ? noun?.id : nil
-            },
-            set: { newID in
-                let currentID = store.selection.noun?.kind == "page" ? store.selection.noun?.id : nil
-                if newID != nil, newID == currentID {
-                    loadGeneration += 1
-                }
-                guard
-                    let newID,
-                    case .ready(let pages) = state,
-                    let page = pages.first(where: { $0.id == newID })
-                else {
-                    store.select(noun: nil)
-                    return
-                }
-                selectPage(page)
-            }
-        )
+    private func listIdealHeight(_ count: Int) -> CGFloat {
+        let rows = CGFloat(min(max(count, 1), 8))
+        return 12 + rows * 44
     }
 
     private func selectPage(_ page: PlayPage) {

--- a/Sources/Play/Local/ProblemsPane.swift
+++ b/Sources/Play/Local/ProblemsPane.swift
@@ -9,7 +9,9 @@ struct ProblemsPane: View {
     @Environment(WorkspaceStore.self) private var store
 
     var body: some View {
+        let hasProblems = !runtime.coordinator.problems.isEmpty
         VStack(alignment: .leading, spacing: 0) {
+            Divider()
             HStack(spacing: 8) {
                 if runtime.coordinator.isRunning {
                     ProgressView()
@@ -25,18 +27,21 @@ struct ProblemsPane: View {
                 }
             }
             .font(.caption)
+            .foregroundStyle(.secondary)
             .padding(.horizontal, 8)
             .padding(.vertical, 5)
 
-            if !runtime.coordinator.problems.isEmpty {
+            if hasProblems {
                 Divider()
                 List(runtime.coordinator.problems, selection: selectedProblem) { item in
                     ProblemRow(item: item)
                         .tag(item.id)
                 }
-                .listStyle(.inset(alternatesRowBackgrounds: true))
+                .listStyle(.inset)
+                .frame(minHeight: 80, idealHeight: 140, maxHeight: 200)
             }
         }
+        .background(.bar)
     }
 
     private var selectedProblem: Binding<String?> {

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -62,7 +62,9 @@ is a separate window — the native buffer — not a tab in Play.
 
 A **source** is a place content lives or publishes: a local folder
 (security-scoped bookmark), a GitHub repo, later whatever earns a
-provider. The first source type is local. GitHub is the second.
+provider. The first source type is local. GitHub — and git remotes
+on a folder we already hold — is the second. They are added in
+Settings → Sources, same store as File → Open….
 
 Sources are **accounts**. They are added, renamed, relocated, and
 removed in **Settings → Sources**, the way Mail adds accounts. File →

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -103,9 +103,12 @@ No scraped prose. No homegrown graph. No third settings store.
   highlight, front-matter form, Cooklang autocomplete, bundling
   `oliver` next to `boris`. The M10 gate is the window + save +
   preview seam (#106 / #108), not those.
-- GitHub as a second **source** (account header + its own mailboxes;
-  we do not have full GitHub access; Pages as a *target* does not
-  require it)
+- **Git / GitHub as sources**, added in Settings → Sources the same
+  way a local folder is. A GitHub repo is the second account type
+  (already reserved on `SourceKind`). Local git remotes on a folder
+  we already have (status, fetch, Boris’s Pages workflow) sit next
+  to that — still `Source`, not a third store. Pages as a *target*
+  does not require this.
 - Content-audit mailbox (`boris-content-audit`)
 - Source-RAG export for AI assist
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)


### PR DESCRIPTION
Visual pass on the window we actually had open. Not a new milestone.

## What

- Pages list is a short stack (no macOS `List` zebra slots for leftover height).
- Settings source list same: one row, not a striped empty table.
- Account header is the title; path stays in the tooltip.
- Problems strip collapses when idle (status bar already has the summary).
- Compose is on the toolbar (pencil).
- Settings + ROADMAP name GitHub / git remotes as a later source in the same account book.

## Still open (issues)

- Trunk page (`index` / My Boris Site) is in the graph (3 pages) and still not drawing — first row looks clipped under the detail chrome.
- Toolbar stays icon-only on macOS 26 glass; labels did not stick.

## Verify

`SKIP_EMBED_BORIS=1 make build` + `make test` green (211 passed locally).