### PR TITLE
docs(cards): land the M11 planning cards on main

### DIFF
--- a/docs/cards/M11-chrome-audit.md
+++ b/docs/cards/M11-chrome-audit.md
@@ -1,0 +1,61 @@
+# Card M11-1 — Chrome and Help audit
+
+**Milestone:** M11 · **Issue:**
+[#124](https://github.com/drawmeanelephant/solipsist/issues/124) ·
+**Lane:** Chrome / help. One worktree, one PR against `main`; branch
+suggestion `feat/m11-chrome-audit`.
+
+## Owns
+
+- `docs/help.md` (and the in-app Help window only if it is a
+  straight bind of that file)
+- Empty-state / first-run copy in `Sources/Chrome/` and
+  `Sources/Play/Local/` **copy only**
+- Accessibility labels on mailbox rows / reading empty states if
+  they are missing
+- `docs/HARNESS.md` §7 “what ships today” if it still describes
+  the pre-M10 window
+
+## Do not touch
+
+- `Sources/Engine/**`
+- `Sources/Compose/**` internals
+- `Sources/Companions/Editor/**` internals
+- Coordinator / publish
+- `Project.yml`
+- #110 / #111 paths
+
+## Why
+
+`docs/help.md` still says “Sources (Left)” and “Play (Center): Pages,
+Outputs, and Publish tabs.” That is the M3 window. Mail-body chrome
+without Mail-body Help is a lie. Empty states that say “select a
+source to view its publication” are the same lie.
+
+## Do
+
+1. Rewrite the spatial section: Settings → Sources, mailbox sidebar,
+   reading place, drawer, Preview / Editor companions, Compose
+   window. Use the nouns HARNESS §2 uses.
+2. Audit `Commands.swift` against Help. Every menu verb and every
+   `.keyboardShortcut` gets a row. File → Edit Page, Compose `⌘⇧C`,
+   mailbox language. Do not invent shortcuts.
+3. First-run / No Sources / No Pages / unreachable source copy:
+   point at Settings or Open… and `Stunts/happy`. Do not say “play
+   tabs.”
+4. Mailbox rows and reading empty states: a VoiceOver label if the
+   control is otherwise silent. Do not restyle the window.
+5. Leave EventSource-on-the-letter and the wide split **out**. Those
+   are Later (M10-DESIGN D-S11 / rejected alternative 6–7).
+
+## Do not
+
+- Add a feature so Help has something to say.
+- Restack the reading pane.
+- Touch Engine or start a second watch.
+
+## Gate
+
+Open Help in the app. It describes mailboxes, the reading place,
+Edit Page, and Compose. A new user sees empty-state copy that
+matches. `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/M11-prove.md
+++ b/docs/cards/M11-prove.md
@@ -1,0 +1,51 @@
+# M11 — Prove the Mail body (tracker)
+
+**Milestone:** M11 · **Lane:** design (this file) + two child cards.
+Does **not** own `Sources/` except the children.
+
+Parent issue:
+[#123](https://github.com/drawmeanelephant/solipsist/issues/123).
+[#110](https://github.com/drawmeanelephant/solipsist/issues/110) /
+[#111](https://github.com/drawmeanelephant/solipsist/issues/111)
+stay ship. They do not expand into this.
+
+## Why
+
+M10 shipped the Mail shape. Help still describes a source list and
+play tabs. Tests are contract decodes plus selection rules — nothing
+asserts the letter URL, and there is no XCUI target. First-run copy
+and empty states were written for the flatter chassis.
+
+This milestone is **prove**, not **invent**. No new Boris surface. No
+compose depth. No GitHub source. No Apple notarize.
+
+## Children
+
+| Card | Issue | Lane | Gate (short) |
+|------|-------|------|----------------|
+| [M11-1 Chrome](M11-chrome-audit.md) | [#124](https://github.com/drawmeanelephant/solipsist/issues/124) | Chrome / help | Help + empty states describe the window that ships; menus match |
+| [M11-2 Tests](M11-test-pass.md) | [#125](https://github.com/drawmeanelephant/solipsist/issues/125) | Tests | Help-vs-Commands test; reading-page URL; no XCUI required |
+
+They can run in parallel: 11-1 owns `docs/help.md` + empty-state
+copy; 11-2 owns `Tests/` and small extractable helpers. If 11-2
+needs a URL helper that lives next to Play, extract it — do not
+rewrite `ReadingPane`.
+
+## Not this tracker
+
+- #110 / #111 (Apple account)
+- Compose depth (diagnostics, bundle `oliver`)
+- GitHub as a source
+- EventSource on the letter (named Later; D-S11)
+- Width-adaptive list-beside-letter (named Later)
+- Nested trunk mailboxes
+- A from-scratch XCUI suite
+- Growing `MainWindow` into a dump
+
+## Gate
+
+A person who has never seen this repo can launch, add `Stunts/happy`
+from Settings or Open…, pick Pages, select a page, see a letter or
+summary, run Validate, and read Help that matches those nouns.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green. Help-vs-Commands
+test fails if a shortcut is undocumented.

--- a/docs/cards/M11-test-pass.md
+++ b/docs/cards/M11-test-pass.md
@@ -1,0 +1,58 @@
+# Card M11-2 — Test pass
+
+**Milestone:** M11 · **Issue:**
+[#125](https://github.com/drawmeanelephant/solipsist/issues/125) ·
+**Lane:** Tests. One worktree, one PR against `main`; branch
+suggestion `feat/m11-test-pass`.
+
+## Owns
+
+- `Tests/ContractTests/` (new files + extensions)
+- A small helper extracted from Play / Preview **only if** the URL
+  rule is currently an inline string and cannot be tested otherwise
+- `docs/help.md` **read-only** (the help-vs-commands test reads it)
+
+## Do not touch
+
+- `Sources/Chrome/MainWindow.swift`
+- `Sources/Engine/**` beyond calling existing types
+- `Sources/Compose/**` (already has contract tests)
+- `Project.yml` — no XCUI target
+- Help copy (M11-1)
+
+## Why
+
+`make test` decodes contracts and checks `WorkspaceSelection` rules.
+The letter URL (`/{graph node id}.html`) is a Solipsist rule with no
+test. Help vs `Commands.swift` was a one-shot queue card (Q25) and
+drifted the moment M10 landed. There is no XCUI target; do not add
+one for this gate.
+
+## Do
+
+1. **Reading URL.** Test the page-letter mapping: helper origin +
+   `/{id}.html`, including an id with a slash (`recipe/soup` must
+   not become a stem-swap of `sourcePath`). Put the rule in a
+   Foundation type if it is not already (`PreviewURL` or a sibling).
+2. **Help vs Commands.** A test that every `.keyboardShortcut` and
+   every `Button(` title in `Sources/App/Commands.swift` appears in
+   `docs/help.md`. Fail loud. Read files from the repo root; do not
+   import SwiftUI into the assertion beyond what ContractTests
+   already allow.
+3. **Mailbox display.** If `WorkspaceMailbox.display` / unknown →
+   Pages-without-rewrite is not fully covered, finish that file.
+   Do not add `WorkspaceStore` to the test target.
+4. Keep tests runnable as `make test` with no boris binary.
+
+## Do not
+
+- Stand up XCUI / `SolipsistUITests`.
+- Hit the network or spawn `boris`.
+- Rewrite ReadingPane to make it “more testable.”
+- Duplicate Compose highlighter tests.
+
+## Gate
+
+`make test` includes a failing-if-undocumented help audit and a
+reading-URL case for a slashed id. `SKIP_EMBED_BORIS=1 make build`
+green. No new test target.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -71,6 +71,17 @@ Compose. Do not pick.
 | [M10-4 Editor](M10-editor-wiring.md) | [#102](https://github.com/drawmeanelephant/solipsist/issues/102) | ✅ |
 | [M10-5 Compose](COMPOSE-EDITOR.md) | [#106](https://github.com/drawmeanelephant/solipsist/issues/106) | ✅ PR [#108](https://github.com/drawmeanelephant/solipsist/pull/108) |
 
+## M11 — Prove the Mail body ✅
+
+Landed. Help and empty states match the window; Help-vs-Commands and
+letter-URL contract tests pin the recut. Do not pick.
+
+| Card | Issue | Fate |
+|------|-------|------|
+| [M11 tracker](M11-prove.md) | [#123](https://github.com/drawmeanelephant/solipsist/issues/123) | ✅ |
+| [M11-1 Chrome/Help audit](M11-chrome-audit.md) | [#124](https://github.com/drawmeanelephant/solipsist/issues/124) | ✅ PR [#126](https://github.com/drawmeanelephant/solipsist/pull/126) |
+| [M11-2 Test pass](M11-test-pass.md) | [#125](https://github.com/drawmeanelephant/solipsist/issues/125) | ✅ PRs [#127](https://github.com/drawmeanelephant/solipsist/pull/127), [#128](https://github.com/drawmeanelephant/solipsist/pull/128) |
+
 ## M12 — Clone (pickable)
 
 | Card | Issue | Lane | Parallel with | Gate |


### PR DESCRIPTION
The three M11 planning cards (tracker, chrome/help audit, test pass) existed **only** on the unmerged `docs/m11-prove` branch — they were never part of the M11 PRs (#126/#127/#128 landed the code, tests, and `help.md` but not the cards).

The repo's convention is to keep milestone cards on main even after the milestone lands (M3/M4/M10 all do). This salvages them:

- `docs/cards/M11-prove.md` — M11 tracker brief (#123)
- `docs/cards/M11-chrome-audit.md` — Chrome/Help audit card (#124 → PR #126)
- `docs/cards/M11-test-pass.md` — Test pass card (#125 → PRs #127/#128)
- `docs/cards/README.md` — new **M11 section** matching the M10 format

Docs-only. After merge, the orphan `docs/m11-prove` branch (and `docs/m9-split-78`, whose content is a superseded draft of the #78-bury doc change already on main) get deleted — completing the branch cleanup.
