### PR TITLE
M13-0 (#144): unknown mailbox is not Pages

### DIFF
--- a/Sources/Inspector/Inspectable.swift
+++ b/Sources/Inspector/Inspectable.swift
@@ -68,15 +68,9 @@ struct InspectorSnapshot: Inspectable {
             }
 
         default:
-            if nounKind == InspectorNounKind.page {
-                sections.append(InspectorSection(id: InspectorSectionID.page, title: "Page"))
-            }
-            if nounKind == InspectorNounKind.target {
-                sections.append(InspectorSection(id: InspectorSectionID.target, title: "Target"))
-            }
-            if sourceKind == .local {
-                sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Profile"))
-            }
+            // Unknown mailbox (e.g. a future trunk id): not the Pages
+            // surface. Execution controls only, until M13-2 lands the
+            // trunk folder filter.
             sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
         }
 

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -25,6 +25,8 @@ struct LocalPlay: PlaySurface {
     var body: some View {
         Group {
             switch WorkspaceMailbox.display(store.selection.mailbox) {
+            case WorkspaceMailbox.pages:
+                pagesMailbox
             case WorkspaceMailbox.outputs:
                 OutputsPane(source: source)
             case WorkspaceMailbox.publish:
@@ -34,7 +36,8 @@ struct LocalPlay: PlaySurface {
             case WorkspaceMailbox.activity:
                 ActivityPane()
             default:
-                pagesMailbox
+                // Unknown mailbox (e.g. a future trunk id) is not Pages.
+                unknownMailbox
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -47,6 +50,22 @@ struct LocalPlay: PlaySurface {
         .task(id: source.id) {
             await load()
         }
+    }
+
+    /// Placeholder until M13-2 lands the trunk folder filter. Unknown
+    /// mailboxes must not surface the full Pages list.
+    @ViewBuilder
+    private var unknownMailbox: some View {
+        ContentUnavailableView {
+            Label(rawMailboxName, systemImage: "folder")
+                .accessibilityLabel("\(source.title), \(rawMailboxName)")
+        } description: {
+            Text("This mailbox has no list in this build yet.")
+        }
+    }
+
+    private var rawMailboxName: String {
+        WorkspaceMailbox.displayName(store.selection.mailbox ?? "")
     }
 
     private var loadedPages: [PlayPage] {

--- a/Sources/Workspace/WorkspaceSelection.swift
+++ b/Sources/Workspace/WorkspaceSelection.swift
@@ -35,8 +35,8 @@ struct MailboxRowID: Hashable, Sendable {
 }
 
 /// M10 mailbox tokens. Open vocabulary — not a closed enum.
-/// M10 UI admits only `all`; unknown values display as Pages
-/// without being rewritten to `pages` in the plist.
+/// M10 UI admits only `all`; unknown values (a future trunk id)
+/// stay themselves and are never rewritten to `pages` in the plist.
 enum WorkspaceMailbox {
     static let pages = "pages"
     static let outputs = "outputs"
@@ -52,10 +52,12 @@ enum WorkspaceMailbox {
         return all.contains(raw)
     }
 
-    /// M10 display/switch value. Does **not** write back.
-    /// A later trunk card must stop using this for persist.
+    /// Center-switch token. Known five pass through; nil (no mailbox
+    /// chosen yet) is the default Pages surface; unknown (including a
+    /// future trunk id) stays itself — it is **not** Pages. Does not
+    /// write back, and the switch never treats unknown as Pages.
     static func display(_ raw: String?) -> String {
-        guard let raw, isKnown(raw) else { return defaultMailbox }
+        guard let raw else { return defaultMailbox }
         return raw
     }
 

--- a/Tests/ContractTests/WorkspaceSelectionTests.swift
+++ b/Tests/ContractTests/WorkspaceSelectionTests.swift
@@ -15,20 +15,22 @@ final class WorkspaceSelectionTests: XCTestCase {
         XCTAssertNil(noun.sourcePath)
     }
 
-    func testDisplayMapsUnknownAndNilToPagesWithoutRewriting() {
+    func testDisplayKeepsUnknownItselfAndNilDefaultsToPages() {
+        // nil (no mailbox chosen yet) is the default Pages surface.
         XCTAssertEqual(WorkspaceMailbox.display(nil), WorkspaceMailbox.pages)
-        XCTAssertEqual(WorkspaceMailbox.display("trunk:guides"), WorkspaceMailbox.pages)
-        XCTAssertEqual(WorkspaceMailbox.display("guides/overview"), WorkspaceMailbox.pages)
+        // Unknown stays itself — never coerced to Pages (M13, #144).
+        XCTAssertEqual(WorkspaceMailbox.display("trunk:guides"), "trunk:guides")
+        XCTAssertEqual(WorkspaceMailbox.display("guides/overview"), "guides/overview")
+        XCTAssertEqual(WorkspaceMailbox.display("index"), "index")
+        XCTAssertEqual(WorkspaceMailbox.display(""), "")
         // Every known token round-trips through display unchanged.
         for token in WorkspaceMailbox.all {
             XCTAssertEqual(WorkspaceMailbox.display(token), token)
         }
-        // Unknown and nil both display as Pages without being written back
-        // (display is a view value; persist keeps the raw string).
-        XCTAssertEqual(WorkspaceMailbox.display(""), WorkspaceMailbox.pages)
 
         XCTAssertFalse(WorkspaceMailbox.isKnown(nil))
         XCTAssertFalse(WorkspaceMailbox.isKnown("trunk:guides"))
+        XCTAssertFalse(WorkspaceMailbox.isKnown("index"))
         XCTAssertTrue(WorkspaceMailbox.isKnown(WorkspaceMailbox.pages))
         XCTAssertTrue(WorkspaceMailbox.isKnown(WorkspaceMailbox.outputs))
         XCTAssertEqual(WorkspaceMailbox.all, [


### PR DESCRIPTION
Closes #144 — M13-0, picked first per the parent tracker.

## What changes
- **`WorkspaceMailbox.display`** no longer coerces unknown mailboxes to `pages`. Known five pass through; `nil` stays the default Pages surface; an unknown token (e.g. a future trunk id like `index`) **stays itself**.
- **Center switch (`LocalPlay`)** — explicit `pages` case plus a placeholder for unknown mailboxes (raw name + folder glyph + "This mailbox has no list in this build yet.") until M13-2 lands the trunk filter. An unknown mailbox does **not** show the full Pages list.
- **Inspector (`Inspectable`)** — unknown mailbox shows Execution controls only, not the Pages-style Page/Profile sections.
- **Restore untouched** — the raw mailbox survives reload; nothing is rewritten to `pages`.

## Tests
Updated to the new contract: `display("index") == "index"`, `display("trunk:guides") == "trunk:guides"`, `isKnown("index")` is false, unknown `displayName` is verbatim.

## Gate (verified live)
Persisted a mailbox of `"index"` into the workspace and launched the app: the center showed the placeholder (`happy, index` · "This mailbox has no list in this build yet.") — **not** the Pages list — and the stored value was still `"index"` after the app loaded (not rewritten). Workspace restored afterward.

**Green:** build · 218 tests / 0 failures · lint 0.
