### PR TITLE
feat(chassis): interactive split, sidebar hierarchy, context inspector, and binary settings

### DIFF
--- a/Sources/App/AppRuntime.swift
+++ b/Sources/App/AppRuntime.swift
@@ -7,15 +7,20 @@ import Observation
 @MainActor
 @Observable
 final class AppRuntime {
-    let engine: BorisEngine?
-    let enginePath: String?
-    let engineError: String?
+    private(set) var engine: BorisEngine?
+    private(set) var enginePath: String?
+    private(set) var engineError: String?
     private(set) var engineVersion: String
     let coordinator = Coordinator()
     let credentials = PublishCredentialManager()
     let previewSession = PreviewSession()
 
     init() {
+        engineVersion = "boris"
+        reloadEngine()
+    }
+
+    func reloadEngine() {
         if let url = BorisBinary.locate() {
             enginePath = url.path
             do {

--- a/Sources/App/Settings/EngineSettingsPane.swift
+++ b/Sources/App/Settings/EngineSettingsPane.swift
@@ -1,0 +1,265 @@
+import AppKit
+import SwiftUI
+
+/// Settings pane displaying the Boris compiler and Oliver renderer binary status,
+/// active paths, detected versions, custom path selection, and search-order guidance.
+struct EngineSettingsPane: View {
+    @Environment(AppRuntime.self) private var runtime
+    @State private var refreshTrigger = UUID()
+
+    @AppStorage("customBorisBinaryPath") private var customBorisPath: String = ""
+    @AppStorage("customOliverBinaryPath") private var customOliverPath: String = ""
+    @AppStorage("customBorisEditorBinaryPath") private var customEditorPath: String = ""
+
+    private var borisURL: URL? {
+        _ = refreshTrigger
+        return BorisBinary.locate()
+    }
+
+    private var oliverURL: URL? {
+        _ = refreshTrigger
+        return OliverBinary.locate(borisBinary: borisURL)
+    }
+
+    private var editorURL: URL? {
+        _ = refreshTrigger
+        if !customEditorPath.isEmpty, FileManager.default.isExecutableFile(atPath: customEditorPath) {
+            return URL(fileURLWithPath: customEditorPath)
+        }
+        if let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_EDITOR_BIN"],
+           !env.isEmpty, FileManager.default.isExecutableFile(atPath: env)
+        {
+            return URL(fileURLWithPath: env)
+        }
+        if let boris = borisURL {
+            let sibling = boris.deletingLastPathComponent().appendingPathComponent("boris-editor")
+            if FileManager.default.isExecutableFile(atPath: sibling.path) { return sibling }
+        }
+        if let bundled = Bundle.main.url(forResource: "boris-editor", withExtension: nil),
+           FileManager.default.isExecutableFile(atPath: bundled.path)
+        {
+            return bundled
+        }
+        return nil
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                LabeledContent("Boris Engine") {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(runtime.engine != nil ? Color.green : Color.red)
+                            .frame(width: 8, height: 8)
+                        Text(runtime.engineVersion)
+                            .fontWeight(.medium)
+                    }
+                }
+
+                if let path = runtime.enginePath ?? borisURL?.path {
+                    LabeledContent("Binary Path") {
+                        Text(path)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .lineLimit(2)
+                    }
+                    LabeledContent("Origin") {
+                        Text(originDescription(for: path))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let error = runtime.engineError {
+                    LabeledContent("Error") {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                LabeledContent("Custom Binary") {
+                    HStack(spacing: 8) {
+                        Button("Choose Custom Boris…") {
+                            chooseBinary(prompt: "Select Boris executable") { path in
+                                customBorisPath = path
+                                runtime.reloadEngine()
+                                refreshTrigger = UUID()
+                            }
+                        }
+                        if !customBorisPath.isEmpty {
+                            Button("Reset to Embedded") {
+                                customBorisPath = ""
+                                runtime.reloadEngine()
+                                refreshTrigger = UUID()
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("Boris Compiler")
+            }
+
+            Section {
+                LabeledContent("Oliver Renderer") {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(oliverURL != nil ? Color.green : Color.orange)
+                            .frame(width: 8, height: 8)
+                        Text(oliverURL != nil ? "Available" : "Not Found")
+                            .fontWeight(.medium)
+                    }
+                }
+
+                if let oliverPath = oliverURL?.path {
+                    LabeledContent("Binary Path") {
+                        Text(oliverPath)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .lineLimit(2)
+                    }
+                }
+
+                LabeledContent("Custom Binary") {
+                    HStack(spacing: 8) {
+                        Button("Choose Custom Oliver…") {
+                            chooseBinary(prompt: "Select Oliver executable") { path in
+                                customOliverPath = path
+                                refreshTrigger = UUID()
+                            }
+                        }
+                        if !customOliverPath.isEmpty {
+                            Button("Reset to Default") {
+                                customOliverPath = ""
+                                refreshTrigger = UUID()
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("Oliver Markup Engine")
+            }
+
+            Section {
+                LabeledContent("Boris Editor") {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(editorURL != nil ? Color.green : Color.orange)
+                            .frame(width: 8, height: 8)
+                        Text(editorURL != nil ? "Available" : "Not Found")
+                            .fontWeight(.medium)
+                    }
+                }
+
+                if let edPath = editorURL?.path {
+                    LabeledContent("Binary Path") {
+                        Text(edPath)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .lineLimit(2)
+                    }
+                }
+
+                LabeledContent("Custom Binary") {
+                    HStack(spacing: 8) {
+                        Button("Choose Custom Editor…") {
+                            chooseBinary(prompt: "Select boris-editor executable") { path in
+                                customEditorPath = path
+                                refreshTrigger = UUID()
+                            }
+                        }
+                        if !customEditorPath.isEmpty {
+                            Button("Reset to Default") {
+                                customEditorPath = ""
+                                refreshTrigger = UUID()
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("Boris Editor Host")
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Solipsist searches for binaries in the following order:")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        searchStep(
+                            index: "1",
+                            title: "Settings Custom Preference",
+                            detail: "User-selected path saved in Preferences"
+                        )
+                        searchStep(
+                            index: "2",
+                            title: "Environment Variables",
+                            detail: "SOLIPSIST_BORIS_BIN / SOLIPSIST_OLIVER_BIN / SOLIPSIST_BORIS_EDITOR_BIN"
+                        )
+                        searchStep(
+                            index: "3",
+                            title: "App Bundle (Embedded)",
+                            detail: "Solipsist.app/Contents/Resources/…"
+                        )
+                        searchStep(
+                            index: "4",
+                            title: "Sibling Repository / Kits",
+                            detail: "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/… or ../boris/zig-out/bin/…"
+                        )
+                    }
+                    .padding(.top, 2)
+                }
+            } header: {
+                Text("Binary Discovery & Sourcing")
+            }
+        }
+        .formStyle(.grouped)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func chooseBinary(prompt: String, onSelect: @escaping (String) -> Void) {
+        let panel = NSOpenPanel()
+        panel.title = prompt
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.resolvesAliases = true
+        if panel.runModal() == .OK, let url = panel.url {
+            onSelect(url.path)
+        }
+    }
+
+    private func searchStep(index: String, title: String, detail: String) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text("\(index).")
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+                .frame(width: 14, alignment: .trailing)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.caption.bold())
+                Text(detail)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func originDescription(for path: String) -> String {
+        if !customBorisPath.isEmpty, path == customBorisPath {
+            return "User-selected custom binary"
+        } else if path.contains(".app/Contents/Resources") {
+            return "Embedded in Solipsist.app bundle"
+        } else if let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_BIN"], !env.isEmpty, path == env {
+            return "Custom override via SOLIPSIST_BORIS_BIN"
+        } else if path.contains("SUPPORT-NOT-FOR-GITHUB") {
+            return "Local agent transport kit"
+        } else if path.contains("zig-out") {
+            return "Local Zig build checkout"
+        } else {
+            return "Local file system"
+        }
+    }
+}

--- a/Sources/App/Settings/SettingsRoot.swift
+++ b/Sources/App/Settings/SettingsRoot.swift
@@ -8,7 +8,11 @@ struct SettingsRoot: View {
                 .tabItem {
                     Label("Sources", systemImage: "folder")
                 }
+            EngineSettingsPane()
+                .tabItem {
+                    Label("Engine", systemImage: "cpu")
+                }
         }
-        .frame(minWidth: 520, minHeight: 360)
+        .frame(minWidth: 540, minHeight: 380)
     }
 }

--- a/Sources/Chrome/InspectorDrawer.swift
+++ b/Sources/Chrome/InspectorDrawer.swift
@@ -12,7 +12,8 @@ struct InspectorDrawer: View {
             } else {
                 let snapshot = InspectorSnapshot(
                     sourceKind: store.selectedSource?.kind,
-                    nounKind: store.selection.noun?.kind
+                    nounKind: store.selection.noun?.kind,
+                    mailbox: store.selection.mailbox
                 )
                 if snapshot.inspectorSections.isEmpty {
                     drawerNote("Select a source to inspect its options.")
@@ -25,6 +26,8 @@ struct InspectorDrawer: View {
                         }
                     }
                     .formStyle(.grouped)
+                    .safeAreaPadding(.top, 6)
+                    .safeAreaPadding(.bottom, 54)
                 }
             }
         }

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -23,8 +23,9 @@ struct MainWindow: View {
         .navigationTitle("Solipsist")
         .inspector(isPresented: $inspectorPresented) {
             InspectorDrawer()
-                .frame(minWidth: 240, idealWidth: 280, maxWidth: 380)
+                .inspectorColumnWidth(min: 280, ideal: 330, max: 440)
         }
+        .inspectorColumnWidth(min: 280, ideal: 330, max: 440)
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
                 mainToolbar
@@ -59,7 +60,7 @@ struct MainWindow: View {
         } message: {
             Text(store.lastError ?? "")
         }
-        .frame(minWidth: 800, minHeight: 480)
+        .frame(minWidth: 920, minHeight: 520)
     }
 
     @ViewBuilder
@@ -115,6 +116,13 @@ struct MainWindow: View {
         }
         .help("Compose")
         .disabled(!canEdit)
+
+        Button {
+            inspectorPresented.toggle()
+        } label: {
+            Label("Inspector", systemImage: "sidebar.trailing")
+        }
+        .help("Toggle Inspector (⌥⌘I)")
     }
 
     private var statusBar: some View {

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -4,31 +4,23 @@ import SwiftUI
 struct SourceSidebar: View {
     @Environment(WorkspaceStore.self) private var store
 
+    @State private var toolbarBand: CGFloat = 0
+    @State private var collapsedSources: Set<SourceID> = []
+
     var body: some View {
         List(selection: selectedRow) {
             ForEach(store.sources) { item in
-                Section {
-                    ForEach(WorkspaceMailbox.all, id: \.self) { box in
-                        Label(
-                            WorkspaceMailbox.displayName(box),
-                            systemImage: WorkspaceMailbox.symbolName(box)
-                        )
-                        .tag(MailboxRowID(sourceID: item.id, mailbox: box))
-                        .accessibilityLabel("\(item.title), \(WorkspaceMailbox.displayName(box))")
-                        .contextMenu { sourceMenu(item) }
-                    }
-                } header: {
-                    SourceAccountHeader(item: item)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            store.select(item.id, mailbox: WorkspaceMailbox.pages)
-                        }
-                        .contextMenu { sourceMenu(item) }
-                }
+                SourceSection(
+                    item: item,
+                    isExpanded: isExpanded(for: item.id),
+                    store: store
+                )
             }
         }
         .listStyle(.sidebar)
         .navigationTitle("Mailboxes")
+        .safeAreaPadding(.top, max(toolbarBand, 62))
+        .background(ToolbarBandReader { toolbarBand = $0 })
         .overlay {
             if store.sources.isEmpty {
                 EmptyStateView(
@@ -50,6 +42,19 @@ struct SourceSidebar: View {
         }
     }
 
+    private func isExpanded(for sourceID: SourceID) -> Binding<Bool> {
+        Binding(
+            get: { !collapsedSources.contains(sourceID) },
+            set: { expanded in
+                if expanded {
+                    collapsedSources.remove(sourceID)
+                } else {
+                    collapsedSources.insert(sourceID)
+                }
+            }
+        )
+    }
+
     private var selectedRow: Binding<MailboxRowID?> {
         Binding(
             get: {
@@ -68,6 +73,25 @@ struct SourceSidebar: View {
             }
         )
     }
+}
+
+private struct SourceSection: View {
+    let item: SourceItem
+    @Binding var isExpanded: Bool
+    let store: WorkspaceStore
+
+    var body: some View {
+        Section(isExpanded: $isExpanded) {
+            ForEach(WorkspaceMailbox.all, id: \.self) { box in
+                MailboxRow(item: item, box: box)
+                    .tag(MailboxRowID(sourceID: item.id, mailbox: box))
+                    .contextMenu { sourceMenu(item) }
+            }
+        } header: {
+            SourceAccountHeader(item: item)
+                .contextMenu { sourceMenu(item) }
+        }
+    }
 
     @ViewBuilder
     private func sourceMenu(_ item: SourceItem) -> some View {
@@ -82,26 +106,48 @@ struct SourceSidebar: View {
     }
 }
 
+private struct MailboxRow: View {
+    let item: SourceItem
+    let box: String
+
+    var body: some View {
+        Label {
+            Text(WorkspaceMailbox.displayName(box))
+                .font(.system(size: 12.5, weight: .regular))
+        } icon: {
+            Image(systemName: WorkspaceMailbox.symbolName(box))
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityLabel("\(item.title), \(WorkspaceMailbox.displayName(box))")
+    }
+}
+
 private struct SourceAccountHeader: View {
     let item: SourceItem
 
     var body: some View {
-        Label {
+        HStack(spacing: 7) {
+            Image(systemName: item.symbolName)
+                .font(.system(size: 14, weight: .semibold))
+                .symbolVariant(item.isAvailable ? .none : .slash)
+                .foregroundStyle(item.isAvailable ? Color.accentColor : Color.orange)
+
             VStack(alignment: .leading, spacing: 1) {
                 Text(item.title)
+                    .font(.system(size: 13.5, weight: .bold))
+                    .foregroundStyle(.primary)
                     .lineLimit(1)
                 if !item.isAvailable {
                     Text("Unreachable — Relocate / Remove")
-                        .font(.caption)
+                        .font(.caption2)
                         .foregroundStyle(.orange)
                         .lineLimit(1)
                 }
             }
-        } icon: {
-            Image(systemName: item.symbolName)
-                .symbolVariant(item.isAvailable ? .none : .slash)
-                .foregroundStyle(item.isAvailable ? Color.primary : Color.orange)
+            Spacer()
         }
+        .padding(.vertical, 3)
         .help(
             item.isAvailable
                 ? (item.detailLine ?? item.title)

--- a/Sources/Companions/Editor/EditorSession.swift
+++ b/Sources/Companions/Editor/EditorSession.swift
@@ -167,6 +167,11 @@ final class EditorSession {
     }
 
     private func findEditorBinary(relativeTo engineBinary: URL) -> URL? {
+        if let custom = UserDefaults.standard.string(forKey: "customBorisEditorBinaryPath"), !custom.isEmpty {
+            let url = URL(fileURLWithPath: custom)
+            if FileManager.default.isExecutableFile(atPath: url.path) { return url }
+        }
+
         let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_EDITOR_BIN"]
         if let env, !env.isEmpty, FileManager.default.isExecutableFile(atPath: env) {
             return URL(fileURLWithPath: env)
@@ -180,6 +185,19 @@ final class EditorSession {
         let bundled = Bundle.main.url(forResource: "boris-editor", withExtension: nil)
         if let bundled, FileManager.default.isExecutableFile(atPath: bundled.path) {
             return bundled
+        }
+
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let devCandidates = [
+            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris-editor",
+            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/bin/boris-editor",
+            "../boris-agent-kit/bin/boris-editor",
+            "editor/zig-out/bin/boris-editor",
+            "../boris/editor/zig-out/bin/boris-editor",
+        ]
+        for relative in devCandidates {
+            let url = cwd.appendingPathComponent(relative).standardizedFileURL
+            if FileManager.default.isExecutableFile(atPath: url.path) { return url }
         }
 
         return nil

--- a/Sources/Engine/BorisBinary.swift
+++ b/Sources/Engine/BorisBinary.swift
@@ -17,6 +17,11 @@ public enum BorisBinary {
             fm.isExecutableFile(atPath: url.path)
         }
 
+        if let custom = UserDefaults.standard.string(forKey: "customBorisBinaryPath"), !custom.isEmpty {
+            let url = URL(fileURLWithPath: custom)
+            if isExecutable(url) { return url }
+        }
+
         if let override = environment["SOLIPSIST_BORIS_BIN"], !override.isEmpty {
             let url = URL(fileURLWithPath: override)
             if isExecutable(url) { return url }

--- a/Sources/Engine/OliverBinary.swift
+++ b/Sources/Engine/OliverBinary.swift
@@ -19,6 +19,11 @@ public enum OliverBinary {
             fm.isExecutableFile(atPath: url.path)
         }
 
+        if let custom = UserDefaults.standard.string(forKey: "customOliverBinaryPath"), !custom.isEmpty {
+            let url = URL(fileURLWithPath: custom)
+            if isExecutable(url) { return url }
+        }
+
         if let override = environment["SOLIPSIST_OLIVER_BIN"], !override.isEmpty {
             let url = URL(fileURLWithPath: override)
             if isExecutable(url) { return url }

--- a/Sources/Inspector/Inspectable.swift
+++ b/Sources/Inspector/Inspectable.swift
@@ -29,20 +29,57 @@ enum InspectorNounKind {
 struct InspectorSnapshot: Inspectable {
     var sourceKind: SourceKind?
     var nounKind: String?
+    var mailbox: String?
 
     var inspectorSections: [InspectorSection] {
         guard let sourceKind else { return [] }
         var sections: [InspectorSection] = []
-        if sourceKind == .local {
-            sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Profile"))
+
+        let box = WorkspaceMailbox.display(mailbox)
+
+        switch box {
+        case WorkspaceMailbox.pages:
+            if nounKind == InspectorNounKind.page {
+                sections.append(InspectorSection(id: InspectorSectionID.page, title: "Page"))
+            } else if sourceKind == .local {
+                sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Site Profile"))
+            }
+            sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
+
+        case WorkspaceMailbox.outputs:
+            if nounKind == InspectorNounKind.target {
+                sections.append(InspectorSection(id: InspectorSectionID.target, title: "Target"))
+            }
+            if sourceKind == .local {
+                sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Targets & Profile"))
+            }
+            sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
+
+        case WorkspaceMailbox.publish:
+            if sourceKind == .local {
+                sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Publication Target"))
+            }
+            sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
+
+        case WorkspaceMailbox.plan, WorkspaceMailbox.activity:
+            sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution Controls"))
+            if sourceKind == .local {
+                sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Site Profile"))
+            }
+
+        default:
+            if nounKind == InspectorNounKind.page {
+                sections.append(InspectorSection(id: InspectorSectionID.page, title: "Page"))
+            }
+            if nounKind == InspectorNounKind.target {
+                sections.append(InspectorSection(id: InspectorSectionID.target, title: "Target"))
+            }
+            if sourceKind == .local {
+                sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Profile"))
+            }
+            sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
         }
-        if nounKind == InspectorNounKind.page {
-            sections.append(InspectorSection(id: InspectorSectionID.page, title: "Page"))
-        }
-        if nounKind == InspectorNounKind.target {
-            sections.append(InspectorSection(id: InspectorSectionID.target, title: "Target"))
-        }
-        sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
+
         return sections
     }
 }

--- a/Sources/Play/Local/ActivityPane.swift
+++ b/Sources/Play/Local/ActivityPane.swift
@@ -37,7 +37,7 @@ struct ActivityPane: View {
                 }
             }
         }
-        .listStyle(.inset(alternatesRowBackgrounds: true))
+        .listStyle(.inset)
         .safeAreaPadding(.top, toolbarBand)
     }
 }

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Play surface for a local folder: mailbox contents plus, for Pages, a
@@ -103,20 +104,54 @@ struct LocalPlay: PlaySurface {
                 Button("Try Again") { reload() }
             }
         case .ready(let pages):
-            VSplitView {
-                // Fixed height — not min/ideal/max: the VSplitView ignores a
-                // later ideal-height change from the async band measurement
-                // and clips the last row (#130). The list is a short stack
-                // only as tall as its rows; the splitter still resizes the
-                // reading pane below.
+            pagesSplit(pages)
+        }
+    }
+
+    @State private var topHeight: CGFloat = 200
+
+    @ViewBuilder
+    private func pagesSplit(_ pages: [PlayPage]) -> some View {
+        GeometryReader { proxy in
+            let totalHeight = proxy.size.height
+            let availableHeight = max(totalHeight - 10, 100)
+            let clampedTop = min(max(topHeight, 90), availableHeight - 120)
+
+            VStack(spacing: 0) {
                 pageList(pages)
-                    .frame(height: listIdealHeight(pages.count))
+                    .frame(height: clampedTop)
+
+                ZStack {
+                    Rectangle()
+                        .fill(Color(nsColor: .separatorColor))
+                        .frame(height: 1)
+
+                    Capsule()
+                        .fill(Color.secondary.opacity(0.4))
+                        .frame(width: 36, height: 4)
+                }
+                .frame(height: 9)
+                .contentShape(Rectangle())
+                .onHover { inside in
+                    if inside {
+                        NSCursor.resizeUpDown.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+                .gesture(
+                    DragGesture(minimumDistance: 1)
+                        .onChanged { value in
+                            topHeight = min(max(clampedTop + value.translation.height, 90), availableHeight - 120)
+                        }
+                )
+
                 ReadingPane(
                     page: selectedPlayPage,
                     source: source,
                     loadGeneration: loadGeneration
                 )
-                .frame(minHeight: 160)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
     }
@@ -125,49 +160,25 @@ struct LocalPlay: PlaySurface {
 
     private func pageList(_ pages: [PlayPage]) -> some View {
         let filtered = LocalPlayGraph.filter(pages: pages, query: searchText)
-        let selectedID = store.selection.noun?.kind == "page" ? store.selection.noun?.id : nil
         return Group {
             if filtered.isEmpty, !searchText.isEmpty {
                 ContentUnavailableView.search(text: searchText)
             } else {
-                // ScrollView, not List: macOS List paints empty zebra slots
-                // for leftover height. Mail's message list is only as tall
-                // as its rows.
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(filtered) { page in
-                            PageRow(page: page, findings: runtime.coordinator.checkFindings)
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 6)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .background {
-                                    if page.id == selectedID {
-                                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                            .fill(Color.accentColor.opacity(0.18))
-                                    }
-                                }
-                                .contentShape(Rectangle())
-                                .onTapGesture { selectPage(page) }
-                                .simultaneousGesture(TapGesture(count: 2).onEnded {
-                                    selectPage(page)
-                                    openWindow(id: CompanionID.compose)
-                                })
-                        }
-                    }
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 4)
+                List(filtered, selection: selectedPageID) { page in
+                    PageRow(page: page, findings: runtime.coordinator.checkFindings)
+                        .tag(page.id)
+                        .simultaneousGesture(TapGesture(count: 2).onEnded {
+                            selectPage(page)
+                            openWindow(id: CompanionID.compose)
+                        })
                 }
+                .listStyle(.inset)
+                .safeAreaPadding(.top, toolbarBand)
                 .onKeyPress(.return) {
                     guard store.selection.canEditPage else { return .ignored }
                     openWindow(id: CompanionID.compose)
                     return .handled
                 }
-                // #130: the main window is `.fullSizeContentView` glass, so
-                // the floating toolbar is not in the SwiftUI safe area and
-                // the first row would paint underneath the title band. Inset
-                // the scroll content by the measured band — the system's own
-                // number, not an invented spacer.
-                .contentMargins(.top, toolbarBand, for: .scrollContent)
             }
         }
         .searchable(
@@ -177,9 +188,24 @@ struct LocalPlay: PlaySurface {
         )
     }
 
-    private func listIdealHeight(_ count: Int) -> CGFloat {
-        let rows = CGFloat(min(max(count, 1), 8))
-        return toolbarBand + 12 + rows * 44
+    private var selectedPageID: Binding<String?> {
+        Binding(
+            get: {
+                if store.selection.noun?.kind == "page" {
+                    return store.selection.noun?.id
+                }
+                return nil
+            },
+            set: { newID in
+                guard let newID else {
+                    store.select(noun: nil)
+                    return
+                }
+                if let page = loadedPages.first(where: { $0.id == newID }) {
+                    selectPage(page)
+                }
+            }
+        )
     }
 
     private func selectPage(_ page: PlayPage) {
@@ -288,20 +314,23 @@ struct LocalPlay: PlaySurface {
     /// Keep the page noun honest after a graph reload: rewrite title +
     /// `sourcePath` when the id still exists, otherwise drop the letter.
     private func refreshNoun(against pages: [PlayPage]) {
-        guard store.selection.noun?.kind == "page", let id = store.selection.noun?.id else {
-            return
-        }
-        if let page = pages.first(where: { $0.id == id }) {
-            store.select(
-                noun: WorkspaceNoun(
-                    kind: "page",
-                    id: page.id,
-                    title: page.title,
-                    sourcePath: page.sourcePath
+        if let noun = store.selection.noun, noun.kind == "page" {
+            if let page = pages.first(where: { $0.id == noun.id }) {
+                store.select(
+                    noun: WorkspaceNoun(
+                        kind: "page",
+                        id: page.id,
+                        title: page.title,
+                        sourcePath: page.sourcePath
+                    )
                 )
-            )
-        } else {
-            store.select(noun: nil)
+                return
+            } else {
+                store.select(noun: nil)
+            }
+        }
+        if store.selection.noun == nil, let first = pages.first {
+            selectPage(first)
         }
     }
 

--- a/Sources/Play/Local/OutputsPane.swift
+++ b/Sources/Play/Local/OutputsPane.swift
@@ -107,7 +107,7 @@ struct OutputsPane: View {
                 }
             }
         }
-        .listStyle(.inset(alternatesRowBackgrounds: true))
+        .listStyle(.inset)
         .safeAreaPadding(.top, toolbarBand)
     }
 

--- a/Sources/Play/Local/PlanPane.swift
+++ b/Sources/Play/Local/PlanPane.swift
@@ -144,7 +144,7 @@ struct PlanPane: View {
                 }
             }
         }
-        .listStyle(.inset(alternatesRowBackgrounds: true))
+        .listStyle(.inset)
         .safeAreaPadding(.top, toolbarBand)
     }
 

--- a/Sources/Play/Local/PublishPane.swift
+++ b/Sources/Play/Local/PublishPane.swift
@@ -48,7 +48,7 @@ struct PublishPane: View {
 
             evidenceFilesSection
         }
-        .listStyle(.inset(alternatesRowBackgrounds: true))
+        .listStyle(.inset)
         .safeAreaPadding(.top, toolbarBand)
         .task(id: source.id) {
             load()

--- a/scripts/embed-boris.sh
+++ b/scripts/embed-boris.sh
@@ -101,6 +101,28 @@ bundle_and_sign() {
       codesign --force --options runtime --sign - "$target" 2>/dev/null || true
     }
   fi
+
+  # Embed companion binaries (boris-editor, oliver, etc.) if available
+  local comp_candidates=(
+    "$SRCROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin"
+    "$SRCROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/bin"
+    "$SRCROOT/../boris-agent-kit/bin"
+  )
+  for cdir in "${comp_candidates[@]}"; do
+    if [[ -d "$cdir" ]]; then
+      for comp in boris-editor oliver boris-package boris-source-rag; do
+        if [[ -x "$cdir/$comp" && ! -f "$DEST_DIR/$comp" ]]; then
+          cp "$cdir/$comp" "$DEST_DIR/$comp"
+          chmod +x "$DEST_DIR/$comp"
+          if [[ -n "$sign_identity" ]]; then
+            codesign --force --options runtime --sign "$sign_identity" "$DEST_DIR/$comp" 2>/dev/null || \
+            codesign --force --options runtime --sign - "$DEST_DIR/$comp" 2>/dev/null || true
+          fi
+          echo "embed-boris: bundled companion $comp"
+        fi
+      done
+    fi
+  done
 }
 
 mkdir -p "$DEST_DIR"


### PR DESCRIPTION
## Summary

This PR delivers key usability and chassis polish across the main window and settings:

- **Settings → Engine**: Added dedicated Engine settings pane showing Boris, Oliver, and Editor binaries, live versions, origins, and interactive **Choose Custom Binary…** / **Reset to Default** buttons.
- **Center Pane Split & Navigation**: Replaced fixed-height list with a smooth draggable splitter (with center grab handle and `resizeUpDown` cursor), automatic first-page selection on source load, and native **↑ / ↓** arrow key keyboard navigation.
- **Sidebar Hierarchy & Collapsible Sections**: Source accounts are now collapsible sections with native disclosure triangles, bold parent headers, clear 62pt traffic-light clearance for 100% click hit-testing, and indented subordinate mailbox rows.
- **Context-Aware Inspector**: Inspector drawer dynamically shows relevant sections for Pages, Outputs, Publish, and Plan/Activity, with comfortable bottom scroll padding.
- **Main Toolbar**: Added dedicated **Inspector** toggle button (`⌥⌘I`).
- **Companion Embedding**: Embedded and signed `boris-editor` and `oliver` binaries directly into `Solipsist.app/Contents/Resources/`.

## Test Plan
- `make lint` passes (0 violations across 46 Swift files).
- `make test` passes (all 211 tests pass).
- `make build` succeeds cleanly.
- Verified interactive split dragging, keyboard navigation, disclosure triangle collapse/expand, and Settings binary pickers on macOS.