### PR TITLE
M14-2 (#148): the letter reloads on the existing SSE event:reload

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -96,6 +96,7 @@ targets:
       - path: Sources/Engine
       - path: Sources/Inspector
       - path: Sources/Play/Local/LocalPlayGraph.swift
+      - path: Sources/Play/Local/LetterReloadClient.swift
       - path: Sources/App/CoordinatorActivity.swift
       - path: Sources/Play/Local/ProblemResolver.swift
       - path: Sources/App/CoordinatorProblems.swift

--- a/Sources/Companions/Preview/PreviewURL.swift
+++ b/Sources/Companions/Preview/PreviewURL.swift
@@ -33,4 +33,13 @@ public enum PreviewURL {
         guard !trimmed.isEmpty else { return nil }
         return URL(string: trimmed + ".html", relativeTo: origin)?.absoluteURL
     }
+
+    /// `GET /__boris/events` on the same server — the SSE reload channel
+    /// the helper page already subscribes to (M14-2). Loopback-gated like
+    /// every other derived URL; the letter must not listen to a foreign or
+    /// non-loopback helper.
+    public static func eventsURL(fromHelper helper: URL) -> URL? {
+        guard isLoopback(helper) else { return nil }
+        return helper.appendingPathComponent("events")
+    }
 }

--- a/Sources/Play/Local/LetterReloadClient.swift
+++ b/Sources/Play/Local/LetterReloadClient.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// One parsed SSE event from the watch helper's `/__boris/events` stream.
+/// The only event the letter acts on is `reload`; the parser is generic so
+/// the wire format is covered by tests.
+struct SSEEvent: Equatable {
+    var name: String
+    var data: String
+}
+
+/// Incremental EventSource line parser. Feed one line at a time; a blank
+/// line dispatches the buffered event. `:` comments and `id:` / `retry:`
+/// fields are ignored; repeated `data:` lines join with a newline.
+struct SSEParser {
+    private var eventName = "message"
+    private var dataLines: [String] = []
+
+    mutating func feed(line: String) -> [SSEEvent] {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            guard !dataLines.isEmpty || eventName != "message" else { return [] }
+            defer {
+                eventName = "message"
+                dataLines = []
+            }
+            return [SSEEvent(name: eventName, data: dataLines.joined(separator: "\n"))]
+        }
+        guard !trimmed.hasPrefix(":") else { return [] }
+        if let colon = trimmed.firstIndex(of: ":") {
+            let field = trimmed[..<colon]
+            var value = String(trimmed[trimmed.index(after: colon)...])
+            if value.hasPrefix(" ") { value.removeFirst() }
+            switch field {
+            case "event":
+                eventName = value
+            case "data":
+                dataLines.append(value)
+            default:
+                break
+            }
+        } else if trimmed == "event" {
+            eventName = ""
+        } else if trimmed == "data" {
+            dataLines.append("")
+        }
+        return []
+    }
+}
+
+/// Decides when the letter listens for SSE reloads (M14-2). The channel is
+/// only the existing helper's `/__boris/events` — never a second watch, and
+/// never a foreign helper: a bound-root mismatch (or watch down, or no page
+/// showing) means idle.
+enum LetterReloadPolicy {
+    static func eventsURL(helper: URL?, bound: Bool, showingPage: Bool) -> URL? {
+        guard bound, showingPage, let helper else { return nil }
+        return PreviewURL.eventsURL(fromHelper: helper)
+    }
+}
+
+/// Watches the existing watch helper's SSE channel and fires `onReload`
+/// when the rebuild counter advances. The letter's web view reloads after a
+/// rebuild without re-selecting the row and without a second watch.
+///
+/// The stream's first event on connect carries the *current* counter
+/// (`data: 0` right after start) — the letter just loaded the page, so that
+/// handshake is recorded, not reloaded. Reloads fire only when the counter
+/// advances (or resets after a watch restart).
+@MainActor
+final class LetterSSEClient {
+    var onReload: (() -> Void)?
+
+    private(set) var isConnected = false
+    private var task: Task<Void, Never>?
+    private var parser = SSEParser()
+    private var lastGeneration: Int?
+
+    func connect(to eventsURL: URL) {
+        disconnect()
+        task = Task { [weak self] in
+            await self?.run(eventsURL)
+        }
+    }
+
+    func disconnect() {
+        task?.cancel()
+        task = nil
+        isConnected = false
+        parser = SSEParser()
+        lastGeneration = nil
+    }
+
+    private func run(_ url: URL) async {
+        while !Task.isCancelled {
+            do {
+                let (bytes, response) = try await URLSession.shared.bytes(for: URLRequest(url: url))
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                    // Watch down or not serving — idle until the pane reconnects.
+                    return
+                }
+                isConnected = true
+                // `bytes.lines` does not yield incrementally on this SDK;
+                // assemble lines from raw bytes (SSE lines are ASCII).
+                var line = ""
+                var iterator = bytes.makeAsyncIterator()
+                while let byte: UInt8 = try await iterator.next() {
+                    if Task.isCancelled { break }
+                    if byte == 0x0A {
+                        for event in parser.feed(line: line) {
+                            handle(event)
+                        }
+                        line = ""
+                    } else if byte != 0x0D {
+                        line.append(Character(UnicodeScalar(byte)))
+                    }
+                }
+                isConnected = false
+                guard !Task.isCancelled else { break }
+                // The server dropped the stream without a restart — reconnect
+                // after a beat, like the helper page's EventSource does.
+                try? await Task.sleep(for: .seconds(2))
+            } catch {
+                // Cancelled by disconnect, or the watch is down — idle until
+                // the pane's channel identity asks again.
+                return
+            }
+        }
+        isConnected = false
+    }
+
+    private func handle(_ event: SSEEvent) {
+        guard event.name == "reload", let generation = Int(event.data) else { return }
+        let (reload, next) = Self.shouldReload(generation: generation, lastGeneration: lastGeneration)
+        lastGeneration = next
+        if reload {
+            onReload?()
+        }
+    }
+
+    /// Pure reload policy. The first event after connect is the current-state
+    /// handshake — record without reloading. Later, reload when the counter
+    /// advances or resets; ignore repeats.
+    nonisolated static func shouldReload(generation: Int, lastGeneration: Int?) -> (reload: Bool, last: Int) {
+        guard let lastGeneration else { return (false, generation) }
+        return (generation != lastGeneration, generation)
+    }
+}

