### PR TITLE
M13-1 (#145): trunk folders under Pages in the sidebar

### DIFF
--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -83,26 +83,86 @@ private struct SourceSection: View {
     var body: some View {
         Section(isExpanded: $isExpanded) {
             ForEach(WorkspaceMailbox.all, id: \.self) { box in
-                MailboxRow(item: item, box: box)
-                    .tag(MailboxRowID(sourceID: item.id, mailbox: box))
-                    .contextMenu { sourceMenu(item) }
+                if box == WorkspaceMailbox.pages {
+                    // Pages grows trunk-folder children from the decoded
+                    // graph (M13-1). No graph yet → no children, not an
+                    // error; Chrome never parses JSON.
+                    PagesGroup(item: item, store: store)
+                } else {
+                    MailboxRow(item: item, box: box)
+                        .tag(MailboxRowID(sourceID: item.id, mailbox: box))
+                        .contextMenu { sourceMenu(item, store: store) }
+                }
             }
         } header: {
             SourceAccountHeader(item: item)
-                .contextMenu { sourceMenu(item) }
+                .contextMenu { sourceMenu(item, store: store) }
         }
     }
+}
 
-    @ViewBuilder
-    private func sourceMenu(_ item: SourceItem) -> some View {
-        if !item.isAvailable {
-            Button("Relocate…") {
-                store.presentRelocatePanel(for: item.id)
+/// Pages plus its trunk-folder children. One child row per trunk;
+/// the selection value is the trunk **id**. Clicking Pages writes
+/// `pages`; clicking a trunk writes its raw id. Expansion is not
+/// persisted (resets to expanded each launch).
+private struct PagesGroup: View {
+    let item: SourceItem
+    let store: WorkspaceStore
+    @State private var expanded = true
+
+    private var pagesRowID: MailboxRowID {
+        MailboxRowID(sourceID: item.id, mailbox: WorkspaceMailbox.pages)
+    }
+
+    private var trunks: [PlayPage] {
+        guard let graph = store.graph(for: item.id) else { return [] }
+        return LocalPlayGraph.trunks(from: graph)
+    }
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $expanded) {
+            ForEach(trunks, id: \.id) { trunk in
+                TrunkRow(item: item, trunk: trunk)
+                    .tag(MailboxRowID(sourceID: item.id, mailbox: trunk.id))
+                    .contextMenu { sourceMenu(item, store: store) }
             }
+        } label: {
+            MailboxRow(item: item, box: WorkspaceMailbox.pages)
+                .tag(pagesRowID)
+                .contextMenu { sourceMenu(item, store: store) }
         }
-        Button("Remove from Sidebar", role: .destructive) {
-            store.remove(item.id)
+    }
+}
+
+/// A trunk folder row under Pages. Label is the trunk title; the
+/// selection value is the trunk id (written raw to `mailbox`).
+private struct TrunkRow: View {
+    let item: SourceItem
+    let trunk: PlayPage
+
+    var body: some View {
+        Label {
+            Text(trunk.title)
+                .font(.system(size: 12.5, weight: .regular))
+                .lineLimit(1)
+        } icon: {
+            Image(systemName: "folder")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
         }
+        .accessibilityLabel("\(item.title), \(trunk.title)")
+    }
+}
+
+@ViewBuilder
+fileprivate func sourceMenu(_ item: SourceItem, store: WorkspaceStore) -> some View {
+    if !item.isAvailable {
+        Button("Relocate…") {
+            store.presentRelocatePanel(for: item.id)
+        }
+    }
+    Button("Remove from Sidebar", role: .destructive) {
+        store.remove(item.id)
     }
 }
 

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -327,6 +327,9 @@ struct LocalPlay: PlaySurface {
         }
         let pages = LocalPlayGraph.pages(from: graph)
         state = pages.isEmpty ? .empty : .ready(pages)
+        // Push the decoded graph so the sidebar can show trunk folders
+        // without Chrome re-parsing JSON (M13-1).
+        store.updateGraph(graph, for: source.id)
         refreshNoun(against: pages)
     }
 

--- a/Sources/Play/Local/LocalPlayGraph.swift
+++ b/Sources/Play/Local/LocalPlayGraph.swift
@@ -74,6 +74,12 @@ enum LocalPlayGraph {
         return rows
     }
 
+    /// The sidebar's folder rows under Pages (M13-1): roots whose role
+    /// is `trunk`. Satellites and non-trunk roots are not folders.
+    static func trunks(from graph: Graph) -> [PlayPage] {
+        pages(from: graph).filter { $0.depth == 0 && $0.role == .trunk }
+    }
+
     /// Filter pages by query string matching title, id, tag, or status.
     /// Supports prefixes: `tag:`, `status:`, `id:`, `title:`.
     static func filter(pages: [PlayPage], query: String) -> [PlayPage] {

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -20,6 +20,11 @@ final class WorkspaceStore {
     @ObservationIgnored
     private var scopedURLs: [SourceID: URL] = [:]
 
+    /// Decoded graph per source (M13-1 sidebar trunks). Play pushes the
+    /// decoded graph after a load/build; Chrome only reads it. Negative
+    /// lookups are never cached, so a later build can make it appear.
+    private(set) var graphs: [SourceID: Graph] = [:]
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         load()
@@ -180,6 +185,40 @@ final class WorkspaceStore {
     /// in place; nothing is added to the source list.
     func cancelClone() {
         activeCloneSession?.terminate()
+    }
+
+    // MARK: - Graph mirror (M13-1)
+
+    /// Sidebar read path for trunk folders. Cached value wins; otherwise
+    /// decode `<root>/.boris/graph.json` lazily. Chrome never parses JSON
+    /// itself — this is the store's mirror.
+    func graph(for id: SourceID) -> Graph? {
+        if let cached = graphs[id] { return cached }
+        guard let url = resolvedURL(for: id) else { return nil }
+        let fileURL = url
+            .appendingPathComponent(".boris", isDirectory: true)
+            .appendingPathComponent("graph.json")
+        guard FileManager.default.fileExists(atPath: fileURL.path),
+              let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode(Graph.self, from: data)
+        else { return nil }
+        graphs[id] = decoded
+        return decoded
+    }
+
+    /// Play pushes the graph it already decoded after a load/build so
+    /// the sidebar stays fresh without re-parsing JSON.
+    func updateGraph(_ graph: Graph, for id: SourceID) {
+        graphs[id] = graph
+    }
+
+    private func resolvedURL(for id: SourceID) -> URL? {
+        if let url = scopedURLs[id] { return url }
+        guard let item = sources.first(where: { $0.id == id }),
+              case .local(let local) = item,
+              let resolved = try? local.resolve().url
+        else { return nil }
+        return resolved.standardizedFileURL
     }
 
     func addLocal(url: URL) {

--- a/Tests/ContractTests/GraphTrunksTests.swift
+++ b/Tests/ContractTests/GraphTrunksTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+/// M13-1 (#145): trunk extraction for the sidebar's Pages children.
+final class GraphTrunksTests: XCTestCase {
+    private func graph(nodes: [GraphNode]) -> Graph {
+        Graph(
+            schemaVersion: "0.3.0",
+            frozen: true,
+            nodes: nodes,
+            edges: [],
+            reverseIndex: [],
+            nav: []
+        )
+    }
+
+    private func node(
+        index: Int,
+        id: String,
+        role: PageRole,
+        parent: String?,
+        title: String
+    ) -> GraphNode {
+        GraphNode(
+            index: index,
+            id: id,
+            sourcePath: id + ".md",
+            role: role,
+            parent: parent,
+            parentIndex: nil,
+            title: title,
+            status: "published",
+            tags: []
+        )
+    }
+
+    func testTrunksExtraction() {
+        let graph = graph(nodes: [
+            node(index: 0, id: "index", role: .trunk, parent: nil, title: "Home"),
+            node(index: 1, id: "guides", role: .trunk, parent: nil, title: "Guides"),
+            node(index: 2, id: "guides/intro", role: .satellite, parent: "guides", title: "Introduction"),
+            node(index: 3, id: "orphan", role: .satellite, parent: nil, title: "Orphan"),
+        ])
+
+        // Trunk roots only — satellites (children or rootless) are not folders.
+        let trunks = LocalPlayGraph.trunks(from: graph)
+        XCTAssertEqual(trunks.map(\.id), ["index", "guides"])
+        XCTAssertEqual(trunks.map(\.depth), [0, 0])
+        XCTAssertEqual(trunks.map(\.title), ["Home", "Guides"])
+        XCTAssertTrue(trunks.allSatisfy { $0.role == .trunk })
+    }
+
+    func testEmptyGraphHasNoTrunks() {
+        XCTAssertTrue(LocalPlayGraph.trunks(from: graph(nodes: [])).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #145 — M13-1, after #144 (M13-0) landed.

## What changes
- **Sidebar (`SourceSidebar`)** — Pages is now a disclosure with one child row per trunk, read from the already-decoded graph. Clicking Pages writes `pages`; clicking a trunk writes the raw trunk **id** as `mailbox`. Expansion is `@State` (not persisted). No disk walk; no graph yet → Pages has no children, not an error.
- **Store graph mirror (`WorkspaceStore`)** — `graph(for:)` (cached, lazy decode of `<root>/.boris/graph.json` as fallback, negative lookups never cached) + `updateGraph(_:for:)` which Play calls after a load/build. Chrome never parses JSON.
- **`LocalPlayGraph.trunks(from:)`** — roots with role `trunk`, the same walk `pages(from:)` already does.
- **Tests** — new `GraphTrunksTests` (trunk roots only; satellites/rootless excluded; empty graph → none).

## Gate (verified live)
Opened `Stunts/dogfood` in the built app:
- Pages showed **7 trunk folders** from `graph.json` (Agent Field Notes, Boris at Build Week, Getting Started with Boris, Apex Markdown Showcase, Content Model Overview, Boris — The Content Exit Hatch, Frontmatter Reference) — and happy showed its own trunk ("My Boris Site") — no disk walk, nothing from `.boris/`/`themes/`/`dist/`
- Clicking a trunk wrote `mailbox: 'agents'` (the trunk id) and the center showed M13-0's placeholder, not Pages
- Clicking Pages wrote `mailbox: 'pages'` and the full list returned

**Green:** build · 220 tests / 0 failures · lint 0.
