### PR TITLE
docs: promote #131 to Add Git Repository… (clone as Local)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -103,12 +103,11 @@ No scraped prose. No homegrown graph. No third settings store.
   highlight, front-matter form, Cooklang autocomplete, bundling
   `oliver` next to `boris`. The M10 gate is the window + save +
   preview seam (#106 / #108), not those.
-- **Git / GitHub as sources**, added in Settings → Sources the same
-  way a local folder is. A GitHub repo is the second account type
-  (already reserved on `SourceKind`). Local git remotes on a folder
-  we already have (status, fetch, Boris’s Pages workflow) sit next
-  to that — still `Source`, not a third store. Pages as a *target*
-  does not require this.
+- **GitHub as its own `SourceKind`** (OAuth / app password, not
+  just a clone). First git slice is pickable:
+  [#131](https://github.com/drawmeanelephant/solipsist/issues/131)
+  (clone URL → folder → Local source). Pages as a *target* does
+  not require either.
 - Content-audit mailbox (`boris-content-audit`)
 - Source-RAG export for AI assist
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)
@@ -454,19 +453,19 @@ here, it is not a v1 promise.
 
 ## 8. Pickup (what to do next)
 
-The gate batch (#72–#77) and the depth batch (#88–#91) are closed.
-Next **ship** is #78. Next **product cut** is M10 (Mail body) — after
-or beside ship, never inside it.
+M10 and M11 landed. Remaining **ship** is Apple-account only.
+Next **product** slice is git clone as a Local source.
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
-| 1 | Ship | [#78](https://github.com/drawmeanelephant/solipsist/issues/78) | Credentials, clean-Mac proof, pin bump, testdata. |
-| 2 | Mail body | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) ([#99](https://github.com/drawmeanelephant/solipsist/issues/99)–[#102](https://github.com/drawmeanelephant/solipsist/issues/102), [#106](https://github.com/drawmeanelephant/solipsist/issues/106)) | Settings, mailboxes, reading, hosted Edit, native Compose. |
+| 1 | Git | [#131](https://github.com/drawmeanelephant/solipsist/issues/131) | Settings → Add Git Repository… clone URL → folder → `addLocal`. |
+| 2 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. Parallel with #131. |
+| 3 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
 
-#78 stays build-lane only (`scripts/embed-boris.sh`, `Project.yml`,
-entitlements, release workflow, `docs/SHIP-HARDENING.md`). Do not
-expand it into chrome, play, inspector, or publish. M10 owns those
-paths.
+[#131](https://github.com/drawmeanelephant/solipsist/issues/131) is
+clone-as-local, not GitHub OAuth. Do not start `SourceKind.github`
+payload work in that PR. #136 (splitter crash) stays parked on
+macOS 27 beta.
 
 ### Landed depth (do not redo)
 
@@ -490,8 +489,9 @@ Quiet on the child.
 Named in this file and **not** a product surface yet: browser OAuth,
 `github-pages-audit`.
 
-Out of v1 (unchanged): GitHub as a source, content-audit, source-rag,
-migration labs, Wasm in the app, `validate --watch` until A5 + pin.
+Out of v1 (unchanged): GitHub OAuth / `SourceKind.github` payload,
+content-audit, source-rag, migration labs, Wasm in the app,
+`validate --watch` until A5 + pin. Clone-as-local is #131.
 Compose **depth** (diagnostics, bundle `oliver`) stays Later; the
 M10 compose window is #106 / #108.
 

--- a/docs/cards/GIT-CLONE.md
+++ b/docs/cards/GIT-CLONE.md
@@ -1,0 +1,75 @@
+# Card — Add Git Repository… (clone into a Local source)
+
+**Issue:** [#131](https://github.com/drawmeanelephant/solipsist/issues/131)
+**Lane:** Settings / workspace. One worktree, one PR against `main`;
+branch suggestion `feat/git-clone-source`.
+
+This is the first git slice. It is **not** GitHub OAuth and it is
+**not** a new `SourceKind` payload. A clone is a folder. We already
+know how to add a folder.
+
+## Owns
+
+- `Sources/App/Settings/SourcesSettingsPane.swift` — **Add Git
+  Repository…**
+- File menu clone verb in `Sources/App/Commands.swift` (menus first)
+- A small git helper (new file under `Sources/Workspace/Git/` or
+  next to `LocalSource`) that runs `/usr/bin/git` as a `Process`
+- Settings / sidebar **detail** when the workspace root is a git
+  checkout (branch; dirty optional)
+- Tests for URL / dest validation and for parsing `git status`
+  porcelain — no network in CI
+
+## Do not touch
+
+- `Sources/Engine/**` (this is not boris)
+- `Sources/Play/**` except a caption if the account header already
+  shows `detailLine`
+- Fake `SourceKind.github` rows
+- Commit / push / pull / fetch UI
+- GitHub app passwords, OAuth, or `gh`
+
+## Why
+
+Settings is the account book. People who do not live in this repo
+will want to add a remote publication the way they add a local
+folder. `git clone` into a user-chosen directory, then the existing
+`WorkspaceStore.addLocal` bookmark, is that verb. GitHub-as-its-own
+source kind stays a follow-on.
+
+## Do
+
+1. **Add Git Repository…** (Settings + File menu). Prompt for a
+   clone URL and a destination folder (`NSOpenPanel` can-create).
+   Reject empty URL, `file://`, and non-`git`/`https`/`ssh`/`git@`
+   shapes. Do not invent a browser OAuth sheet.
+2. Run `/usr/bin/git clone -- <url> <dest>` with the destination
+   already in the sandbox (user-selected). Surface stdout/stderr and
+   a non-zero exit. Do not swallow. Cancel = SIGTERM on that
+   process (not the engine slot — this is a one-shot next to
+   Settings, not `BorisEngine`).
+3. On exit 0, `store.addLocal(url: dest)`. Same store as Open….
+4. If `workspaceRoot/.git` exists, Settings row (and sidebar
+   tooltip / detail if it already shows a second line) shows
+   `branch` from `git rev-parse --abbrev-ref HEAD` or
+   `status --porcelain=v2 --branch`. Missing git or not-a-repo →
+   no badge, not an error.
+5. Entitlements: `network.client` already exists for clone.
+   Do not add a new entitlement unless sandbox blocks `/usr/bin/git`
+   — if it does, file the finding on the issue, do not guess.
+
+## Do not
+
+- Reimplement git in Swift.
+- Clone into `SUPPORT-NOT-FOR-GITHUB/` or any kit path.
+- Auto-open a default GitHub account.
+- Walk `content/` as Finder.
+- Expand #110 / #111.
+
+## Gate
+
+Settings → Add Git Repository… a public `https://` URL into a new
+folder → it appears as a Local source and the sidebar can open it.
+A Local source that is already a checkout shows its branch in
+Settings. Failed clone shows the git exit / stderr. `SKIP_EMBED_BORIS=1
+make build` + `make test` green (no live clone in CI).

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -73,12 +73,16 @@ hosted Edit from the selected page, native Compose.
 
 #78 stays build-lane only. Do not pick an M10 card by growing ship.
 
+## Git (pickable)
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [Add Git Repository…](GIT-CLONE.md) | [#131](https://github.com/drawmeanelephant/solipsist/issues/131) | Settings / workspace | #110 | clone URL → folder → Local source; branch in Settings |
+
 ## Do not start yet
 
-GitHub as a source. Wasm in the app. The fart app. Compose **depth**
-(diagnostics, bundle `oliver`). Preview, editor host, and publish
-already have gates — M10 wires them into Mail's shape; it does not
-rebuild them.
+GitHub OAuth / `SourceKind.github` payload. Wasm in the app. The
+fart app. Compose **depth**. #136 splitter crash (macOS 27 beta).
 
 ## Shared noun kinds (play writes, inspector reads)
 


### PR DESCRIPTION
Makes [#131](https://github.com/drawmeanelephant/solipsist/issues/131) pickable. Card: `docs/cards/GIT-CLONE.md`. Clone URL → folder → `addLocal`. Not GitHub OAuth.