### PR TITLE
M14-1 (#147): consume A1 --watch-json / serve-started

### DIFF
--- a/Sources/Companions/Preview/PreviewSession.swift
+++ b/Sources/Companions/Preview/PreviewSession.swift
@@ -22,6 +22,11 @@ final class PreviewSession {
 
     private(set) var phase: Phase = .idle
 
+    /// Most recent problem reported by the watch stream (`build-failed` /
+    /// `watch-error` / unexpected `watch-stopped`) while still serving the
+    /// last good build. Surfaced in `statusText`; never swallowed.
+    private(set) var lastProblem: String?
+
     /// The helper URL (`…/__boris/`) the web view should load, if serving.
     var serveURL: URL? {
         if case .serving(let url) = phase { return url }
@@ -47,6 +52,9 @@ final class PreviewSession {
         case .starting:
             return "Starting boris watch…"
         case .serving(let url):
+            if let lastProblem {
+                return "Serving \(url.absoluteString) — \(lastProblem)"
+            }
             return "Serving \(url.absoluteString)"
         case .failed(let message):
             return message
@@ -92,6 +100,9 @@ final class PreviewSession {
             server.onServe = { [weak self] url in
                 Task { @MainActor in self?.handleServe(url: url) }
             }
+            server.onProblem = { [weak self] message in
+                Task { @MainActor in self?.handleProblem(message) }
+            }
             server.onExit = { [weak self] exit in
                 Task { @MainActor in self?.handleExit(exit) }
             }
@@ -122,6 +133,7 @@ final class PreviewSession {
         if let server {
             coordinator?.unregisterWatch(server)
             server.onServe = nil
+            server.onProblem = nil
             server.onExit = nil
             server.stop()
             self.server = nil
@@ -133,7 +145,19 @@ final class PreviewSession {
     private func handleServe(url: URL) {
         timeoutTask?.cancel()
         timeoutTask = nil
+        lastProblem = nil
         phase = .serving(url)
+    }
+
+    /// Surfaces a watch-stream problem. While serving, the last good build
+    /// keeps serving and the problem shows in the status line; before the
+    /// port arrives, it fails the phase like a non-zero exit would.
+    private func handleProblem(_ message: String) {
+        if case .serving = phase {
+            lastProblem = message
+        } else {
+            phase = .failed(message)
+        }
     }
 
     private func handleExit(_ exit: WatchExit) {
@@ -145,6 +169,7 @@ final class PreviewSession {
         timeoutTask?.cancel()
         timeoutTask = nil
         rootPath = nil
+        lastProblem = nil
         if exit.exitCode == 0 {
             phase = .idle
         } else {

--- a/Sources/Engine/WatchEvent.swift
+++ b/Sources/Engine/WatchEvent.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// One line of the A1 `--watch-json` NDJSON stream (boris#648; contract
+/// `docs/issues/boris-A1-watch-events.md`). The pinned kit (`6b930b7`)
+/// emits `watch_events_schema: 1`.
+///
+/// Additive decode: unknown fields are ignored, unknown `event` values
+/// decode as `.unknown` and are skipped — never fatal (D8).
+enum WatchEvent: Decodable {
+    case hello(schema: Int, compiler: String?)
+    case serveStarted(url: URL?, helper: URL?, port: Int?)
+    case buildFailed(errors: Int, recoverable: Bool)
+    case watchError(message: String, recoverable: Bool)
+    case watchStopped(reason: String?)
+    case unknown
+
+    enum CodingKeys: String, CodingKey {
+        case event
+        case watchEventsSchema = "watch_events_schema"
+        case compiler
+        case url
+        case helper
+        case port
+        case errors
+        case recoverable
+        case message
+        case reason
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch try c.decode(String.self, forKey: .event) {
+        case "hello":
+            self = .hello(
+                schema: try c.decodeIfPresent(Int.self, forKey: .watchEventsSchema) ?? 0,
+                compiler: try c.decodeIfPresent(String.self, forKey: .compiler)
+            )
+        case "serve-started":
+            self = .serveStarted(
+                url: try c.decodeIfPresent(String.self, forKey: .url).flatMap(URL.init(string:)),
+                helper: try c.decodeIfPresent(String.self, forKey: .helper).flatMap(URL.init(string:)),
+                port: try c.decodeIfPresent(Int.self, forKey: .port)
+            )
+        case "build-failed":
+            self = .buildFailed(
+                errors: try c.decodeIfPresent(Int.self, forKey: .errors) ?? 0,
+                recoverable: try c.decodeIfPresent(Bool.self, forKey: .recoverable) ?? true
+            )
+        case "watch-error":
+            self = .watchError(
+                message: try c.decodeIfPresent(String.self, forKey: .message) ?? "unknown watch error",
+                recoverable: try c.decodeIfPresent(Bool.self, forKey: .recoverable) ?? true
+            )
+        case "watch-stopped":
+            self = .watchStopped(reason: try c.decodeIfPresent(String.self, forKey: .reason))
+        default:
+            self = .unknown
+        }
+    }
+
+    /// Decodes one NDJSON line. Blank and non-JSON lines return nil —
+    /// a hostile or older stderr stream never crashes the consumer.
+    static func decode(line: String) -> WatchEvent? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(WatchEvent.self, from: data)
+    }
+}
+
+/// Pure, testable consumer of the A1 NDJSON stream. `WatchServer` feeds
+/// complete lines; the parser owns the handshake gate (D8), the helper-URL
+/// emission, and problem surfacing — so the behavior is testable without a
+/// live `watch` process.
+struct WatchStreamParser {
+    /// The only known `watch_events_schema`. Unknown versions degrade: the
+    /// stream is not trusted and problems are surfaced — no crash.
+    static let supportedSchema = 1
+
+    private(set) var handshake: Int?
+    private(set) var serveURL: URL?
+    private(set) var didServe = false
+    private(set) var problems: [String] = []
+
+    mutating func consume(line: String) {
+        guard let event = WatchEvent.decode(line: line) else { return }
+        switch event {
+        case .hello(let schema, _):
+            handshake = schema
+            if schema != Self.supportedSchema {
+                problems.append(
+                    "watch events schema \(schema) is not supported (supported: \(Self.supportedSchema))"
+                )
+            }
+        case .serveStarted(let url, let helper, let port):
+            // D8: never trust an unknown contract's shapes — the helper URL
+            // only counts once the stream handshook with a known schema.
+            guard handshake == Self.supportedSchema else {
+                problems.append("serve-started before a supported watch events handshake — ignoring")
+                return
+            }
+            guard !didServe, let helperURL = Self.helperURL(url: url, helper: helper, port: port) else {
+                return
+            }
+            didServe = true
+            serveURL = helperURL
+        case .buildFailed(let errors, let recoverable):
+            problems.append(
+                "build failed: \(errors) error\(errors == 1 ? "" : "s")\(recoverable ? " (recoverable)" : "")"
+            )
+        case .watchError(let message, _):
+            problems.append("watch error: \(message)")
+        case .watchStopped(let reason):
+            problems.append("watch stopped: \(reason ?? "unknown reason")")
+        case .unknown:
+            break
+        }
+    }
+
+    /// The helper page URL (`…/__boris/`) the preview web view loads. The
+    /// A1 contract always carries `helper`; `url` / `port` are fallbacks
+    /// for a shape that omits it.
+    private static func helperURL(url: URL?, helper: URL?, port: Int?) -> URL? {
+        if let helper { return helper }
+        if let url { return url.appendingPathComponent("__boris/") }
+        if let port { return URL(string: "http://127.0.0.1:\(port)/__boris/") }
+        return nil
+    }
+}

--- a/Sources/Engine/WatchServer.swift
+++ b/Sources/Engine/WatchServer.swift
@@ -13,25 +13,31 @@ public struct WatchExit: Sendable {
 
 /// The M4 preview server (D5): a long-lived `boris watch --serve` subprocess.
 ///
-/// Runs `boris watch --serve --port 0 --input <contentRoot>` with
-/// `cwd = workingDirectory` (D1: the app runs boris with cwd = project
+/// Runs `boris watch --serve --watch-json --port 0 --input <contentRoot>`
+/// with `cwd = workingDirectory` (D1: the app runs boris with cwd = project
 /// folder, so workspace-relative layouts/themes resolve and output trees
-/// stay contained; `--input` may be absolute). stderr is streamed through
-/// a pipe; the only line the app parses is the startup line:
+/// stay contained; `--input` may be absolute). With `--watch-json` (A1,
+/// boris#648) stderr is exclusively NDJSON — no prose port line. The
+/// pinned kit emits `hello` (schema 1) first, then `serve-started` with
+/// `url` / `helper` / `port`.
 ///
-///     preview: http://127.0.0.1:PORT/  (auto-reload helper: http://127.0.0.1:PORT/__boris/)
-///
-/// `onServe` fires exactly once, with the `http://127.0.0.1:PORT/__boris/`
-/// helper URL (the helper page owns the iframe + SSE `EventSource` and
-/// auto-reloads — the web view needs no SSE handling of its own).
+/// `onServe` fires exactly once, from the `serve-started` event, with the
+/// `http://127.0.0.1:PORT/__boris/` helper URL (the helper page owns the
+/// iframe + SSE `EventSource` and auto-reloads — the web view needs no SSE
+/// handling of its own). `onProblem` fires for `build-failed` /
+/// `watch-error` / unexpected `watch-stopped` — never swallowed.
 /// `onExit` fires exactly once, when the process ends.
 ///
-/// Both callbacks run on an arbitrary background thread — hop to the main
+/// Callbacks run on an arbitrary background thread — hop to the main
 /// actor before touching UI. A server is one-shot: after `stop()` or a
 /// spontaneous exit it cannot be restarted; the caller creates a new one.
 public final class WatchServer: @unchecked Sendable {
-    /// Fired once with the helper URL after the startup port line is parsed.
+    /// Fired once with the helper URL after the `serve-started` event.
     public var onServe: ((URL) -> Void)?
+
+    /// Fired for `build-failed` / `watch-error` / unexpected `watch-stopped`
+    /// events — problems the watch stream reports without ending the process.
+    public var onProblem: ((String) -> Void)?
 
     /// Fired exactly once when the process ends (after `stop()` or on its own).
     public var onExit: ((WatchExit) -> Void)?
@@ -40,15 +46,18 @@ public final class WatchServer: @unchecked Sendable {
     private var process: Process?
     private let stderrPipe = Pipe()
     private var stderrAccumulator = Data()
+    private var lineBuffer = Data()
+    private var parser = WatchStreamParser()
     private var stderrTailText = ""
     private var _serveURL: URL?
-    private var didServe = false
+    private var didFireServe = false
+    private var deliveredProblemCount = 0
 
     public init(binary: URL, contentRoot: URL, workingDirectory: URL, port: Int = 0) {
         let process = Process()
         process.executableURL = binary
         process.arguments = [
-            "watch", "--serve",
+            "watch", "--serve", "--watch-json",
             "--port", String(port),
             "--input", contentRoot.path,
         ]
@@ -177,27 +186,44 @@ public final class WatchServer: @unchecked Sendable {
     private func consume(_ data: Data) {
         lock.lock()
         stderrAccumulator.append(data)
-        // Bound the buffer: only the tail is kept for diagnostics, and the
-        // moderately sized stream keeps the port scan cheap.
+        // Bound the buffer: only the tail is kept for diagnostics.
         if stderrAccumulator.count > 65_536 {
             stderrAccumulator.removeFirst(stderrAccumulator.count - 32_768)
         }
         stderrTailText = String(decoding: stderrAccumulator.suffix(4_096), as: UTF8.self)
 
-        var url: URL?
-        var serveCallback: ((URL) -> Void)?
-        if !didServe {
-            url = scanServeURL(in: stderrAccumulator)
-            if let url {
-                didServe = true
-                _serveURL = url
-                serveCallback = onServe
+        // Feed complete NDJSON lines to the parser; keep the trailing
+        // fragment for the next chunk.
+        lineBuffer.append(data)
+        while let newline = lineBuffer.firstIndex(of: 0x0A) {
+            let lineData = lineBuffer[..<newline]
+            lineBuffer.removeSubrange(...newline)
+            if let line = String(data: lineData, encoding: .utf8) {
+                parser.consume(line: line)
             }
         }
+
+        var serveURL: URL?
+        var serveCallback: ((URL) -> Void)?
+        if parser.didServe, !didFireServe {
+            didFireServe = true
+            _serveURL = parser.serveURL
+            serveURL = parser.serveURL
+            serveCallback = onServe
+        }
+        var problems: [String] = []
+        if parser.problems.count > deliveredProblemCount {
+            problems = Array(parser.problems[deliveredProblemCount...])
+            deliveredProblemCount = parser.problems.count
+        }
+        let problemCallback = onProblem
         lock.unlock()
 
-        if let url, let serveCallback {
-            serveCallback(url)
+        if let serveURL, let serveCallback {
+            serveCallback(serveURL)
+        }
+        for problem in problems {
+            problemCallback?(problem)
         }
     }
 
@@ -214,44 +240,6 @@ public final class WatchServer: @unchecked Sendable {
         _suspended = false
         lock.unlock()
         onExit?(exit)
-    }
-
-    /// Scans the accumulated stderr bytes for NDJSON `serve-started` or prose
-    /// `http://127.0.0.1:<port>` and returns the helper URL `http://127.0.0.1:<port>/__boris/`.
-    private func scanServeURL(in data: Data) -> URL? {
-        // 1. A1 structured NDJSON serve-started event: {"event":"serve-started",..."helper":"..."...}
-        if let str = String(data: data, encoding: .utf8) {
-            for line in str.components(separatedBy: .newlines) {
-                if line.contains("\"event\":\"serve-started\""),
-                   let lineData = line.data(using: .utf8),
-                   let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
-                {
-                    if let helper = json["helper"] as? String, let url = URL(string: helper) {
-                        return url
-                    }
-                    if let rawURL = json["url"] as? String, let url = URL(string: rawURL) {
-                        return url.appendingPathComponent("__boris/")
-                    }
-                    if let port = json["port"] as? Int {
-                        return URL(string: "http://127.0.0.1:\(port)/__boris/")
-                    }
-                }
-            }
-        }
-
-        // 2. Prose line fallback: `http://127.0.0.1:PORT`
-        let hostPrefix = Data("http://127.0.0.1:".utf8)
-        guard var index = data.range(of: hostPrefix)?.lowerBound else { return nil }
-        index += hostPrefix.count
-        var portBytes: [UInt8] = []
-        while index < data.count, portBytes.count < 6, data[index] >= 0x30, data[index] <= 0x39 {
-            portBytes.append(data[index])
-            index += 1
-        }
-        guard !portBytes.isEmpty,
-              let port = Int(String(decoding: portBytes, as: UTF8.self))
-        else { return nil }
-        return URL(string: "http://127.0.0.1:\(port)/__boris/")
     }
 }
 

--- a/Tests/ContractTests/WatchEventTests.swift
+++ b/Tests/ContractTests/WatchEventTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+
+/// M14-1 (#147): A1 `--watch-json` NDJSON lines decode, `serve-started`
+/// yields the helper URL after the `hello` handshake, and an unknown
+/// `watch_events_schema` degrades without crashing. No live `watch` in CI.
+final class WatchEventTests: XCTestCase {
+    // MARK: Decode (fixture lines from the A1 contract)
+
+    func testHelloDecodes() throws {
+        let event = try XCTUnwrap(
+            WatchEvent.decode(line: #"{"event":"hello","watch_events_schema":1,"compiler":"boris/0.8.1"}"#)
+        )
+        guard case .hello(let schema, let compiler) = event else {
+            return XCTFail("expected hello, got \(event)")
+        }
+        XCTAssertEqual(schema, 1)
+        XCTAssertEqual(compiler, "boris/0.8.1")
+    }
+
+    func testServeStartedDecodesHelperURL() throws {
+        let event = try XCTUnwrap(
+            WatchEvent.decode(
+                line: #"{"event":"serve-started","url":"http://127.0.0.1:53202/","helper":"http://127.0.0.1:53202/__boris/","port":53202}"#
+            )
+        )
+        guard case .serveStarted(let url, let helper, let port) = event else {
+            return XCTFail("expected serve-started, got \(event)")
+        }
+        XCTAssertEqual(url?.absoluteString, "http://127.0.0.1:53202/")
+        XCTAssertEqual(helper?.absoluteString, "http://127.0.0.1:53202/__boris/")
+        XCTAssertEqual(port, 53202)
+    }
+
+    func testFailureAndStopEventsDecode() throws {
+        let failed = try XCTUnwrap(
+            WatchEvent.decode(
+                line: #"{"event":"build-failed","phase":"rebuild","errors":1,"recoverable":true,"duration_ms":14}"#
+            )
+        )
+        guard case .buildFailed(let errors, let recoverable) = failed else {
+            return XCTFail("expected build-failed, got \(failed)")
+        }
+        XCTAssertEqual(errors, 1)
+        XCTAssertTrue(recoverable)
+
+        let watchError = try XCTUnwrap(
+            WatchEvent.decode(line: #"{"event":"watch-error","message":"poll error (BrokenPipe)","recoverable":true}"#)
+        )
+        guard case .watchError(let message, _) = watchError else {
+            return XCTFail("expected watch-error, got \(watchError)")
+        }
+        XCTAssertEqual(message, "poll error (BrokenPipe)")
+
+        let stopped = try XCTUnwrap(
+            WatchEvent.decode(line: #"{"event":"watch-stopped","reason":"signal"}"#)
+        )
+        guard case .watchStopped(let reason) = stopped else {
+            return XCTFail("expected watch-stopped, got \(stopped)")
+        }
+        XCTAssertEqual(reason, "signal")
+    }
+
+    func testUnknownEventAndGarbageNeverCrash() {
+        // Unknown event value → skipped, no crash.
+        XCTAssertNotNil(
+            WatchEvent.decode(line: #"{"event":"build-succeeded","pages_written":25}"#)
+        )
+        // Not JSON / empty lines → nil, no crash.
+        XCTAssertNil(WatchEvent.decode(line: "preview: http://127.0.0.1:53202/  (auto-reload helper: …)"))
+        XCTAssertNil(WatchEvent.decode(line: ""))
+    }
+
+    // MARK: Parser (handshake gate + helper URL + problem surfacing)
+
+    func testServeStartedAfterHelloYieldsHelperURL() {
+        var parser = WatchStreamParser()
+        parser.consume(line: #"{"event":"hello","watch_events_schema":1,"compiler":"boris/0.8.1"}"#)
+        parser.consume(line: #"{"event":"serve-started","url":"http://127.0.0.1:53202/","helper":"http://127.0.0.1:53202/__boris/","port":53202}"#)
+        XCTAssertEqual(parser.serveURL?.absoluteString, "http://127.0.0.1:53202/__boris/")
+        XCTAssertTrue(parser.didServe)
+        XCTAssertTrue(parser.problems.isEmpty)
+    }
+
+    func testServeStartedWithURLOnlyDerivesHelper() {
+        var parser = WatchStreamParser()
+        parser.consume(line: #"{"event":"hello","watch_events_schema":1}"#)
+        parser.consume(line: #"{"event":"serve-started","url":"http://127.0.0.1:8123/","port":8123}"#)
+        XCTAssertEqual(parser.serveURL?.absoluteString, "http://127.0.0.1:8123/__boris/")
+    }
+
+    func testUnknownSchemaDegradesWithoutCrash() {
+        var parser = WatchStreamParser()
+        parser.consume(line: #"{"event":"hello","watch_events_schema":2,"compiler":"boris/0.9.0"}"#)
+        parser.consume(line: #"{"event":"serve-started","url":"http://127.0.0.1:9999/","helper":"http://127.0.0.1:9999/__boris/","port":9999}"#)
+        // D8: unknown shape is not trusted — no helper URL, problem surfaced.
+        XCTAssertNil(parser.serveURL)
+        XCTAssertFalse(parser.didServe)
+        XCTAssertEqual(
+            parser.problems.first,
+            "watch events schema 2 is not supported (supported: 1)"
+        )
+    }
+
+    func testServeStartedBeforeHandshakeIsIgnored() {
+        var parser = WatchStreamParser()
+        parser.consume(line: #"{"event":"serve-started","helper":"http://127.0.0.1:1/__boris/"}"#)
+        XCTAssertNil(parser.serveURL)
+        XCTAssertEqual(
+            parser.problems.first,
+            "serve-started before a supported watch events handshake — ignoring"
+        )
+    }
+
+    func testBuildFailedAndWatchStoppedAreSurfaced() {
+        var parser = WatchStreamParser()
+        parser.consume(line: #"{"event":"hello","watch_events_schema":1}"#)
+        parser.consume(line: #"{"event":"build-failed","errors":2,"recoverable":true}"#)
+        parser.consume(line: #"{"event":"watch-error","message":"poll error","recoverable":false}"#)
+        parser.consume(line: #"{"event":"watch-stopped","reason":"signal"}"#)
+        XCTAssertEqual(
+            parser.problems,
+            [
+                "build failed: 2 errors (recoverable)",
+                "watch error: poll error",
+                "watch stopped: signal",
+            ]
+        )
+    }
+
+    func testFullFixtureStreamServesOnce() {
+        // The probe of the pinned-kit lineage (boris 0.8.1 + A1).
+        var parser = WatchStreamParser()
+        let stream = [
+            #"{"event":"hello","watch_events_schema":1,"compiler":"boris/0.8.1"}"#,
+            #"{"event":"build-started","phase":"initial","mode":"html","targets":["default"]}"#,
+            #"{"event":"build-succeeded","phase":"initial","mode":"html","targets":["default"],"pages_written":0,"duration_ms":69}"#,
+            #"{"event":"watcher-started","mode":"html","targets":["default"]}"#,
+            #"{"event":"serve-started","url":"http://127.0.0.1:58317/","helper":"http://127.0.0.1:58317/__boris/","port":58317}"#,
+            #"{"event":"build-failed","phase":"rebuild","errors":1,"recoverable":true,"duration_ms":14}"#,
+            #"{"event":"watch-stopped","reason":"signal"}"#,
+        ]
+        for line in stream {
+            parser.consume(line: line)
+        }
+        XCTAssertEqual(parser.serveURL?.absoluteString, "http://127.0.0.1:58317/__boris/")
+        XCTAssertTrue(parser.didServe)
+        XCTAssertEqual(
+            parser.problems,
+            ["build failed: 1 error (recoverable)", "watch stopped: signal"]
+        )
+    }
+}

--- a/docs/ENGINE-CONTRACTS.md
+++ b/docs/ENGINE-CONTRACTS.md
@@ -20,16 +20,20 @@ don't hand-roll.
 ### Invocation & discovery
 
 ```
-boris watch --serve [--port N] --input <content-root>
+boris watch --serve --watch-json [--port N] --input <content-root>
 ```
 
 - Default port **8090**; `--port 0` = ephemeral.
-- **Port discovery:** stderr prints one parseable line on startup:
+- **Port discovery (A1, M14):** with `--watch-json` stderr is exclusively
+  NDJSON; the app learns the port from the `serve-started` event, not a
+  prose regex:
   ```
-  preview: http://127.0.0.1:18090/  (auto-reload helper: http://127.0.0.1:18090/__boris/)
+  {"event":"hello","watch_events_schema":1,"compiler":"boris/0.8.1"}
+  {"event":"serve-started","url":"http://127.0.0.1:18090/","helper":"http://127.0.0.1:18090/__boris/","port":18090}
   ```
-  For `--port 0`, parse this line (regex `127\.0\.0\.1:[0-9]+`) to find the
-  ephemeral port. This is the only stderr line the app needs to parse.
+  The app fires `onServe` with the `helper` URL after a `hello` handshake
+  at `watch_events_schema: 1` (unknown versions degrade — D8). `build-failed`
+  / `watch-error` / `watch-stopped` are surfaced, never swallowed.
 - Run with `cwd = project folder` (containment: `--input` may be absolute,
   but outputs — including `dist/` — are workspace-relative; see
   A7).


### PR DESCRIPTION
Closes #147 — the first M14 child (tracker #143).

## What changed

- **`WatchServer`** now runs `boris watch --serve --watch-json --port 0 --input <contentRoot>`. The A1 NDJSON stream is fed line-by-line to a pure `WatchStreamParser`; the prose port regex is **removed**.
- **`Sources/Engine/WatchEvent.swift`** — additive `WatchEvent` decode (hello / serve-started / build-failed / watch-error / watch-stopped / unknown-skipped) + `WatchStreamParser`: `onServe` fires from `serve-started` **only after a `hello` handshake at `watch_events_schema: 1`** (D8 — unknown versions degrade: problem surfaced, no crash, stream not trusted). `build-failed` / `watch-error` / unexpected `watch-stopped` surface via `onProblem`, never swallowed.
- **`PreviewSession`** — wires `onProblem`: while serving, the last good build keeps serving and the problem shows in the status line (`Serving <url> — build failed: …`); pre-serve problems fail the phase like a non-zero exit.
- **`ENGINE-CONTRACTS.md`** — port-discovery section documents the NDJSON contract instead of the regex.

## Pin honesty — probed live

The pinned-kit lineage (boris 0.8.1 + A1) was probed before deleting the regex; it emits exactly the documented stream:

```
{"event":"hello","watch_events_schema":1,"compiler":"boris/0.8.1"}
{"event":"build-started","phase":"initial","mode":"html","targets":["default"]}
{"event":"build-succeeded","phase":"initial","mode":"html","targets":["default"],"pages_written":0,"duration_ms":69}
{"event":"watcher-started","mode":"html","targets":["default"]}
{"event":"serve-started","url":"http://127.0.0.1:58317/","helper":"http://127.0.0.1:58317/__boris/","port":58317}
{"event":"watch-stopped","reason":"signal"}
```

No new boris issue filed — the pin matches `docs/issues/boris-A1-watch-events.md`.

## Gate (live app run with the A1 binary embedded)

- Preview ⌘⇧P → child argv: `boris watch --serve --watch-json --port 0 --input …/happy/content` ✅
- Window status: **`Serving http://127.0.0.1:58343/__boris/`** — helper URL from `serve-started` ✅
- Quit → watch child gone (SIGTERM shutdown, A12) ✅

## Tests

`WatchEventTests` (10): fixture NDJSON lines decode; helper URL accepted after hello; url-only derive; **unknown schema degrades without crash**; serve-before-handshake ignored; build-failed/watch-stopped surfaced; full fixture stream serves once. No live `watch` in CI.

Green: build · **235 tests / 0 failures** · lint 0.
