### PR TITLE
docs(cards): register the post-ship Later-promotion batch on the board

### DIFF
--- a/docs/cards/LATER-content-audit.md
+++ b/docs/cards/LATER-content-audit.md
@@ -1,0 +1,44 @@
+# Card LATER-1 — Content-audit mailbox
+
+**Issue:** [#165](https://github.com/drawmeanelephant/solipsist/issues/165)
+· **Lane:** workspace / mailbox. One worktree, one PR against `main`;
+branch suggestion `mailbox/content-audit`.
+
+## Owns
+
+- `Sources/Workspace/**` — the `WorkspaceMailbox` token (`content-audit`)
+  and selection wiring
+- `Sources/Chrome/SourceSidebar.swift` — the new mailbox row
+- The center pane (alongside Plan / Outputs / Activity) that runs the audit
+- Binary locate/embed for `boris-content-audit` — a **separate kit
+  binary**, not the embedded `boris`
+
+## Do
+
+1. **Probe first — already done.** The probed contract is recorded in
+   `docs/ENGINE-CONTRACTS.md` §8 (PR #168); the short version is on
+   [#165](https://github.com/drawmeanelephant/solipsist/issues/165#issuecomment-5341401505):
+   flags, verified exit codes 0/1/2/3/4, `report.json` shape,
+   `missing_id` → structural semantics, and the `--out`-must-be-real-path
+   gotcha.
+2. Add the `content-audit` mailbox token (displayName, symbolName, `all`)
+   and a sidebar row.
+3. Add the center pane: run the audit against the selected source's
+   workspace root, render `exceptions[]`, never swallow diagnostics or
+   non-zero exit codes (D11).
+4. Run it through the coordinator's single `Process?` slot — no second
+   subprocess.
+
+## Do not
+
+- Reimplement audit semantics in Swift (D11) — run the binary.
+- Touch `Sources/Engine/**` beyond an additive, single-owner change
+  (future lanes #160/#161 own the boundary).
+- Mutate the content tree — read-only mailbox.
+- Grow `Sources/Chrome/MainWindow.swift`.
+
+## Gate
+
+Open a source → select the content-audit mailbox → findings render;
+non-zero exit surfaces in the problems/status UI. `SKIP_EMBED_BORIS=1
+make build` + `make test` green.

--- a/docs/cards/LATER-source-rag.md
+++ b/docs/cards/LATER-source-rag.md
@@ -1,0 +1,37 @@
+# Card LATER-2 — Source-RAG export
+
+**Issue:** [#166](https://github.com/drawmeanelephant/solipsist/issues/166)
+· **Lane:** export / menu. One worktree, one PR against `main`; branch
+suggestion `export/source-rag`.
+
+## Owns
+
+- The menu verb (File → Export → Source RAG…, or an Outputs / Activity
+  action)
+- Finder reveal / open of the produced pack
+- Binary locate/embed for `boris-source-rag` — a **separate kit binary**,
+  not the embedded `boris`
+
+## Do
+
+1. **Probe first — already done.** The probed contract is recorded in
+   `docs/ENGINE-CONTRACTS.md` §9 (PR #168); the short version is on
+   [#166](https://github.com/drawmeanelephant/solipsist/issues/166#issuecomment-5341401629):
+   flags, verified exit codes 0/2/3, output tree, manifest shapes,
+   `--pack-by=tool`.
+2. Add the menu verb that runs the tool against the selected source.
+3. Reveal `--out` in Finder (or open `INDEX.md`).
+4. Same process seam: the coordinator's single `Process?` slot, surface
+   exit codes.
+
+## Do not
+
+- Reimplement packing in Swift.
+- Conflate with the M7 `--rag` edition row (already in `OutputsPane`).
+- Touch `Sources/Engine/**` beyond an additive, single-owner change
+  (future lanes #160/#161 own the boundary).
+
+## Gate
+
+Menu verb produces the pack, Finder reveals it, non-zero exit surfaces.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -105,11 +105,25 @@ letter-URL contract tests pin the recut. Do not pick.
 | [M14-1 A1 consume](M14-a1-consume.md) | [#147](https://github.com/drawmeanelephant/solipsist/issues/147) | Engine + Preview | M13 | `--watch-json` / `serve-started` is how we learn the port |
 | [M14-2 Letter SSE](M14-letter-sse.md) | [#148](https://github.com/drawmeanelephant/solipsist/issues/148) | Reading | after #147 | letter reloads on `event: reload`; no second watch |
 
+## Post-ship — Later promotions (pickable)
+
+Promoted from ROADMAP §3 "Later" — unblocked because the agent kit ships
+the binaries. Probed contracts are recorded in `docs/ENGINE-CONTRACTS.md`
+§8–§9 (PR #168); the short versions are posted on the issues
+([#165](https://github.com/drawmeanelephant/solipsist/issues/165#issuecomment-5341401505),
+[#166](https://github.com/drawmeanelephant/solipsist/issues/166#issuecomment-5341401629)).
+All three run through the coordinator's single `Process?` slot.
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [Content-audit mailbox](LATER-content-audit.md) | [#165](https://github.com/drawmeanelephant/solipsist/issues/165) | workspace / mailbox | #166 | findings render; exit codes surfaced |
+| [Source-RAG export](LATER-source-rag.md) | [#166](https://github.com/drawmeanelephant/solipsist/issues/166) | export / menu | #165 | menu verb → pack revealed in Finder |
+| Compose depth (tracker — issue only) | [#167](https://github.com/drawmeanelephant/solipsist/issues/167) | compose | after #165/#166 | one slice per PR; Oliver span diagnostics first |
+
 ## Do not start yet
 
 GitHub OAuth / `SourceKind.github` payload. Wasm in the app. The
-fart app. Compose **depth**. Fetch / pull / commit / push.
-#136 splitter crash (macOS 27 beta).
+fart app. Fetch / pull / commit / push.
 
 ## Shared noun kinds (play writes, inspector reads)
 


### PR DESCRIPTION
Register the post-ship "Later promotion" batch on the cards board.

- **`docs/cards/LATER-content-audit.md`** — #165 content-audit mailbox brief (workspace/mailbox lane, branch `mailbox/content-audit`), pointing at ENGINE-CONTRACTS §8 + the probed contract posted on the issue.
- **`docs/cards/LATER-source-rag.md`** — #166 source-rag export brief (export/menu lane, branch `export/source-rag`), pointing at ENGINE-CONTRACTS §9 + the issue comment.
- **`docs/cards/README.md`** — new "Post-ship — Later promotions (pickable)" board section (parallel: #165 ↔ #166; #167 compose-depth after), and prunes the now-stale entries from "Do not start yet" (Compose depth is filed as #167; #136 splitter crash is closed).

Docs-only — no `Sources/**`. Independent of #168 (probe doc); the cards link to it for the full contracts.
