### PR TITLE
Refresh queue/parallel READMEs after M12–M14; index Q26/Q27

### DIFF
--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -73,10 +73,11 @@ the agent-pack, `plan --out`.
 | 9 | [issue-templates](issue-templates.md) | done (#22) |
 
 New work lives in the [delegation queue](../queue/README.md) — batch 2
-is landed. The queue is empty. Next pickable product card is
-[#131](https://github.com/drawmeanelephant/solipsist/issues/131) (M12
-clone — Settings / workspace, not this lane). Apple-account ship
-(#110 / #111) is operator, not this lane.
+is landed and the queue is empty. M12 clone (#131), M13 graph folders
+(#142), and M14 watch contract (#143) all landed and closed. Apple-
+account ship (#110 / #111) is operator, not this lane. Two low-priority
+pin-follow trackers are filed for the named follow-ups: #160 (A15
+`open=`, boris#649) and #161 (A5 `validate --watch`, boris#647).
 
 Skip: fart app (`make fart` must keep failing). Skip GitHub-as-source.
 Skip publication flows. Skip Wasm in the app.

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -55,6 +55,8 @@ Status legend: **open** · **in flight** (PR open) · **done** (merged — do no
 | Q23 | [site-content-expansion](site-content-expansion.md) | `site/` only | done (#49) |
 | Q24 | [stunt-textile-corpus](stunt-textile-corpus.md) | `Stunts/` + `Tests/Fixtures/` | done (#50) |
 | Q25 | [help-doc-coverage](help-doc-coverage.md) | `docs/help.md` only | done (#48) |
+| Q26 | [gate-plan-activity-content](gate-plan-activity-content.md) | verification only (no source) | done (#134/#135) |
+| Q27 | [close-102-verification](close-102-verification.md) | verification only (no source) | done (#118) |
 
 ### Retired
 
@@ -67,10 +69,11 @@ lives in the issue tracker (#58–#61; briefs in
 `docs/cards/B3-*.md`) — those own grind-lane paths, so they are not
 queue cards.
 
-The depth batch (#88–#91) landed. M9 (#78), M10 (#98), and M11
-(#123) landed. Remaining ship is Apple-account only (#110 / #111)
-— not this queue. Next product cut is
-[#131](https://github.com/drawmeanelephant/solipsist/issues/131)
-(M12 clone) plus the M13 / M14 grind cards; those own Settings /
-Workspace / Play / Engine, so they are not queue cards. The queue
-stays empty unless someone cuts a docs-only or `Tests/`-only slice.
+The depth batch (#88–#91) landed. M9 (#78), M10 (#98), M11
+(#123), M12 (#131), M13 (#142), and M14 (#143) all landed and
+closed. Remaining ship is Apple-account only (#110 / #111) — not
+this queue. Two low-priority pin-follow trackers are filed for the
+named-but-untracked follow-ups: [#160](https://github.com/drawmeanelephant/solipsist/issues/160)
+(A15 `open=`, boris#649) and [#161](https://github.com/drawmeanelephant/solipsist/issues/161)
+(A5 `validate --watch`, boris#647). The queue stays empty unless
+someone cuts a docs-only or `Tests/`-only slice.


### PR DESCRIPTION
Docs-only refresh of the two delegation READMEs after M12–M14 landed.

- **queue/README.md** — indexes the two verification cards that existed on disk but were never tabled: **Q26 gate-plan-activity-content** (done, #134/#135) and **Q27 close-102-verification** (done, #118). Closing prose no longer says "next product cut is #131"; it points at the two newly filed pin-follow trackers.
- **parallel/README.md** — "next pickable product card is #131" → M12/M13/M14 all landed and closed; queue empty; Apple ship is operator-only.

Trackers filed alongside this review:
- **#160** later(a15): consume boris#649 `open=` — Edit Page lands on the file (pin-follow from close-102-verification.md)
- **#161** later(a5): consume `validate --watch` (boris#647) for watch-driven validation (upstream-blocked, named in ROADMAP "Later")

No source changes. The queue is genuinely empty until someone cuts a docs-only or `Tests/`-only slice.