### PR TITLE
Fix git clone under the App Sandbox + show branch in Settings (follow-up to #152)

### DIFF
--- a/Sources/App/Settings/SourcesSettingsPane.swift
+++ b/Sources/App/Settings/SourcesSettingsPane.swift
@@ -138,6 +138,12 @@ private struct SourceAccountRow: View {
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
+                if let branch = item.branch {
+                    Text("⤷ \(branch)")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
                 if !item.isAvailable {
                     Text("Unreachable — Relocate / Remove")
                         .font(.caption)

--- a/Sources/Workspace/Git/GitClone.swift
+++ b/Sources/Workspace/Git/GitClone.swift
@@ -5,6 +5,23 @@ import Foundation
 /// `WorkspaceStore.addLocal`. This is not `BorisEngine` — it is a
 /// settings-adjacent one-shot process with its own cancel path.
 public enum GitClone {
+    /// `/usr/bin/git` on Apple platforms is an `xcrun` wrapper that refuses
+    /// to run inside the App Sandbox ("xcrun: error: cannot be used within
+    /// an App Sandbox"). Resolve the real binary — Command Line Tools or
+    /// Xcode — and fall back to `/usr/bin/git` where that is the only git
+    /// (unsandboxed hosts: spike, tests, non-Apple builds).
+    public static func gitExecutableURL() -> URL {
+        let candidates = [
+            "/Library/Developer/CommandLineTools/usr/bin/git",
+            "/Applications/Xcode.app/Contents/Developer/usr/bin/git",
+            "/usr/bin/git",
+        ]
+        for path in candidates where FileManager.default.isExecutableFile(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+        return URL(fileURLWithPath: "/usr/bin/git")
+    }
+
     public struct CloneResult: Sendable {
         public let exitCode: Int32
         public let stderr: String
@@ -66,7 +83,7 @@ public enum GitClone {
     /// finishes; call off the main actor.
     public static func clone(url: String, to dest: URL, session: CloneSession) throws -> CloneResult {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.executableURL = gitExecutableURL()
         process.arguments = ["clone", "--", url, dest.path]
         let errPipe = Pipe()
         process.standardOutput = FileHandle.nullDevice
@@ -94,7 +111,7 @@ public enum GitClone {
             return nil
         }
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.executableURL = gitExecutableURL()
         process.arguments = ["-C", root.path, "status", "--porcelain=v2", "--branch"]
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/Sources/Workspace/Local/LocalSource.swift
+++ b/Sources/Workspace/Local/LocalSource.swift
@@ -10,6 +10,9 @@ struct LocalSource: PublicationSource, Hashable, Sendable, Codable {
     var displayPath: String
     /// Transient: resolved at load time. Not persisted.
     var isAvailable: Bool = true
+    /// Transient: current checkout branch when the folder has `.git`
+    /// (read at add/load time via `GitClone.currentBranch`). Not persisted.
+    var branch: String? = nil
 
     var kind: SourceKind { .local }
 

--- a/Sources/Workspace/Source.swift
+++ b/Sources/Workspace/Source.swift
@@ -74,4 +74,11 @@ enum SourceItem: Identifiable, Hashable, Sendable {
         case .local(let source): return source.displayPath
         }
     }
+
+    /// Current checkout branch for git-backed sources; nil otherwise.
+    var branch: String? {
+        switch self {
+        case .local(let source): return source.branch
+        }
+    }
 }

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -359,6 +359,9 @@ final class WorkspaceStore {
             if resolved.stale, let refreshed = try? local.refreshedBookmark() {
                 local.bookmarkData = refreshed.bookmarkData
             }
+            // One porcelain read per add/load; nil for non-repos. Never
+            // surfaced as an error — not-a-repo is a normal folder.
+            local.branch = GitClone.currentBranch(at: resolved.url)
         } catch {
             local.isAvailable = false
         }

--- a/Tests/ContractTests/GitCloneTests.swift
+++ b/Tests/ContractTests/GitCloneTests.swift
@@ -24,6 +24,14 @@ final class GitCloneTests: XCTestCase {
         XCTAssertFalse(GitClone.isValidCloneURL("git@host")) // scp-like needs a path
     }
 
+    // MARK: - Executable resolution
+
+    func testGitExecutableResolutionFindsARunnableGit() {
+        let git = GitClone.gitExecutableURL()
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: git.path))
+        XCTAssertEqual(git.path, GitClone.gitExecutableURL().path, "resolution must be deterministic")
+    }
+
     // MARK: - Repo naming
 
     func testRepoNameFromUrl() {


### PR DESCRIPTION
Follow-up to #152 (M12 / #131). Live verification of the clone flow in the app found two things:

## 1. The clone always failed inside the App Sandbox
`/usr/bin/git` on Apple platforms is an `xcrun` wrapper that refuses to run in a sandboxed process — the Workspace alert surfaced `git clone failed (exit 1): xcrun: error: cannot be used within an App Sandbox` for *every* clone. `GitClone` now resolves the real binary (Command Line Tools → Xcode → `/usr/bin/git` fallback for unsandboxed spike/tests) via `gitExecutableURL()`, used by both `clone` and `currentBranch`.

## 2. The branch caption wasn't wired into the UI
`currentBranch` existed but was never called. `LocalSource` gains a transient `branch` field (not persisted), populated at add/load time in `beginAccess`, and the Settings Sources row shows it as a `⤷ branch` caption.

## Verified live (loopback git daemon, zero internet)
- **Success:** File → Clone Repository… with `git://127.0.0.1:9419/repo.git` → cloned to the chosen parent; source `repo` appears selected with its mailboxes; Settings → Sources shows `repo` · `Local` · path · **`⤷ main`**
- **Failure:** clone of a missing repo → Workspace alert surfaces `git clone failed (exit 128): … fatal: remote error: access denied or repository not exported`
- **Green:** build · 218 tests / 0 failures · lint 0
