### PR TITLE
feat(compose): put the native editor where you can find it (#132)

### DIFF
--- a/Sources/Compose/ComposeWindow.swift
+++ b/Sources/Compose/ComposeWindow.swift
@@ -137,8 +137,23 @@ struct ComposeWindow: View {
         ContentUnavailableView {
             Label("Compose", systemImage: "square.and.pencil")
         } description: {
-            Text("Select a page in the main window, then open the compose window.")
+            Text(emptyStateMessage)
         }
+    }
+
+    /// Compose is the native buffer for the selected page's source file.
+    /// Say so here instead of a blank window that looks like the feature
+    /// is missing; name the missing selection so the gate reads clearly.
+    private var emptyStateMessage: String {
+        let intro = "Compose is the native editor for a page's source file. "
+        if store.selectedSource == nil {
+            return intro
+                + "Add a source first: File → Open… or Settings → Sources "
+                + "(try Stunts/happy), then select a page in the Pages mailbox."
+        }
+        return intro
+            + "Select a page in the Pages mailbox, then open it from "
+            + "View → Compose (⌘⇧C), the letter header, or the toolbar."
     }
 
     private var statusBar: some View {

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -144,7 +144,7 @@ struct LocalPlay: PlaySurface {
                                 .onTapGesture { selectPage(page) }
                                 .simultaneousGesture(TapGesture(count: 2).onEnded {
                                     selectPage(page)
-                                    openWindow(id: CompanionID.editor)
+                                    openWindow(id: CompanionID.compose)
                                 })
                         }
                     }
@@ -153,7 +153,7 @@ struct LocalPlay: PlaySurface {
                 }
                 .onKeyPress(.return) {
                     guard store.selection.canEditPage else { return .ignored }
-                    openWindow(id: CompanionID.editor)
+                    openWindow(id: CompanionID.compose)
                     return .handled
                 }
             }

--- a/Sources/Play/Local/ReadingPane.swift
+++ b/Sources/Play/Local/ReadingPane.swift
@@ -89,6 +89,13 @@ struct ReadingPane: View {
                 Label("Edit", systemImage: "square.and.pencil")
             }
             .help("Open the hosted editor for this page")
+
+            Button {
+                openWindow(id: CompanionID.compose)
+            } label: {
+                Label("Compose", systemImage: "pencil")
+            }
+            .help("Open the native Compose editor for this page")
         }
         .buttonStyle(.bordered)
         .controlSize(.small)


### PR DESCRIPTION
## feat(compose): put the native editor where you can find it (#132)

Compose was in the menu but not the chrome you look at. This surfaces it in the three places the issue names.

**Changes**

1. **Letter header**: new **Compose** button next to Preview / Edit in the reading pane, opening `CompanionID.compose` (`ReadingPane.swift`).
2. **Double-click / Return** on a Pages row now opens **Compose** (Mail's compose), not the hosted editor (`LocalPlay.swift`). Hosted `boris-editor` stays at View → Editor / File → Edit Page.
3. **Compose empty state** (`ComposeWindow.swift`): names the native editor, the missing selection, and the path in — "Compose is the native editor for a page's source file…" with a source-first message when no source is selected, and a select-a-page message with the ⌘⇧C / letter-header / toolbar routes when one is. No more blank window that looks like the feature is missing.

**Already on main:** toolbar Compose landed with #129 (same `canEditPage` enablement), so item 2 of the issue needed nothing here.

**Deliberately not touched:** highlighter / Oliver preview, `oliver` bundling, `boris-editor` hiding. Not blocked on #130 (missing trunk row) but it does make "select a page" harder than it should be — worth a look separately.

**Verified:** `SKIP_EMBED_BORIS=1 make build` green · `make test` 205 tests, 0 failures · `make lint` 0 violations.

The hands-on gate (select Getting Started → Compose opens the buffer for that `sourcePath`) needs a live `boris` graph, same as the #102 gate.
