### PR TITLE
docs: schedule M12 clone, M13 graph folders, M14 watch contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,5 +65,11 @@ ship ✅ ([#78](https://github.com/drawmeanelephant/solipsist/issues/78))
 Settings / mailboxes / reading / compose #106)
 · **M11** prove the Mail body ✅
 ([#123](https://github.com/drawmeanelephant/solipsist/issues/123) —
-Help audit + test pass). Remaining ship is Apple-account only
-(#110 / #111).
+Help audit + test pass)
+· **M12** clone 📋
+([#131](https://github.com/drawmeanelephant/solipsist/issues/131))
+· **M13** graph folders 📋
+([#142](https://github.com/drawmeanelephant/solipsist/issues/142))
+· **M14** watch contract 📋
+([#143](https://github.com/drawmeanelephant/solipsist/issues/143)).
+Remaining ship is Apple-account only (#110 / #111).

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -258,6 +258,12 @@ cut wrong — stop and recut.
 | **Reading** (M10) | `Sources/Play/Local/`; named recut: `PlayHost` binder, `AppRuntime.previewSession`, `Companions/Preview/` session share + `PreviewURL` helpers | Chrome mailbox construction, `MainWindow.swift`, Engine | Tabs gone; center is message list + reading pane driven by `mailbox` |
 | **Editor wiring** (M10) | `Sources/Companions/Editor/`, File → Edit Page in `Commands.swift` | `Sources/Compose/`, Play list internals, `MainWindow.swift` | File → Edit Page; header shows title + `sourcePath`; merge after Reading |
 | **Compose** (M10) | `Sources/Compose/`, `OliverRenderer` / `OliverBinary` in `Engine/`, Compose menu / window | `Companions/Editor/`, Play list internals, `MainWindow.swift` | ⌘⇧C opens the selected page; explicit save; Oliver preview when the binary is present |
+| **Git clone** (M12) | `Sources/Workspace/Git/` (new), Settings Sources pane, File menu clone verb in `Commands.swift` | `Sources/Engine/**`, Play except a caption, fake GitHub rows | clone URL → folder → `addLocal`; branch badge on a checkout |
+| **Unknown mailbox** (M13-0) | `WorkspaceMailbox` / selection display rules in `WorkspaceSelection.swift` | Sidebar construction, Play list internals, Engine | Unknown raw `mailbox` is not treated as Pages in the center switch |
+| **Trunk folders** (M13-1) | `SourceSidebar.swift` only | Settings, Play row rendering, Engine | Pages grows child rows from `graph.parent`; writes `mailbox = trunk id` |
+| **Filter letters** (M13-2) | `Sources/Play/Local/` | `SourceSidebar.swift`, Engine, `MainWindow.swift` | Selecting a trunk mailbox filters the list; Pages still means all |
+| **A1 consume** (M14-1) | `Sources/Engine/WatchServer.swift` (+ Engine watch start), `Companions/Preview/` port wiring | Play list internals, `MainWindow.swift` | `--watch-json` / `serve-started` is how we learn the port |
+| **Letter SSE** (M14-2) | reading pane only; observe existing session | `WatchServer` argv, Engine start line | Letter reloads on `event: reload`. No second watch. |
 | **Issues** | `docs/issues/` | `Sources/` | Draft fact-checked against afterparty, then filed |
 | **Design** | `docs/*.md` except `issues/` | `Sources/` | Decisions recorded; no silent contradiction with this file |
 
@@ -337,4 +343,8 @@ window.
 Do not expand Apple-account ship
 ([#110](https://github.com/drawmeanelephant/solipsist/issues/110),
 [#111](https://github.com/drawmeanelephant/solipsist/issues/111))
-into this chrome. #78 is closed.
+into this chrome. #78 is closed. Next product lanes: M12 clone
+(`Sources/Workspace/Git/` + Settings), M13 graph folders
+(sidebar + `Play/Local/` filter), M14 watch contract (`Engine/`
+`WatchServer` then the reading pane). Paths in [`ROADMAP.md`](ROADMAP.md)
+§5 / [`cards/README.md`](cards/README.md).

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -69,28 +69,31 @@ compiler repo. Solipsist is the complementary **native desktop citizen**:
 
 ## Where we are
 
-- **M0–M8 gates plus depth.** Spike, chassis, list, verbs,
-  preview/editor, outputs, publish family, first-run, filter, profile
-  1:1, `recipe-scale`. Remaining **ship** card:
-  [#78](https://github.com/drawmeanelephant/solipsist/issues/78).
-  Next **product cut:** M10 Mail body
+- **M0–M11 landed.** Spike, chassis, list, verbs, preview/editor,
+  outputs, publish family, first-run, filter, profile 1:1,
+  `recipe-scale`, ship pipeline (#78), Mail body
   ([#98](https://github.com/drawmeanelephant/solipsist/issues/98) —
-  Settings, mailbox sidebar, reading pane, native compose
-  [#106](https://github.com/drawmeanelephant/solipsist/issues/106)).
-  Sequence: [ROADMAP.md](ROADMAP.md) §8.
+  Settings, mailboxes, reading, compose #106), prove (#123).
+  Remaining **ship** is Apple-account only (#110 / #111).
+  Next **product cut:** M12 clone
+  ([#131](https://github.com/drawmeanelephant/solipsist/issues/131)).
+  Then M13 graph folders and M14 watch contract. Sequence:
+  [ROADMAP.md](ROADMAP.md) §8.
 - **Engine baseline:** afterparty `boris/0.8.1`. Kit pin `6b930b7`
   (contains A1/A14/A7 + A3/A4/A13).
-- **Next:** clean-Mac ship (#78), then the Mail-body recut. Roadmap
-  **P** is withdrawn — the public site ships via Cloudflare Pages
-  (`site/`).
+- Roadmap **P** is withdrawn — the public site ships via Cloudflare
+  Pages (`site/`).
 
 ## What success looks like
 
-Open any folder of Boris content on a Mac → it is a **source** in
-Settings → it appears as an account with mailboxes → the reading place
-shows the graph as messages and a pane for the selected page → the
+Open any folder of Boris content on a Mac — or clone a URL into one
+— → it is a **source** in Settings → it appears as an account with
+mailboxes (Pages folders from the graph) → the reading place shows
+the graph as messages and a pane for the selected page → the
 drawer shows the profile and that page → Plan / Validate / Build
-surface every diagnostic → Preview reloads through `watch --serve` →
-Edit hosts `boris-editor` → Compose is the native buffer → publish to GitHub Pages, Standard.site, or
-Nostr with the Proof Pack attached. All of it driven by the compiler's
-contracts; none of it by scraped prose or reimplemented logic.
+surface every diagnostic → Preview reloads through `watch --serve`
+(A1 events, not a port regex) → Edit hosts `boris-editor` →
+Compose is the native buffer → publish to GitHub Pages,
+Standard.site, or Nostr with the Proof Pack attached. All of it
+driven by the compiler's contracts; none of it by scraped prose or
+reimplemented logic.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,21 +42,24 @@ A5 as a discussion (`docs/issues/README.md`).
 
 ## 2. North-star success
 
-Open a folder of Boris content → it is added as a **source** in
-Settings (File → Open… writes the same store) → it appears as an
-account header with mailboxes underneath → the reading place shows
-the selected mailbox’s messages and a reading pane for the selected
-page → the drawer shows the publication profile and that page’s
-fields from `completion.json` → Plan / Validate / Build are menu
-verbs that surface every diagnostic and exit code → Preview reloads
-the full site through `watch --serve` (the reading pane reuses that
-watch for the selected page) → Edit opens `boris-editor` against the
-selected page → Build All fans the profile out to HTML targets and
-editions (IR, RAG, Context, llms, RSS, sitemap, search) → Publish
-runs GitHub Pages evidence (Boris-powered, we do not need full
-GitHub access to *use* the target), Standard.site, or Nostr with the
-Proof Pack attached. This project’s own public face ships via
-Cloudflare Pages (`site/`).
+Open a folder of Boris content — or **File / Settings → Add Git
+Repository…** a clone URL into a user-chosen folder — → it is added
+as a **source** in Settings (File → Open… writes the same store) →
+it appears as an account header with mailboxes underneath (Pages
+folders come from `graph.parent`, not the disk) → the reading place
+shows the selected mailbox’s messages and a reading pane for the
+selected page → the drawer shows the publication profile and that
+page’s fields from `completion.json` → Plan / Validate / Build are
+menu verbs that surface every diagnostic and exit code → Preview
+reloads the full site through `watch --serve` (the reading pane
+reuses that watch; port and ready come from A1 `--watch-json`, not
+a regex) → Edit opens `boris-editor` against the selected page →
+Build All fans the profile out to HTML targets and editions (IR,
+RAG, Context, llms, RSS, sitemap, search) → Publish runs GitHub
+Pages evidence (Boris-powered, we do not need full GitHub access to
+*use* the target), Standard.site, or Nostr with the Proof Pack
+attached. This project’s own public face ships via Cloudflare Pages
+(`site/`).
 
 No scraped prose. No homegrown graph. No third settings store.
 
@@ -80,8 +83,11 @@ No scraped prose. No homegrown graph. No third settings store.
 | Outputs fan-out | Every profile target and edition, isolated, reported |
 | Publication console | GH Pages evidence (Boris-owned workflow + audit), Standard.site, Nostr — secrets on stdin |
 | Proof Pack visible | `boris-package` evidence, read-only |
-| Project subdomain | Early, parallel: `hosts/cloudflare-worker` + `compileBundle` Wasm + R2, Workers Free |
-| Sandboxed, bundled, pinned | D6, D7. Unknown `schemaVersion` degrades (D8) |
+| Clone a remote publication into a Local source | Settings is the account book. A URL is how people who do not live in this repo get a folder. Same store as Open…. |
+| Pages folders from the graph | Trunks as mailbox folders. From `graph.parent` only — never a disk walk. Dogfood gate is 7 trunks. |
+| Watch events from the A1 contract | Pin `6b930b7` already contains `--watch-json` / `serve-started`. Preview still sniffs a port line. |
+| Sandboxed, bundled, pinned | D6, D7. Unknown `schemaVersion` degrades (D8). Pipeline ✅ (#78). |
+| Notarized DMG a stranger can download | Operator. First `v*` release + clean-Mac proof (#110 / #111). |
 
 ### v1 must not
 
@@ -113,6 +119,9 @@ No scraped prose. No homegrown graph. No third settings store.
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)
 - Cooklang recipe-scale as a first-class mailbox (v1: available from
   the page inspector when the corpus has recipes)
+- Fetch / pull / commit / push on a checkout (clone is M12; remotes
+  stay later)
+- Width-adaptive list-left-of-letter split (M10 default is stacked)
 - The fart app (CI job reserved, `make fart` refuses; do not build it)
 
 ---
@@ -134,6 +143,9 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M9** Ship | ✅ release pipeline, clean-Mac proof, testdata, pin bump (#78) |
 | **M10** Mail body | ✅ Settings, mailboxes, reading pane, hosted Edit, native Compose ([#98](https://github.com/drawmeanelephant/solipsist/issues/98); children #99–#102, #106) |
 | **M11** Prove the Mail body | ✅ Help audit + test pass ([#123](https://github.com/drawmeanelephant/solipsist/issues/123); #124/#125 → PRs #126/#127/#128) |
+| **M12** Clone | 📋 Add Git Repository… → Local source ([#131](https://github.com/drawmeanelephant/solipsist/issues/131)) |
+| **M13** Graph folders | 📋 trunk mailboxes from `graph.parent` ([#142](https://github.com/drawmeanelephant/solipsist/issues/142); #144–#146) |
+| **M14** Watch contract | 📋 A1 `--watch-json` + letter SSE ([#143](https://github.com/drawmeanelephant/solipsist/issues/143); #147/#148) |
 
 **Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
 batch then landed: first-run and problem→page (#88/#94), graph filter /
@@ -143,8 +155,10 @@ proof (#91/#93). Then **M9 ship** (#78), the **M10 Mail-body cut**
 (#98 + #99–#102, #106), and **M11 prove** (#123) all landed and
 closed. Remaining ship is Apple-account only (#110 notarized `v*`
 DMG, #111 clean-Mac proof) — operator, blocked on a paid team ID.
-Next product slice: git clone as a Local source (#131),
-`docs/cards/GIT-CLONE.md`. Do not grow `MainWindow`.
+Next product slice: **M12** git clone as a Local source (#131).
+**M13** graph folders and **M14** watch contract are filed and
+pickable in their own lanes after (or beside) M12. Do not grow
+`MainWindow`.
 
 ---
 
@@ -427,6 +441,95 @@ completed.
 tests 0 failures · `make lint` 0 violations · CI `app` / `fixtures`
 / `lint` / `spike` all pass.
 
+### M12 — Clone 📋
+
+**Goal.** A remote publication becomes a Local source the way a
+folder does. Settings → **Add Git Repository…** clones a URL into
+a user-chosen directory, then the existing `addLocal` bookmark.
+
+This is **not** GitHub OAuth and **not** a `SourceKind.github`
+payload. A clone is a folder. We already add folders.
+
+| Surface | Where |
+|---------|--------|
+| `/usr/bin/git clone` | Settings + File menu. One-shot `Process`, not `BorisEngine` |
+| Branch badge | Settings row (and sidebar detail if it already has a second line) when `workspaceRoot/.git` exists |
+
+**Gate.** Settings → Add Git Repository… a public `https://` URL
+into a new folder → it appears as a Local source and the sidebar
+can open it. An existing checkout shows its branch. Failed clone
+shows git’s exit / stderr. No live clone in CI.
+
+**Lane.** Settings / `Sources/Workspace/Git/`. Card:
+[`cards/GIT-CLONE.md`](cards/GIT-CLONE.md). Issue
+[#131](https://github.com/drawmeanelephant/solipsist/issues/131).
+Parallel with #110. Do not share files with M13 or M14.
+
+**Not this milestone.** Commit / push / pull / fetch UI. GitHub
+app password or OAuth. Fake **Add GitHub…**. Expanding #110 / #111.
+
+### M13 — Graph folders 📋
+
+**Goal.** Pages folders come from the graph. Dogfood shows **7
+trunk folders** under Pages. Selecting a trunk filters the letter
+list. Unknown `mailbox` is never rewritten to `pages`.
+
+M10 stored `mailbox` as an open string and displayed only five
+tokens. Trunks were named then and deferred. Do not invent a
+second selection field. `mailbox` becomes the trunk id.
+
+| Surface | Where |
+|---------|--------|
+| `graph.parent` / trunk nodes | Sidebar children under Pages |
+| Unknown `mailbox` | Display verbatim; center switch does **not** treat it as Pages |
+| Trunk mailbox | Reading list filters to that parent. Pages still means all |
+
+**Gate.** Open dogfood → Pages shows 7 trunk folders from
+`graph.json`. Selecting a trunk shows only that trunk’s pages.
+Selecting Pages shows all. A stored unknown mailbox survives
+relaunch and is not coerced to `pages`. `SKIP_EMBED_BORIS=1 make
+build` + `make test` green.
+
+**Lanes.** Workspace (unknown-mailbox rule) → Mailboxes (sidebar)
+→ Reading (filter). Tracker
+[#142](https://github.com/drawmeanelephant/solipsist/issues/142);
+children #144 / #145 / #146. Cards in [`cards/`](cards/README.md).
+
+**Not this milestone.** Walking `content/` as Finder. Status / tag
+folders. Persist outline expansion. Engine. GitHub source.
+
+### M14 — Watch contract 📋
+
+**Goal.** Preview and the letter take port / ready from A1
+`--watch-json` / `serve-started`, not a port regex. The reading
+pane reloads on the existing SSE `event: reload` without a second
+`Process`.
+
+The pin already contains A1 (boris#648). Watch still parses:
+
+```
+preview: http://127.0.0.1:PORT/  (auto-reload helper: http://127.0.0.1:PORT/__boris/)
+```
+
+| Boris surface | Where |
+|---------------|--------|
+| `--watch-json` + `serve-started` | Engine `WatchServer`; Preview binds the helper URL |
+| SSE `event: reload` | Reading pane observes the existing session |
+
+**Gate.** Preview ▶ starts with `--watch-json`. `serve-started`
+is how we learn the port. The letter reloads on rebuild without
+re-selecting the row. No second watch. No `file://`. Port regex
+is fallback then gone in the same PR if the pin is honest.
+
+**Lanes.** Engine + Preview (A1 consume), then Reading (letter
+SSE). Tracker
+[#143](https://github.com/drawmeanelephant/solipsist/issues/143);
+children #147 / #148. Cards in [`cards/`](cards/README.md).
+
+**Not this milestone.** A5 `validate --watch`. A15 `open=` (app
+already appends it; pin-follow). A second `Process`. Growing
+`WatchServer` argv on the letter card.
+
 ---
 
 ## 6. Capability coverage
@@ -438,11 +541,11 @@ here, it is not a v1 promise.
 |------------------|-----------|------------------------|
 | Markdown / Textile / Cooklang input | M3–M6 | Profile `input_format`; cook recipe-scale in the drawer |
 | Closed frontmatter | M3, M6 | Inspector from `completion.json`; editor owns the buffer |
-| Trunk/Satellite graph, wiki-links, includes, relations | M3 | Play list from `graph.json` |
+| Trunk/Satellite graph, wiki-links, includes, relations | M3, M13 | Play list from `graph.json`; M13 trunks as Pages folders |
 | HTML + layouts + theme catalog | M4, M7 | Build target; theme picker |
 | `validate` | M4 | Save-triggered problems; A5 later |
-| `watch --serve` + SSE | M5, M10 | Preview companion; M10 reading pane reuses the same session |
-| `--watch-json` (A1) | M5 once pinned | Replaces port regex + watch prose |
+| `watch --serve` + SSE | M5, M10, M14 | Preview companion; M10 reading pane reuses the same session; M14 letter listens to SSE |
+| `--watch-json` (A1) | M14 | Replaces port regex + watch prose. Pin already contains it. |
 | `plan --profile` | M4, M8 | Settings lint; publish prelude |
 | `build --report` / `--timings` | M4, M7 | Results + Activity |
 | IR (`manifest` / `graph` / `completion` / `build-report`) | M1, M3, M7 | Decode, list, inspect, export |
@@ -454,7 +557,7 @@ here, it is not a v1 promise.
 | `boris-editor` | M6, M10 | Companion (A14); M10 opens it from the selected page |
 | Oliver (`oliver render`) | M10 | Compose preview; Engine-owned subprocess; not a Swift parse |
 | GitHub Pages + audit | M8 | In-app evidence; Boris workflow owns push; we are not the GH operator |
-| `hosts/cloudflare-worker` + `compileBundle` Wasm | **P (now)** | This project’s subdomain. Free-tier host glue. Not in-app |
+| `hosts/cloudflare-worker` + `compileBundle` Wasm | **P withdrawn** | Public face is Cloudflare Pages (`site/`). Not in-app. |
 | `boris-job-runner` / CF Containers (#300) | parked | Different host (native binary in a container), not the Free Wasm path |
 | Standard.site family | M8 | Native flow, stdin secrets |
 | Nostr plan/sign/publish | M8 | Native flow, `--key-stdin` |
@@ -484,13 +587,16 @@ here, it is not a v1 promise.
 ## 8. Pickup (what to do next)
 
 M10 and M11 landed. Remaining **ship** is Apple-account only.
-Next **product** slice is git clone as a Local source.
+Next **product** slice is M12 clone. M13 and M14 are filed; pick
+them in their own worktrees once the lanes are free.
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
-| 1 | Git | [#131](https://github.com/drawmeanelephant/solipsist/issues/131) | Settings → Add Git Repository… clone URL → folder → `addLocal`. |
+| 1 | M12 Clone | [#131](https://github.com/drawmeanelephant/solipsist/issues/131) | Settings → Add Git Repository… clone URL → folder → `addLocal`. |
 | 2 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. Parallel with #131. |
 | 3 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
+| 4 | M13 Graph folders | [#142](https://github.com/drawmeanelephant/solipsist/issues/142) | After M12, or parallel if it stays out of Settings / `Workspace/Git/`. First pick #144. |
+| 5 | M14 Watch contract | [#143](https://github.com/drawmeanelephant/solipsist/issues/143) | Parallel with M13 (Engine / Preview / Reading). First pick #147. |
 
 [#131](https://github.com/drawmeanelephant/solipsist/issues/131) is
 clone-as-local, not GitHub OAuth. Do not start `SourceKind.github`
@@ -517,11 +623,12 @@ plan/sign/publish (per-relay verdicts), `boris-package`, `--version`,
 Quiet on the child.
 
 Named in this file and **not** a product surface yet: browser OAuth,
-`github-pages-audit`.
+`github-pages-audit`, A1 `--watch-json` (M14), trunk mailbox
+folders (M13).
 
 Out of v1 (unchanged): GitHub OAuth / `SourceKind.github` payload,
 content-audit, source-rag, migration labs, Wasm in the app,
-`validate --watch` until A5 + pin. Clone-as-local is #131.
+`validate --watch` until A5 + pin. Clone-as-local is M12 / #131.
 Compose **depth** (diagnostics, bundle `oliver`) stays Later; the
 M10 compose window is #106 / #108.
 

--- a/docs/cards/GIT-CLONE.md
+++ b/docs/cards/GIT-CLONE.md
@@ -1,6 +1,7 @@
 # Card — Add Git Repository… (clone into a Local source)
 
-**Issue:** [#131](https://github.com/drawmeanelephant/solipsist/issues/131)
+**Milestone:** M12 · **Issue:**
+[#131](https://github.com/drawmeanelephant/solipsist/issues/131)
 **Lane:** Settings / workspace. One worktree, one PR against `main`;
 branch suggestion `feat/git-clone-source`.
 

--- a/docs/cards/M10-mail-body.md
+++ b/docs/cards/M10-mail-body.md
@@ -56,7 +56,7 @@ Do not invent a second vocabulary. `WorkspaceSelection` grows
 | `publish` | publication console |
 | `plan` | plan document |
 | `activity` | timings / job log |
-| later: a trunk id | nested folder under Pages, from `graph.parent` only |
+| later: a trunk id | nested folder under Pages, from `graph.parent` only — now [M13](M13-graph-folders.md) / [#142](https://github.com/drawmeanelephant/solipsist/issues/142) |
 
 Existing `WorkspaceNoun.kind` values (`page`, `profile`, `target`,
 `edition`) stay. Chrome writes `sourceID` + `mailbox`. Play writes

--- a/docs/cards/M13-filter-letters.md
+++ b/docs/cards/M13-filter-letters.md
@@ -1,0 +1,55 @@
+# Card M13-2 — Filter letters by trunk mailbox
+
+**Milestone:** M13 · **Issue:**
+[#146](https://github.com/drawmeanelephant/solipsist/issues/146)
+(parent [#142](https://github.com/drawmeanelephant/solipsist/issues/142))
+· **Lane:** Reading. One worktree, one PR against `main`;
+branch suggestion `feat/m13-filter-letters`.
+
+Merges **after** M13-1. Reads `mailbox`. Does not edit the sidebar.
+
+## Owns
+
+- `Sources/Play/Local/` — list contents for a trunk mailbox
+- `LocalPlayGraph` filter helper if one does not exist yet
+
+## Do not touch
+
+- `SourceSidebar.swift` (M13-1)
+- `Sources/Engine/**`
+- `MainWindow.swift`
+- Settings / `Workspace/Git/`
+
+## Why
+
+Selecting a trunk folder that still shows every page is a lie.
+Pages means all. A trunk id means that parent and its satellites.
+
+## Do
+
+1. When `selection.mailbox` is `pages` (or nil treated as Pages),
+   show the full `LocalPlayGraph.pages` list — today’s behavior.
+2. When `mailbox` is a known M10 token (`outputs` / `publish` /
+   `plan` / `activity`), do not change those surfaces.
+3. When `mailbox` is anything else, treat it as a trunk id: show
+   the trunk row plus descendants whose `parent` chain reaches
+   that id. Empty folder → empty list, not a fall-through to all
+   pages.
+4. Selecting a row still writes `noun` the way Reading does today
+   (`sourcePath` included).
+5. Tests: a three-node fixture (trunk + child + unrelated trunk)
+   filters to two rows; `pages` still returns three.
+
+## Do not
+
+- Rebuild the sidebar.
+- Walk the disk.
+- Fall back to the full list when the id is missing from the
+  current graph — empty is honest; the graph reloaded.
+
+## Gate
+
+Select a dogfood trunk folder → the letter list is that trunk and
+its satellites only. Select Pages → all 45. A stale trunk id
+(graph no longer contains it) shows empty, not everything.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/M13-graph-folders.md
+++ b/docs/cards/M13-graph-folders.md
@@ -1,0 +1,51 @@
+# M13 — Graph folders (tracker)
+
+**Milestone:** M13 · **Lane:** design (this file) + three child cards.
+Does **not** own `Sources/`. Children do.
+
+Parent issue:
+[#142](https://github.com/drawmeanelephant/solipsist/issues/142).
+
+## Why
+
+M10 stored `mailbox` as an open string and displayed five tokens.
+HARNESS already named trunks as folders under Pages. M10-DESIGN
+D-S1 / D-S6 deferred them on purpose: unknown still *displays* as
+Pages, so a persisted trunk id would open the full letter list.
+
+Dogfood is **45 pages / 7 trunks**. The list already walks
+`graph.parent` (`LocalPlayGraph.pages`). The sidebar does not.
+
+## Children
+
+One card = one worktree = one PR. M13-0 first. M13-1 writes
+`mailbox = trunk id`. M13-2 reads it.
+
+| Card | Issue | Lane | Gate (short) |
+|------|-------|------|----------------|
+| [M13-0 Unknown mailbox](M13-unknown-mailbox.md) | [#144](https://github.com/drawmeanelephant/solipsist/issues/144) | Workspace | unknown raw `mailbox` is not treated as Pages in the center switch |
+| [M13-1 Trunk folders](M13-trunk-folders.md) | [#145](https://github.com/drawmeanelephant/solipsist/issues/145) | Mailboxes | Pages grows children from `graph.parent`; no disk walk |
+| [M13-2 Filter letters](M13-filter-letters.md) | [#146](https://github.com/drawmeanelephant/solipsist/issues/146) | Reading | trunk mailbox filters the list; Pages still means all |
+
+## Not this tracker
+
+- M12 clone (#131)
+- Walking `content/` as Finder; `.boris/` / `themes/` / `dist/` as mailboxes
+- Status / tag folders
+- Persist outline expansion
+- Engine / `--watch-json` (M14)
+- GitHub as a source
+- Growing #110 / #111
+
+## Shared nouns
+
+Do not invent a second field. `mailbox` stays an open string.
+
+| `mailbox` | Meaning |
+|-----------|---------|
+| `pages` | all graph nodes |
+| `outputs` / `publish` / `plan` / `activity` | unchanged |
+| a trunk id | nested folder under Pages, from `graph.parent` only |
+
+Chrome writes `sourceID` + `mailbox`. Play writes `noun`. Drawer
+and companions only read.

--- a/docs/cards/M13-trunk-folders.md
+++ b/docs/cards/M13-trunk-folders.md
@@ -1,0 +1,61 @@
+# Card M13-1 — Trunk folders under Pages
+
+**Milestone:** M13 · **Issue:**
+[#145](https://github.com/drawmeanelephant/solipsist/issues/145)
+(parent [#142](https://github.com/drawmeanelephant/solipsist/issues/142))
+· **Lane:** Mailboxes. One worktree, one PR against `main`;
+branch suggestion `feat/m13-trunk-folders`.
+
+Merges **after** M13-0. Writes `mailbox = trunk id`. Does not
+filter the letter list (M13-2).
+
+## Owns
+
+- `Sources/Chrome/SourceSidebar.swift` — child rows under Pages
+- Read-only use of the already-decoded graph (do not parse JSON
+  here; Play / the store already have `Graph`)
+
+## Do not touch
+
+- `WorkspaceMailbox.display` rules (M13-0)
+- `Sources/Play/Local/` filter (M13-2)
+- `Sources/Engine/**`
+- Settings / `Workspace/Git/`
+- `MainWindow.swift` unless a column-width collision is real —
+  stop and recut if it is
+- Walking the content directory
+
+## Why
+
+Mailboxes are not Finder. Nested folders under Pages are allowed
+when they come from `graph.parent` — trunks as folders, satellites
+as messages. M10 shipped five flat mailboxes. Dogfood has 7 trunks.
+
+## Do
+
+1. Under each source’s **Pages** row, add one child row per trunk
+   (`role == trunk`, or a root with children — same walk
+   `LocalPlayGraph` already does). Label is the trunk title; the
+   selection value is the trunk **id**.
+2. Clicking a trunk writes `selection.mailbox` to that id (raw).
+   Clicking Pages still writes `pages`.
+3. No disk walk. No `.boris/`, `themes/`, `dist/` rows.
+4. Expansion is not persisted. A disclosure that forgets on
+   relaunch is acceptable.
+5. Chrome does not decode `graph.json`. If the graph is not loaded
+   yet, Pages has no children — not an error.
+
+## Do not
+
+- Filter the letter list (M13-2).
+- Persist outline expansion.
+- Use `WorkspaceMailbox.display` to coerce a trunk id back to
+  `pages` on click.
+- Invent status / tag folders.
+
+## Gate
+
+Open dogfood → Pages shows **7 trunk folders** from `graph.json`.
+Selecting a trunk writes that id as `mailbox`. Selecting Pages
+writes `pages`. No folder comes from walking the disk.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/M13-unknown-mailbox.md
+++ b/docs/cards/M13-unknown-mailbox.md
@@ -1,0 +1,67 @@
+# Card M13-0 — Unknown mailbox is not Pages
+
+**Milestone:** M13 · **Issue:**
+[#144](https://github.com/drawmeanelephant/solipsist/issues/144)
+(parent [#142](https://github.com/drawmeanelephant/solipsist/issues/142))
+· **Lane:** Workspace. One worktree, one PR against `main`;
+branch suggestion `feat/m13-unknown-mailbox`.
+
+Prerequisite for M13-1. Without this, a persisted trunk id still
+opens the full Pages list.
+
+## Owns
+
+- `Sources/Workspace/WorkspaceSelection.swift` —
+  `WorkspaceMailbox.display` / the center-switch helper
+- Tests that already compile this file (ContractTests). Do **not**
+  add `WorkspaceStore.swift` to the test target
+- Call sites that treat `display()` as “which play surface”:
+  `Sources/Inspector/Inspectable.swift` if it switches on the
+  coerced Pages token
+
+## Do not touch
+
+- `Sources/Chrome/SourceSidebar.swift` (M13-1)
+- `Sources/Play/Local/` list filter (M13-2)
+- `Sources/Engine/**`
+- Settings / `Workspace/Git/` (M12)
+- `Project.yml`
+
+## Why
+
+`WorkspaceMailbox.display` maps unknown → `pages` without writing
+back. That was the M10 limit (D-S1). A trunk card must stop using
+that helper for the center switch **before** it writes a trunk id.
+
+`displayName` / `symbolName` already pass unknown through. Persist
+already stores the raw string. Only the switch is wrong.
+
+## Do
+
+1. Stop using `display()` as “this is Pages.” Keep a known-token
+   helper for the five M10 mailboxes. Unknown (including a future
+   trunk id) stays itself.
+2. Center / inspector switch: known five → existing surfaces;
+   unknown → **not** the full Pages surface. A placeholder /
+   empty “folder” state is fine until M13-2 lands the filter.
+3. Persist-on-select must not run unknown through `display()`.
+   `WorkspaceSelectionRules.restore` already keeps the raw string
+   — do not regress that.
+4. Tests: unknown raw displays verbatim (`displayName`);
+   `display` / the new helper does not coerce `"index"` to
+   `"pages"`; `isKnown("index")` is false.
+
+## Do not
+
+- Write trunk rows in the sidebar.
+- Filter the letter list.
+- Invent `WorkspaceMailbox.trunk` as a closed case.
+- Canonicalize stored mailbox on load.
+
+## Gate
+
+A selection whose `mailbox` is `"index"` (or any string not in
+`WorkspaceMailbox.all`) does **not** show the full Pages list.
+Unknown displays as the raw string in the UI helper. Reloading
+the store does not rewrite it to `pages`.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/M14-a1-consume.md
+++ b/docs/cards/M14-a1-consume.md
@@ -1,0 +1,69 @@
+# Card M14-1 — Consume A1 `--watch-json`
+
+**Milestone:** M14 · **Issue:**
+[#147](https://github.com/drawmeanelephant/solipsist/issues/147)
+(parent [#143](https://github.com/drawmeanelephant/solipsist/issues/143))
+· **Lane:** Engine + Preview. One worktree, one PR against `main`;
+branch suggestion `feat/m14-a1-consume`.
+
+## Owns
+
+- `Sources/Engine/WatchServer.swift` — argv + how `onServe` fires
+- Engine watch start if the flag is assembled outside `WatchServer`
+- `Sources/Companions/Preview/` only as far as it reads `serveURL`
+  / the helper URL (do not restyle the window)
+- Decode of the A1 event line (Engine or Models — additive
+  Codable only; do not rewrite IR types)
+
+## Do not touch
+
+- Reading pane / Play list internals (M14-2)
+- `WatchServer` as a second session
+- `MainWindow.swift`
+- Settings / M13 sidebar
+- `Project.yml`
+
+## Why
+
+`WatchServer` today parses:
+
+```
+preview: http://127.0.0.1:PORT/  (auto-reload helper: http://127.0.0.1:PORT/__boris/)
+```
+
+A1 replaced that contract. The pin has the flag. We still sniff
+prose.
+
+## Do
+
+1. Pass `--watch-json` on `watch --serve`. Keep `--port 0` and
+   `--input`. stderr is NDJSON; do not expect the old preview
+   line when the flag is on.
+2. Fire `onServe` from a `serve-started` event (`helper` URL,
+   same helper the web view already loads). Handshake
+   `hello.watch_events_schema` — unknown version degrades (D8),
+   no crash.
+3. Port regex becomes fallback for a binary that rejects the
+   flag, then **dies in this PR** if the pinned kit is honest.
+   Do not leave two parsers “just in case” after you have
+   probed the pin.
+4. Surface `build-failed` / unexpected `watch-stopped` the way
+   we already surface a non-zero watch exit. Do not swallow.
+5. Tests: fixture NDJSON lines decode; a `serve-started` helper
+   URL is accepted; unknown `watch_events_schema` does not
+   crash. No live `watch` in CI.
+
+## Do not
+
+- Subscribe the letter to SSE (M14-2).
+- Change `WatchServer` into two processes.
+- Reimplement the SSE browser channel. That stays served.
+- File a new boris issue unless the pin’s `--watch-json` does
+  not match `docs/issues/boris-A1-watch-events.md` — then draft,
+  do not patch boris.
+
+## Gate
+
+Preview ▶ starts with `--watch-json`. The helper URL comes from
+`serve-started`. Stop still SIGTERMs. `SKIP_EMBED_BORIS=1 make
+build` + `make test` green.

--- a/docs/cards/M14-letter-sse.md
+++ b/docs/cards/M14-letter-sse.md
@@ -1,0 +1,60 @@
+# Card M14-2 — Letter reloads on existing SSE
+
+**Milestone:** M14 · **Issue:**
+[#148](https://github.com/drawmeanelephant/solipsist/issues/148)
+(parent [#143](https://github.com/drawmeanelephant/solipsist/issues/143))
+· **Lane:** Reading. One worktree, one PR against `main`;
+branch suggestion `feat/m14-letter-sse`.
+
+Merges **after** M14-1. Needs a trustworthy `serveURL`.
+
+## Owns
+
+- The reading pane (Pages letter) in `Sources/Play/Local/`
+- An EventSource client **against the existing watch helper**,
+  or a WK reload triggered by that channel — one session,
+  already started by PlayHost / Preview
+
+## Do not touch
+
+- `WatchServer` argv / Engine start line (M14-1)
+- `MainWindow.swift`
+- Sidebar / M13
+- A second `boris watch`
+
+## Why
+
+M10 D-S11: the letter does not subscribe to SSE. It reloads when
+`serveURL` changes or the user re-selects the row. After a save
+the companion helper reloads and the letter stays stale until you
+click again. Users will feel that gap. This card is the named
+add-on.
+
+## Do
+
+1. When watch is up and the letter is showing the served page,
+   reload that WKWebView on `event: reload` from the existing
+   helper (`/__boris/events` or whatever A1 + `--serve` already
+   publish). Probe the pin; do not invent a second channel.
+2. Root mismatch (`isBound(to:)`) still means idle — do not
+   reload a foreign helper.
+3. 404 / load failure stays in-pane summary. No `file://`. No
+   Swift Markdown.
+4. Preview companion keeps its own WKWebView. Two views, one
+   server.
+5. Tests: a fixture event triggers the reload hook; a bound-root
+   mismatch does not. No live watch in CI.
+
+## Do not
+
+- Spawn a second watch.
+- Parse `--watch-json` NDJSON in Play (Engine already did that).
+- Subscribe when watch is down.
+- Change how Preview starts or stops the session.
+
+## Gate
+
+With watch up, save a page (or inject `event: reload`) → the
+letter reloads without re-selecting the row. Source switch still
+treats a foreign helper as idle. `SKIP_EMBED_BORIS=1 make build`
++ `make test` green.

--- a/docs/cards/M14-watch-contract.md
+++ b/docs/cards/M14-watch-contract.md
@@ -1,0 +1,36 @@
+# M14 — Watch contract (tracker)
+
+**Milestone:** M14 · **Lane:** design (this file) + two child cards.
+Does **not** own `Sources/`. Children do.
+
+Parent issue:
+[#143](https://github.com/drawmeanelephant/solipsist/issues/143).
+
+## Why
+
+The pin (`6b930b7`) already contains A1 (boris#648): `--watch-json`
+emits NDJSON including `serve-started` with `url` / `helper` /
+`port`. Preview still regexes the prose port line in
+`WatchServer`. The letter (M10-3) loads a URL and reloads only
+when `serveURL` changes or the row is re-selected — D-S11
+rejected an EventSource client for the M10 gate.
+
+Contracts we have and do not consume are debt.
+
+## Children
+
+Engine is single-owner. M14-2 starts after M14-1.
+
+| Card | Issue | Lane | Gate (short) |
+|------|-------|------|----------------|
+| [M14-1 A1 consume](M14-a1-consume.md) | [#147](https://github.com/drawmeanelephant/solipsist/issues/147) | Engine + Preview | `--watch-json` / `serve-started` is how we learn the port |
+| [M14-2 Letter SSE](M14-letter-sse.md) | [#148](https://github.com/drawmeanelephant/solipsist/issues/148) | Reading | letter reloads on `event: reload`; no second watch |
+
+## Not this tracker
+
+- A5 `validate --watch` (boris#647, still open)
+- A15 `open=` (app already appends it; pin-follow)
+- A second `Process` or a second watch session
+- M13 trunk folders
+- Growing #110 / #111
+- `file://` preview

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -19,11 +19,11 @@ with a dispatch comment — [#72 M3](https://github.com/drawmeanelephant/solipsi
 [#78 M9](https://github.com/drawmeanelephant/solipsist/issues/78).
 
 M3–M8 **gates** are closed (#72–#77). The #87 depth batch is closed
-(#88/#94 · #89/#96 · #90/#95 · #91/#93). Active **ship** card:
-[#78 ship](https://github.com/drawmeanelephant/solipsist/issues/78).
-Next **product cut** is [M10 Mail body](M10-mail-body.md)
-([#98](https://github.com/drawmeanelephant/solipsist/issues/98)) —
-after #78, never inside it.
+(#88/#94 · #89/#96 · #90/#95 · #91/#93). **M9 ship** (#78), **M10
+Mail body** (#98), and **M11 prove** (#123) landed. Remaining ship
+is Apple-account only (#110 / #111). Pickable product: **M12
+clone** ([#131](https://github.com/drawmeanelephant/solipsist/issues/131)).
+M13 graph folders and M14 watch contract are filed below.
 
 **Legacy board (landed or withdrawn — do not pick):**
 
@@ -57,32 +57,48 @@ stdin wiring merges after B3-1. B3-4 must keep
 `files.user-selected.read-write` (B3-2) and `network.server` (M5
 preview) in the entitlements matrix.
 
-## M10 — Mail body (after #78, not instead of it)
+## M10 — Mail body ✅
 
-Spatial recut. Settings for sources, mailbox sidebar, reading pane,
-hosted Edit from the selected page, native Compose.
+Landed. Settings, mailboxes, reading pane, hosted Edit, native
+Compose. Do not pick.
 
-| Card | Issue | Lane | Parallel with | Gate |
-|------|-------|------|----------------|------|
-| [M10 tracker](M10-mail-body.md) | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) | design | — | children filed; [`M10-DESIGN.md`](../M10-DESIGN.md) + HARNESS §2 |
-| [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | Settings | #100 | Settings → Sources adds/removes/relocates ✅ |
-| [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | Mailboxes | #99 | account headers + mailboxes; writes `mailbox` ✅ |
-| [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | Reading | — (after #100) | tabs gone; list + reading pane |
-| [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | Editor wiring | — (merge after #101) | File → Edit Page; header `sourcePath` |
-| [M10-5 Compose](COMPOSE-EDITOR.md) | [#106](https://github.com/drawmeanelephant/solipsist/issues/106) | Compose | #101, #102 | `⌘⇧C` on a selected page; Oliver preview; PR [#108](https://github.com/drawmeanelephant/solipsist/pull/108) |
+| Card | Issue | Fate |
+|------|-------|------|
+| [M10 tracker](M10-mail-body.md) | [#98](https://github.com/drawmeanelephant/solipsist/issues/98) | ✅ |
+| [M10-1 Settings](M10-settings-sources.md) | [#99](https://github.com/drawmeanelephant/solipsist/issues/99) | ✅ |
+| [M10-2 Mailboxes](M10-mailbox-sidebar.md) | [#100](https://github.com/drawmeanelephant/solipsist/issues/100) | ✅ |
+| [M10-3 Reading](M10-reading-pane.md) | [#101](https://github.com/drawmeanelephant/solipsist/issues/101) | ✅ |
+| [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | ✅ |
+| [M10-5 Compose](COMPOSE-EDITOR.md) | [#106](https://github.com/drawmeanelephant/solipsist/issues/106) | ✅ PR [#108](https://github.com/drawmeanelephant/solipsist/pull/108) |
 
-#78 stays build-lane only. Do not pick an M10 card by growing ship.
-
-## Git (pickable)
+## M12 — Clone (pickable)
 
 | Card | Issue | Lane | Parallel with | Gate |
 |------|-------|------|----------------|------|
 | [Add Git Repository…](GIT-CLONE.md) | [#131](https://github.com/drawmeanelephant/solipsist/issues/131) | Settings / workspace | #110 | clone URL → folder → Local source; branch in Settings |
 
+## M13 — Graph folders (filed; pick after M12 or in a second worktree)
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [M13 tracker](M13-graph-folders.md) | [#142](https://github.com/drawmeanelephant/solipsist/issues/142) | design | — | children filed; unknown mailbox is not Pages |
+| [M13-0 Unknown mailbox](M13-unknown-mailbox.md) | [#144](https://github.com/drawmeanelephant/solipsist/issues/144) | Workspace | M14 | unknown `mailbox` displays verbatim; center does not treat it as Pages |
+| [M13-1 Trunk folders](M13-trunk-folders.md) | [#145](https://github.com/drawmeanelephant/solipsist/issues/145) | Mailboxes | after #144 | Pages grows children from `graph.parent` |
+| [M13-2 Filter letters](M13-filter-letters.md) | [#146](https://github.com/drawmeanelephant/solipsist/issues/146) | Reading | after #145 | trunk mailbox filters the list; Pages still means all |
+
+## M14 — Watch contract (filed; parallel with M13)
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [M14 tracker](M14-watch-contract.md) | [#143](https://github.com/drawmeanelephant/solipsist/issues/143) | design | — | children filed |
+| [M14-1 A1 consume](M14-a1-consume.md) | [#147](https://github.com/drawmeanelephant/solipsist/issues/147) | Engine + Preview | M13 | `--watch-json` / `serve-started` is how we learn the port |
+| [M14-2 Letter SSE](M14-letter-sse.md) | [#148](https://github.com/drawmeanelephant/solipsist/issues/148) | Reading | after #147 | letter reloads on `event: reload`; no second watch |
+
 ## Do not start yet
 
 GitHub OAuth / `SourceKind.github` payload. Wasm in the app. The
-fart app. Compose **depth**. #136 splitter crash (macOS 27 beta).
+fart app. Compose **depth**. Fetch / pull / commit / push.
+#136 splitter crash (macOS 27 beta).
 
 ## Shared noun kinds (play writes, inspector reads)
 

--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -73,9 +73,10 @@ the agent-pack, `plan --out`.
 | 9 | [issue-templates](issue-templates.md) | done (#22) |
 
 New work lives in the [delegation queue](../queue/README.md) — batch 2
-is landed. The queue is empty. Next pickable card is
-[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (ship,
-build-lane only — not this lane).
+is landed. The queue is empty. Next pickable product card is
+[#131](https://github.com/drawmeanelephant/solipsist/issues/131) (M12
+clone — Settings / workspace, not this lane). Apple-account ship
+(#110 / #111) is operator, not this lane.
 
 Skip: fart app (`make fart` must keep failing). Skip GitHub-as-source.
 Skip publication flows. Skip Wasm in the app.

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -67,10 +67,10 @@ lives in the issue tracker (#58–#61; briefs in
 `docs/cards/B3-*.md`) — those own grind-lane paths, so they are not
 queue cards.
 
-The depth batch (#88–#91) landed. The remaining **ship** card is
-[#78](https://github.com/drawmeanelephant/solipsist/issues/78) (M9).
-M10 Mail body
-([#98](https://github.com/drawmeanelephant/solipsist/issues/98),
-[`../M10-mail-body.md`](../M10-mail-body.md)) is the next product cut
-and owns grind-lane chrome/play paths, so it is not a queue card. The queue stays empty unless someone cuts a docs-only
-or `Tests/`-only slice.
+The depth batch (#88–#91) landed. M9 (#78), M10 (#98), and M11
+(#123) landed. Remaining ship is Apple-account only (#110 / #111)
+— not this queue. Next product cut is
+[#131](https://github.com/drawmeanelephant/solipsist/issues/131)
+(M12 clone) plus the M13 / M14 grind cards; those own Settings /
+Workspace / Play / Engine, so they are not queue cards. The queue
+stays empty unless someone cuts a docs-only or `Tests/`-only slice.


### PR DESCRIPTION
M10/M11 are landed. The board still only named #131 as next. This PR sets the next milestones and files the cards.

## Goals (ROADMAP §3)

- Drop **Project subdomain** from v1 must (P is withdrawn).
- Add clone-as-local, Pages folders from the graph, and A1 watch events.
- Split sandbox/pipeline (✅) from a notarized DMG a stranger can download (#110/#111).

## Milestones

GitHub milestones M9–M14 now exist.

| Milestone | Status | Tracker |
|-----------|--------|---------|
| M9 Ship | 🔧 operator | #110 / #111 |
| M10 / M11 | ✅ | closed |
| **M12 Clone** | 📋 pickable | #131 |
| **M13 Graph folders** | 📋 filed | #142 · #144 / #145 / #146 |
| **M14 Watch contract** | 📋 filed | #143 · #147 / #148 |

## Cards

New briefs under `docs/cards/M13-*.md` and `M14-*.md`. Pickup in ROADMAP §8. `agents.md`, MISSION, HARNESS lanes, queue/parallel READMEs stop pointing at #78 / M10.

## Not this PR

No `Sources/`. Do not implement clone, trunks, or `--watch-json` here. Next grind pick is still #131.

Docs-only.