### PR TITLE
M13-2 (#146): filter the letter list by trunk mailbox

### DIFF
--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -36,8 +36,9 @@ struct LocalPlay: PlaySurface {
             case WorkspaceMailbox.activity:
                 ActivityPane()
             default:
-                // Unknown mailbox (e.g. a future trunk id) is not Pages.
-                unknownMailbox
+                // Unknown mailbox is a trunk id (M13): Pages means all;
+                // a trunk id means that folder and its descendants.
+                trunkMailbox
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -52,20 +53,21 @@ struct LocalPlay: PlaySurface {
         }
     }
 
-    /// Placeholder until M13-2 lands the trunk folder filter. Unknown
-    /// mailboxes must not surface the full Pages list.
-    @ViewBuilder
-    private var unknownMailbox: some View {
-        ContentUnavailableView {
-            Label(rawMailboxName, systemImage: "folder")
-                .accessibilityLabel("\(source.title), \(rawMailboxName)")
-        } description: {
-            Text("This mailbox has no list in this build yet.")
-        }
+    /// The raw mailbox value when it is a trunk id (not one of the known
+    /// M10 tokens and not nil). Trunk ids come from `graph.parent` only.
+    private var trunkID: String? {
+        guard
+            let mailbox = store.selection.mailbox,
+            !WorkspaceMailbox.isKnown(mailbox)
+        else { return nil }
+        return mailbox
     }
 
-    private var rawMailboxName: String {
-        WorkspaceMailbox.displayName(store.selection.mailbox ?? "")
+    /// The letter list for the current trunk folder, or the full list when
+    /// the mailbox is Pages. Empty when the id is stale — never all pages.
+    private var displayedPages: [PlayPage] {
+        guard let trunkID else { return loadedPages }
+        return LocalPlayGraph.pages(in: loadedPages, trunkID: trunkID)
     }
 
     private var loadedPages: [PlayPage] {
@@ -86,26 +88,64 @@ struct LocalPlay: PlaySurface {
 
     @ViewBuilder
     private var pagesMailbox: some View {
+        mailboxContent(pages: loadedPages, empty: .noPages)
+    }
+
+    /// Unknown mailbox = trunk id: the folder's letter list, or an honest
+    /// empty state when the folder has none in the current graph.
+    @ViewBuilder
+    private var trunkMailbox: some View {
+        mailboxContent(pages: displayedPages, empty: .emptyFolder)
+    }
+
+    private enum MailboxEmptyKind {
+        /// The source's graph has no pages at all.
+        case noPages
+        /// The trunk folder has no pages in the current graph (or its id
+        /// is stale — the graph no longer contains it).
+        case emptyFolder
+    }
+
+    @ViewBuilder
+    private func mailboxContent(pages: [PlayPage], empty: MailboxEmptyKind) -> some View {
         switch state {
         case .idle, .reading, .building:
             ProgressView(progressTitle)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         case .unavailable:
-            ContentUnavailableView {
-                Label(source.title, systemImage: "folder")
-                    .accessibilityLabel("\(source.title), unreachable")
-            } description: {
-                Text("This folder is unreachable. Relocate it from File → Relocate Source… or Settings → Sources, or remove it.")
-            } actions: {
-                Button("Relocate…") {
-                    store.presentRelocatePanel(for: source.id)
-                }
-                Button("Remove", role: .destructive) {
-                    store.remove(source.id)
-                }
-            }
+            unreachableContent
+        case .failed(let message):
+            failedContent(message)
         case .empty:
+            emptyContent(empty)
+        case .ready where pages.isEmpty:
+            emptyContent(empty)
+        case .ready:
+            pagesSplit(pages)
+        }
+    }
+
+    private var unreachableContent: some View {
+        ContentUnavailableView {
+            Label(source.title, systemImage: "folder")
+                .accessibilityLabel("\(source.title), unreachable")
+        } description: {
+            Text("This folder is unreachable. Relocate it from File → Relocate Source… or Settings → Sources, or remove it.")
+        } actions: {
+            Button("Relocate…") {
+                store.presentRelocatePanel(for: source.id)
+            }
+            Button("Remove", role: .destructive) {
+                store.remove(source.id)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func emptyContent(_ kind: MailboxEmptyKind) -> some View {
+        switch kind {
+        case .noPages:
             ContentUnavailableView {
                 Label("No Pages", systemImage: "doc.text")
             } description: {
@@ -114,16 +154,23 @@ struct LocalPlay: PlaySurface {
             .accessibilityElement(children: .combine)
             .accessibilityLabel("No Pages")
             .accessibilityHint("Add Stunts/happy from Settings → Sources or File → Open… to see a working publication.")
-        case .failed(let message):
+        case .emptyFolder:
             ContentUnavailableView {
-                Label("Graph Unavailable", systemImage: "exclamationmark.triangle")
+                Label("No Pages in This Folder", systemImage: "folder")
             } description: {
-                Text(message)
-            } actions: {
-                Button("Try Again") { reload() }
+                Text("This folder has no pages in the current graph.")
             }
-        case .ready(let pages):
-            pagesSplit(pages)
+            .accessibilityLabel("No Pages in This Folder")
+        }
+    }
+
+    private func failedContent(_ message: String) -> some View {
+        ContentUnavailableView {
+            Label("Graph Unavailable", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("Try Again") { reload() }
         }
     }
 

--- a/Sources/Play/Local/LocalPlayGraph.swift
+++ b/Sources/Play/Local/LocalPlayGraph.swift
@@ -11,6 +11,10 @@ struct PlayPage: Identifiable, Hashable, Sendable {
     let depth: Int
     let tags: [String]
     let sourcePath: String
+    /// The trunk this row belongs to (M13-2): the root `role == .trunk`
+    /// whose `parent` chain this row reaches, or nil for non-trunk roots.
+    /// Drives the trunk-mailbox filter; never the sidebar.
+    let trunkID: String?
 
     init(
         id: String,
@@ -19,7 +23,8 @@ struct PlayPage: Identifiable, Hashable, Sendable {
         role: PageRole = .trunk,
         depth: Int = 0,
         tags: [String] = [],
-        sourcePath: String = ""
+        sourcePath: String = "",
+        trunkID: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -28,6 +33,7 @@ struct PlayPage: Identifiable, Hashable, Sendable {
         self.depth = depth
         self.tags = tags
         self.sourcePath = sourcePath
+        self.trunkID = trunkID
     }
 }
 
@@ -47,7 +53,7 @@ enum LocalPlayGraph {
         }
 
         var rows: [PlayPage] = []
-        func emit(_ node: GraphNode, depth: Int) {
+        func emit(_ node: GraphNode, depth: Int, trunkID: String?) {
             rows.append(
                 PlayPage(
                     id: node.id,
@@ -56,22 +62,30 @@ enum LocalPlayGraph {
                     role: node.role,
                     depth: depth,
                     tags: node.tags ?? [],
-                    sourcePath: node.sourcePath
+                    sourcePath: node.sourcePath,
+                    trunkID: trunkID
                 )
             )
             for child in children[node.id] ?? [] {
-                emit(child, depth: depth + 1)
+                emit(child, depth: depth + 1, trunkID: trunkID)
             }
         }
 
         // Trunks first so a mixed-index corpus still reads as a publication.
         for node in roots where node.role == .trunk {
-            emit(node, depth: 0)
+            emit(node, depth: 0, trunkID: node.id)
         }
         for node in roots where node.role != .trunk {
-            emit(node, depth: 0)
+            emit(node, depth: 0, trunkID: nil)
         }
         return rows
+    }
+
+    /// The trunk mailbox's letter list (M13-2): the trunk row plus every
+    /// descendant whose `parent` chain reaches it. Empty when the id is
+    /// missing from the current graph — never a fall-through to all pages.
+    static func pages(in pages: [PlayPage], trunkID: String) -> [PlayPage] {
+        pages.filter { $0.trunkID == trunkID }
     }
 
     /// The sidebar's folder rows under Pages (M13-1): roots whose role

--- a/Tests/ContractTests/FilterLettersTests.swift
+++ b/Tests/ContractTests/FilterLettersTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+/// M13-2 (#146): a trunk mailbox filters the letter list to that folder;
+/// Pages still means all pages.
+final class FilterLettersTests: XCTestCase {
+    private func graph(nodes: [GraphNode]) -> Graph {
+        Graph(
+            schemaVersion: "0.3.0",
+            frozen: true,
+            nodes: nodes,
+            edges: [],
+            reverseIndex: [],
+            nav: []
+        )
+    }
+
+    private func node(
+        index: Int,
+        id: String,
+        role: PageRole,
+        parent: String?,
+        title: String
+    ) -> GraphNode {
+        GraphNode(
+            index: index,
+            id: id,
+            sourcePath: id + ".md",
+            role: role,
+            parent: parent,
+            parentIndex: nil,
+            title: title,
+            status: "published",
+            tags: []
+        )
+    }
+
+    /// The card's fixture: trunk + child + unrelated trunk.
+    private var threeNodeGraph: Graph {
+        graph(nodes: [
+            node(index: 0, id: "index", role: .trunk, parent: nil, title: "Home"),
+            node(index: 1, id: "index/child", role: .satellite, parent: "index", title: "Child"),
+            node(index: 2, id: "guides", role: .trunk, parent: nil, title: "Guides"),
+        ])
+    }
+
+    func testPagesStillReturnsAllThree() {
+        let pages = LocalPlayGraph.pages(from: threeNodeGraph)
+        XCTAssertEqual(pages.map(\.id), ["index", "index/child", "guides"])
+    }
+
+    func testTrunkFilterKeepsTrunkAndDescendants() {
+        let pages = LocalPlayGraph.pages(from: threeNodeGraph)
+        let filtered = LocalPlayGraph.pages(in: pages, trunkID: "index")
+        XCTAssertEqual(filtered.map(\.id), ["index", "index/child"])
+        // The unrelated trunk is not part of this folder.
+        XCTAssertFalse(filtered.contains { $0.id == "guides" })
+        XCTAssertEqual(filtered.map(\.trunkID), ["index", "index"])
+        XCTAssertEqual(filtered.map(\.depth), [0, 1])
+    }
+
+    func testGrandchildChainIsIncluded() {
+        let graph = graph(nodes: [
+            node(index: 0, id: "trunk", role: .trunk, parent: nil, title: "Trunk"),
+            node(index: 1, id: "trunk/a", role: .satellite, parent: "trunk", title: "A"),
+            node(index: 2, id: "trunk/a/b", role: .satellite, parent: "trunk/a", title: "B"),
+        ])
+        let filtered = LocalPlayGraph.pages(
+            in: LocalPlayGraph.pages(from: graph),
+            trunkID: "trunk"
+        )
+        XCTAssertEqual(filtered.map(\.id), ["trunk", "trunk/a", "trunk/a/b"])
+        XCTAssertEqual(filtered.map(\.depth), [0, 1, 2])
+        XCTAssertEqual(filtered.map(\.trunkID), ["trunk", "trunk", "trunk"])
+    }
+
+    func testMissingTrunkIsEmptyNotFallthrough() {
+        let pages = LocalPlayGraph.pages(from: threeNodeGraph)
+        // Stale id — the graph no longer contains it. Empty is honest.
+        XCTAssertTrue(LocalPlayGraph.pages(in: pages, trunkID: "stale").isEmpty)
+    }
+
+    func testOrphanSatelliteIsInNoTrunkFolder() {
+        let graph = graph(nodes: [
+            node(index: 0, id: "index", role: .trunk, parent: nil, title: "Home"),
+            node(index: 1, id: "orphan", role: .satellite, parent: nil, title: "Orphan"),
+        ])
+        let pages = LocalPlayGraph.pages(from: graph)
+        // Present in the full list, absent from the trunk folder.
+        XCTAssertEqual(pages.map(\.id), ["index", "orphan"])
+        XCTAssertEqual(LocalPlayGraph.pages(in: pages, trunkID: "index").map(\.id), ["index"])
+    }
+}


### PR DESCRIPTION
Closes #146 — the last M13 child (also closes tracker #142).

## What changed

- **`PlayPage.trunkID`** — threaded through the `pages(from:)` flattening: trunk roots carry their own id, descendants inherit it, non-trunk roots stay nil. No new graph walks, no disk access.
- **`LocalPlayGraph.pages(in:trunkID:)`** — the filter helper: the trunk row plus every descendant whose `parent` chain reaches it. Missing id → empty, never all pages.
- **`LocalPlay`** — the unknown-mailbox branch (M13-0 placeholder) is now a real list: when `mailbox` is a trunk id it shows that folder's letters via the same state switch as Pages, with an honest **"No Pages in This Folder"** empty state for stale/missing ids. Pages / outputs / publish / plan / activity are untouched. Selecting a row still writes `noun` with `sourcePath` exactly as Reading does.
- **Tests** — `FilterLettersTests`: the card's 3-node fixture (trunk + child + unrelated trunk) filters to 2 rows while Pages returns 3; grandchild chains; stale id empty; orphan satellites in no folder.

## Gate (verified live on Stunts/dogfood)

- Clicked **Getting Started with Boris** → persisted `mailbox: 'getting-started'`, list shows exactly 2 rows (trunk + its 1 satellite)
- Clicked **Content Model Overview** → `mailbox: 'guides/overview'`, exactly 4 rows (trunk + 3 satellites)
- Clicked **Pages** → `mailbox: 'pages'`, full 45-page list returns
- Persisted a stale id (`stale-trunk`) → center shows **"No Pages in This Folder"**, not the full list

Workspace restored afterward (dogfood removed, happy selected). `SKIP_EMBED_BORIS=1 make build` + `make test` (225 tests, 0 failures) + lint all green.