--- a/Sources/Play/Local/ReadingPane.swift
+++ b/Sources/Play/Local/ReadingPane.swift
@@ -38,6 +38,13 @@ struct ReadingPane: View {
         .task(id: completionIdentity) {
             relations = Self.loadRelations(source: source, pageID: page?.id)
         }
+        .task(id: reloadChannelIdentity) {
+            if let url = reloadEventsURL {
+                model.connectReload(to: url)
+            } else {
+                model.disconnectReload()
+            }
+        }
     }
 
     // MARK: - Letter
@@ -278,6 +285,27 @@ struct ReadingPane: View {
             phaseKey = "failed"
         }
         return "\(loadGeneration)|\(page?.id ?? "")|\(phaseKey)|\(isBoundToThisSource)"
+    }
+
+    /// The SSE channel this letter listens on, or nil when it must not
+    /// auto-reload: watch down, a bound-root mismatch (foreign helper), or
+    /// no served page showing (M14-2).
+    private var reloadEventsURL: URL? {
+        let helper: URL?
+        if case .serving(let url) = session.phase {
+            helper = url
+        } else {
+            helper = nil
+        }
+        return LetterReloadPolicy.eventsURL(
+            helper: helper,
+            bound: isBoundToThisSource,
+            showingPage: page != nil && model.outcome == .loaded
+        )
+    }
+
+    private var reloadChannelIdentity: String {
+        reloadEventsURL?.absoluteString ?? "off"
     }
 
     private var completionIdentity: String {

--- a/Sources/Play/Local/ReadingWebView.swift
+++ b/Sources/Play/Local/ReadingWebView.swift
@@ -19,11 +19,30 @@ final class ReadingWebModel: NSObject {
     let webView: WKWebView
     private(set) var outcome: ReadingLoadOutcome = .idle
 
+    /// SSE listener on the existing watch helper's `/__boris/events`.
+    /// One session — the letter never spawns a second watch.
+    private let reloadClient = LetterSSEClient()
+
     override init() {
         webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
         super.init()
         webView.navigationDelegate = self
         webView.allowsMagnification = true
+    }
+
+    /// Start listening for rebuild reloads on the served helper's SSE
+    /// channel. The pane calls this only when the helper is bound to this
+    /// source and a page is showing.
+    func connectReload(to eventsURL: URL) {
+        reloadClient.onReload = { [weak self] in
+            self?.reloadServedPage()
+        }
+        reloadClient.connect(to: eventsURL)
+    }
+
+    /// Stop listening (watch down, source switched, or row changed).
+    func disconnectReload() {
+        reloadClient.disconnect()
     }
 
     func load(url: URL) {
@@ -47,6 +66,18 @@ final class ReadingWebModel: NSObject {
 
     func fail(_ message: String) {
         outcome = .failed(message)
+    }
+
+    /// Reload the served page in place after a rebuild (M14-2). Only fires
+    /// while the page is actually showing; the SSE client only connects in
+    /// the `.loaded`/`.loading` states anyway.
+    private func reloadServedPage() {
+        switch outcome {
+        case .loaded, .loading:
+            webView.reload()
+        case .idle, .unavailable, .failed:
+            break
+        }
     }
 
     private func handleHTTPFailure(_ status: Int) {

--- a/Tests/ContractTests/LetterSSETests.swift
+++ b/Tests/ContractTests/LetterSSETests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+/// M14-2 (#148): the letter reloads on the existing helper's SSE
+/// `event: reload`; a fixture event triggers the reload hook, and a
+/// bound-root mismatch never opens the channel. No live `watch` in CI.
+final class LetterSSETests: XCTestCase {
+    // MARK: SSE wire parse
+
+    func testFixtureReloadEventParses() {
+        var parser = SSEParser()
+        var events: [SSEEvent] = []
+        for line in ["event: reload", "data: 1", "", ""] {
+            events.append(contentsOf: parser.feed(line: line))
+        }
+        XCTAssertEqual(events, [SSEEvent(name: "reload", data: "1")])
+    }
+
+    func testHandshakeLineParses() {
+        var parser = SSEParser()
+        var events: [SSEEvent] = []
+        for line in ["event: reload", "data: 0", ""] {
+            events.append(contentsOf: parser.feed(line: line))
+        }
+        XCTAssertEqual(events, [SSEEvent(name: "reload", data: "0")])
+    }
+
+    func testCommentAndRetryFieldsAreIgnored() {
+        var parser = SSEParser()
+        let ignored = parser.feed(line: ": keep-alive comment")
+        XCTAssertTrue(ignored.isEmpty)
+        let retry = parser.feed(line: "retry: 1000")
+        XCTAssertTrue(retry.isEmpty)
+        let id = parser.feed(line: "id: 7")
+        XCTAssertTrue(id.isEmpty)
+    }
+
+    func testMultiLineDataJoinsWithNewline() {
+        var parser = SSEParser()
+        var events: [SSEEvent] = []
+        for line in ["event: reload", "data: a", "data: b", ""] {
+            events.append(contentsOf: parser.feed(line: line))
+        }
+        XCTAssertEqual(events, [SSEEvent(name: "reload", data: "a\nb")])
+    }
+
+    func testCarriageReturnsAreTolerated() {
+        var parser = SSEParser()
+        var events: [SSEEvent] = []
+        for line in ["event: reload\r", "data: 2\r", "\r"] {
+            events.append(contentsOf: parser.feed(line: line))
+        }
+        XCTAssertEqual(events, [SSEEvent(name: "reload", data: "2")])
+    }
+
+    // MARK: Reload policy (generation counter)
+
+    func testFirstEventIsHandshakeNotReload() {
+        let result = LetterSSEClient.shouldReload(generation: 0, lastGeneration: nil)
+        XCTAssertFalse(result.reload)
+        XCTAssertEqual(result.last, 0)
+    }
+
+    func testAdvancingGenerationReloads() {
+        let result = LetterSSEClient.shouldReload(generation: 1, lastGeneration: 0)
+        XCTAssertTrue(result.reload)
+        XCTAssertEqual(result.last, 1)
+    }
+
+    func testSameGenerationDoesNotReload() {
+        let result = LetterSSEClient.shouldReload(generation: 3, lastGeneration: 3)
+        XCTAssertFalse(result.reload)
+        XCTAssertEqual(result.last, 3)
+    }
+
+    func testCounterResetAfterRestartReloads() {
+        let result = LetterSSEClient.shouldReload(generation: 0, lastGeneration: 5)
+        XCTAssertTrue(result.reload)
+        XCTAssertEqual(result.last, 0)
+    }
+
+    // MARK: Channel gating
+
+    func testEventsURLDerivedFromLoopbackHelper() throws {
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:58343/__boris/"))
+        let events = try XCTUnwrap(PreviewURL.eventsURL(fromHelper: helper))
+        XCTAssertEqual(events.absoluteString, "http://127.0.0.1:58343/__boris/events")
+    }
+
+    func testEventsURLRejectsForeignHost() throws {
+        let helper = try XCTUnwrap(URL(string: "https://example.com/__boris/"))
+        XCTAssertNil(PreviewURL.eventsURL(fromHelper: helper))
+    }
+
+    func testPolicyRequiresBoundRoot() throws {
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:58343/__boris/"))
+        // Bound-root mismatch → idle, even with a serving helper.
+        XCTAssertNil(LetterReloadPolicy.eventsURL(helper: helper, bound: false, showingPage: true))
+        // No page showing → idle.
+        XCTAssertNil(LetterReloadPolicy.eventsURL(helper: helper, bound: true, showingPage: false))
+        // Watch down (no helper) → idle.
+        XCTAssertNil(LetterReloadPolicy.eventsURL(helper: nil, bound: true, showingPage: true))
+    }
+
+    func testPolicyOpensChannelOnlyWhenBoundAndShowing() throws {
+        let helper = try XCTUnwrap(URL(string: "http://127.0.0.1:58343/__boris/"))
+        let events = try XCTUnwrap(
+            LetterReloadPolicy.eventsURL(helper: helper, bound: true, showingPage: true)
+        )
+        XCTAssertEqual(events.absoluteString, "http://127.0.0.1:58343/__boris/events")
+    }
+}


### PR DESCRIPTION
Closes #148 — the last M14 child (closes tracker #143).

## What changed

- **`LetterReloadClient.swift`** — an EventSource client against the **existing** watch helper's `/__boris/events` (one session, never a second watch):
  - `SSEParser` — incremental EventSource wire parser (comments/`id:`/`retry:` ignored, multi-line data joined).
  - `LetterSSEClient` — URLSession byte-stream client. The first event on connect is the current-state handshake (`data: <generation>`) — recorded, **not** reloaded, so row-selects don't double-load. Reloads fire when the counter advances or resets after a restart. Reconnects after a dropped stream, like the helper page's EventSource.
  - **SDK gotcha found live:** `URLSession.AsyncBytes.lines` never yields incrementally on this SDK — verified with a standalone harness against the real stream (status 200, zero lines). The client assembles lines from raw bytes instead; that path was proven against the live endpoint (handshake `data: 6` → rebuild `data: 7`).
- **`LetterReloadPolicy`** — the channel only opens when the helper is bound to this source, watch is serving, and a page is showing. A bound-root mismatch or watch-down is idle.
- **`ReadingWebModel`** — `connectReload`/`disconnectReload`; the reload hook `webView.reload()`s the served page in place.
- **`ReadingPane`** — drives the channel identity from session state + letter outcome.
- **`PreviewURL.eventsURL(fromHelper:)`** — loopback-gated `…/__boris/events` derivation.

## Gate (live app, A1-lineage binary)

- Watch up (Preview opened, then closed — session survives), letter showing the served **Getting Started** page with the "Served" badge, SSE connection established (`Solipsist → boris …/__boris/events`).
- **Appended a marker to the page → the letter reloaded within 1 second, zero interaction** — the "Gate marker" heading appeared in the letter without re-selecting the row.
- Source-switch / foreign-helper idleness is enforced by `LetterReloadPolicy` (unit-tested) — the letter never opens a channel for an unbound helper.

## Tests

`LetterSSETests` (13): fixture `event: reload` → reload hook; handshake skip; advance / same / counter-reset policy; comment/retry ignored; `\r` tolerated; **bound-root mismatch → no channel**; non-loopback helper rejected. No live `watch` in CI.

Green: build · **248 tests / 0 failures** · lint 0.
