### PR TITLE
fix(play): keep Outputs/Publish/Plan/Activity lists clear of the toolbar band

### DIFF
--- a/Sources/Play/Local/ActivityPane.swift
+++ b/Sources/Play/Local/ActivityPane.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// tracking verb, exit code, execution timings duration, problem counts, and diagnostics.
 struct ActivityPane: View {
     @Environment(AppRuntime.self) private var runtime
+    @Environment(\.toolbarBand) private var toolbarBand
 
     var body: some View {
         Group {
@@ -37,6 +38,7 @@ struct ActivityPane: View {
             }
         }
         .listStyle(.inset(alternatesRowBackgrounds: true))
+        .safeAreaPadding(.top, toolbarBand)
     }
 }
 

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -42,6 +42,7 @@ struct LocalPlay: PlaySurface {
             ProblemsPane(pages: loadedPages)
         }
         .background(ToolbarBandReader { toolbarBand = $0 })
+        .environment(\.toolbarBand, toolbarBand)
         .task(id: source.id) {
             await load()
         }
@@ -323,33 +324,6 @@ struct LocalPlay: PlaySurface {
         case empty
         case ready([PlayPage])
         case failed(String)
-    }
-}
-
-/// Measures the window's floating toolbar band height for #130.
-///
-/// The main window uses `.fullSizeContentView` + `.glassEffect()`, so the
-/// toolbar floats *over* the content and is deliberately absent from the
-/// SwiftUI safe area (a `GeometryReader` here reports top == 0). AppKit still
-/// reserves the band in `contentLayoutRect`; `frame.height - maxY` is the
-/// exact band, which the Pages list uses as its scroll-content inset instead
-/// of a hardcoded spacer.
-private struct ToolbarBandReader: NSViewRepresentable {
-    var onBand: (CGFloat) -> Void
-
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        DispatchQueue.main.async { measure(view) }
-        return view
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async { measure(nsView) }
-    }
-
-    private func measure(_ view: NSView) {
-        guard let window = view.window else { return }
-        onBand(max(0, window.frame.height - window.contentLayoutRect.maxY))
     }
 }
 

--- a/Sources/Play/Local/OutputsPane.swift
+++ b/Sources/Play/Local/OutputsPane.swift
@@ -9,6 +9,7 @@ struct OutputsPane: View {
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
+    @Environment(\.toolbarBand) private var toolbarBand
     @State private var profile: PublicationProfile?
     @State private var loadError: String?
 
@@ -107,6 +108,7 @@ struct OutputsPane: View {
             }
         }
         .listStyle(.inset(alternatesRowBackgrounds: true))
+        .safeAreaPadding(.top, toolbarBand)
     }
 
     private var selectedOutputID: Binding<String?> {

--- a/Sources/Play/Local/PlanPane.swift
+++ b/Sources/Play/Local/PlanPane.swift
@@ -7,6 +7,7 @@ struct PlanPane: View {
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
+    @Environment(\.toolbarBand) private var toolbarBand
     @State private var plan: PublicationPlan?
 
     var body: some View {
@@ -144,6 +145,7 @@ struct PlanPane: View {
             }
         }
         .listStyle(.inset(alternatesRowBackgrounds: true))
+        .safeAreaPadding(.top, toolbarBand)
     }
 
     private func loadIfPossible() {

--- a/Sources/Play/Local/PublishPane.swift
+++ b/Sources/Play/Local/PublishPane.swift
@@ -9,6 +9,7 @@ struct PublishPane: View {
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
+    @Environment(\.toolbarBand) private var toolbarBand
     @State private var profile: PublicationProfile?
     @State private var proofFiles: [ProofFileItem] = []
     @State private var proofPack: ProofPackDocument?
@@ -48,6 +49,7 @@ struct PublishPane: View {
             evidenceFilesSection
         }
         .listStyle(.inset(alternatesRowBackgrounds: true))
+        .safeAreaPadding(.top, toolbarBand)
         .task(id: source.id) {
             load()
         }

--- a/Sources/Play/Local/ToolbarBand.swift
+++ b/Sources/Play/Local/ToolbarBand.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Height of the main window's floating glass toolbar band (#130).
+///
+/// The main window uses `.fullSizeContentView` + `.glassEffect()`, so the
+/// toolbar floats *over* the content and is deliberately absent from the
+/// SwiftUI safe area (a `GeometryReader` in the detail column reports
+/// `top == 0`). AppKit still reserves the band in `contentLayoutRect`, so
+/// `frame.height - contentLayoutRect.maxY` is the exact band. Mailbox lists
+/// inset their scroll content by this measured value instead of a hardcoded
+/// spacer.
+private struct ToolbarBandKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    var toolbarBand: CGFloat {
+        get { self[ToolbarBandKey.self] }
+        set { self[ToolbarBandKey.self] = newValue }
+    }
+}
+
+/// Measures the band from the window the view lands in.
+struct ToolbarBandReader: NSViewRepresentable {
+    var onBand: (CGFloat) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { measure(view) }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { measure(nsView) }
+    }
+
+    private func measure(_ view: NSView) {
+        guard let window = view.window else { return }
+        onBand(max(0, window.frame.height - window.contentLayoutRect.maxY))
+    }
+}


### PR DESCRIPTION
Follow-up to #130 (merged in #134) — the same first-row-under-toolbar clipping existed in the other mailboxes.

## Verified (live, `Stunts/happy`, no boris binary)

| Mailbox | Before | After |
|---|---|---|
| Outputs | "HTML Targets" header at y=47, first row at y=86 — under the band (40..92), colliding with the nav title | scroll area at y=92, header at y=99 ✅ |
| Publish | "Publication Declaration" at y=47, first row at y=82 | scroll area at y=92, header at y=99 ✅ |
| Plan / Activity | empty states only in this fixture (centered, unaffected) — same `List` structure when non-empty | same inset applied |

Pages regression-checked after the change — trunk row still at y=102, all three rows visible. ✅

## What changed

- `ToolbarBandReader` + an `EnvironmentValues.toolbarBand` key moved to a shared file (`Sources/Play/Local/ToolbarBand.swift`); `LocalPlay` measures once and injects the band into the environment.
- Each mailbox pane (`OutputsPane`, `PublishPane`, `PlanPane`, `ActivityPane`) reads it and applies `.safeAreaPadding(.top, toolbarBand)` to its `List`.

One implementation note: `.contentMargins(.top, band, for: .scrollContent)` — the mechanism used for the Pages `ScrollView` — is **ignored by `List`** (measured: header stayed at y=47). The explicit-length `.safeAreaPadding(.top, band)` is what actually moves a `List`'s first row below the band.

## Verification

- `SKIP_EMBED_BORIS=1 make build` ✅ · `make test` 211 tests, 0 failures ✅ · `make lint` 0 ✅
- Live AX geometry checks above, on the final build.
