### PR TITLE
feat(export): Export Source RAG… menu verb (LATER-2 / #166)

### DIFF
--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -161,6 +161,11 @@ struct SolipsistCommands: Commands {
             }
             .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
+            Button("Export Source RAG…") {
+                runtime.coordinator.run(.sourceRag, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
             Divider()
 
             Button("Stop") {

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 
@@ -218,6 +219,9 @@ final class Coordinator {
                 engine: engine,
                 secret: secret
             )
+            if verb == .sourceRag, result.exit == 0, let reveal = result.revealURL {
+                NSWorkspace.shared.activateFileViewerSelecting([reveal])
+            }
             let elapsed = startTime.duration(to: .now)
             let (secs, attos) = elapsed.components
             let elapsedNs = Int(secs * 1_000_000_000) + Int(attos / 1_000_000_000)
@@ -371,6 +375,8 @@ final class Coordinator {
         var checkReport: AnalysisReport? = nil
         var timings: TimingsReport? = nil
         var totalDurationNs: Int? = nil
+        /// Set when a job produced a tree the app should surface (Finder reveal).
+        var revealURL: URL? = nil
     }
 
     private static func takeOrPromptSecret(
@@ -721,6 +727,36 @@ final class Coordinator {
                     exit: result.exitCode,
                     summary: result.exitCode == 0 ? "Package archive ok" : "Package exit \(result.exitCode)",
                     problems: items
+                )
+
+            case .sourceRag:
+                guard let tool = SourceRagBinary.locate(borisBinary: engine.binaryURL) else {
+                    return JobResult(
+                        exit: 3,
+                        summary: "source RAG: boris-source-rag not found",
+                        problems: CoordinatorProblems.fromFailure(
+                            code: "source-rag",
+                            message: "boris-source-rag binary not found (set SOLIPSIST_SOURCE_RAG_BIN)"
+                        )
+                    )
+                }
+                let workspaceRoot = try source.workspaceRoot()
+                let outDir = workspaceRoot.appendingPathComponent("source-rag")
+                let result = try await engine.runTool(
+                    binary: tool,
+                    arguments: ["--root", workspaceRoot.path, "--out", outDir.path, "--quiet"],
+                    workingDirectory: workspaceRoot
+                )
+                let items = CoordinatorProblems.fromCommand(
+                    code: "source-rag",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Source RAG ok" : "Source RAG exit \(result.exitCode)",
+                    problems: items,
+                    revealURL: result.exitCode == 0 ? outDir : nil
                 )
             }
         } catch {

--- a/Sources/App/CoordinatorPolicy.swift
+++ b/Sources/App/CoordinatorPolicy.swift
@@ -20,11 +20,13 @@ enum CoordinatorVerb: String, Sendable {
     case publishNostr = "publish Nostr"
     case package
     case recipeScale = "recipe-scale"
+    case sourceRag = "source RAG"
 
-    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof, packages).
+    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof, packages)
+    /// or generate artifacts in the workspace (source RAG pack).
     var writesTree: Bool {
         switch self {
-        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr, .package:
+        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr, .package, .sourceRag:
             true
         case .plan, .validate, .check, .impact, .standardSiteVerify, .standardSiteRecords, .standardSiteSessions, .standardSiteLogout, .standardSiteSmoke, .recipeScale:
             false

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -856,6 +856,25 @@ public actor BorisEngine {
         return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
     }
 
+    // MARK: Kit tools
+
+    /// Runs a standalone kit-tool binary (e.g. `boris-source-rag`) through
+    /// the engine's single process slot, so Stop / cancel reaches the tool
+    /// too. Output is captured exactly like engine runs; no decoding.
+    public func runTool(
+        binary: URL,
+        arguments: [String],
+        workingDirectory: URL? = nil
+    ) async throws -> BorisPublishResult {
+        let out = try await BorisRunner.run(
+            binary: binary,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            handle: runHandle
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
     // MARK: Recipe Scale
 
     /// Runs `boris recipe-scale` (or evaluates scaled Cooklang recipe).

--- a/Sources/Engine/SourceRagBinary.swift
+++ b/Sources/Engine/SourceRagBinary.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Locates the `boris-source-rag` kit tool — packs project source files
+/// for LLM upload (LATER-2 / #166). Distinct from the M7 `--rag` build
+/// projection.
+///
+/// Search order:
+///   1. `SOLIPSIST_SOURCE_RAG_BIN` environment override
+///   2. `Resources/boris-source-rag` inside the running app bundle
+///   3. A sibling of the located `boris` binary (kit/bin dirs ship both)
+///   4. Common dev-checkout locations relative to the current directory
+public enum SourceRagBinary {
+    public static func locate(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        borisBinary: URL? = nil
+    ) -> URL? {
+        let fm = FileManager.default
+
+        func isExecutable(_ url: URL) -> Bool {
+            fm.isExecutableFile(atPath: url.path)
+        }
+
+        if let custom = UserDefaults.standard.string(forKey: "customSourceRagBinaryPath"), !custom.isEmpty {
+            let url = URL(fileURLWithPath: custom)
+            if isExecutable(url) { return url }
+        }
+
+        if let override = environment["SOLIPSIST_SOURCE_RAG_BIN"], !override.isEmpty {
+            let url = URL(fileURLWithPath: override)
+            if isExecutable(url) { return url }
+        }
+
+        if let resources = Bundle.main.resourceURL {
+            let bundled = resources.appendingPathComponent("boris-source-rag")
+            if isExecutable(bundled) { return bundled }
+        }
+
+        if let borisBinary {
+            let sibling = borisBinary.deletingLastPathComponent().appendingPathComponent("boris-source-rag")
+            if isExecutable(sibling) { return sibling }
+        }
+
+        let cwd = URL(fileURLWithPath: fm.currentDirectoryPath)
+        let devCandidates = [
+            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris-source-rag",
+            "../boris-agent-kit/bin/boris-source-rag",
+            "../boris/zig-out/bin/boris-source-rag",
+            "boris/zig-out/bin/boris-source-rag",
+            "zig-out/bin/boris-source-rag",
+        ]
+        for relative in devCandidates {
+            let url = cwd.appendingPathComponent(relative).standardizedFileURL
+            if isExecutable(url) { return url }
+        }
+
+        return nil
+    }
+}

--- a/docs/help.md
+++ b/docs/help.md
@@ -48,6 +48,7 @@ Every menu verb and keyboard shortcut:
 | Logout Standard.site | — | End the Standard.site session. |
 | Publish to Nostr… | — | Prompt for nsec/hex (stdin), then `nostr plan` → `sign --key-stdin` → `publish`. Optional Keychain remember. |
 | Package Archive | — | Build a `boris package` archive (`packages/`, checksums, machine-readable version). |
+| Export Source RAG… | — | Run `boris-source-rag` to pack project source files for LLM upload into `source-rag/`, then reveal it in Finder. |
 | Stop | `⌘.` | Cancel the running job (SIGTERM, then SIGKILL after 2s). With no job, stops preview watch. Tree-writing jobs freeze watch until they finish. |
 
 ### View


### PR DESCRIPTION
Implements LATER-2 / **#166** — the Source-RAG export verb.

**Boris → Export Source RAG…** runs the kit's `boris-source-rag` against the selected workspace, writes the pack to `<workspace>/source-rag/`, and reveals it in Finder on success. Non-zero exits surface as problems (never swallowed, per D11); missing tool binary → exit 3 + problem, like engine-not-found.

Changes:
- **`Sources/Engine/SourceRagBinary.swift`** (new) — locator in the house pattern: `SOLIPSIST_SOURCE_RAG_BIN` env override → `Resources/boris-source-rag` → sibling of the located boris binary → dev-checkout paths. A future `embed-boris.sh` extension just works via the Resources slot.
- **`BorisEngine.runTool`** — additive seam that launches a kit-tool binary through the engine's **single process slot** (`runHandle`), so the coordinator's one-job rule and Stop/cancel still reach the tool. Contract §9 (`docs/ENGINE-CONTRACTS.md`) says exit 0/2/3; verified exit codes surface via `CoordinatorProblems.fromCommand`.
- **`CoordinatorVerb.sourceRag`** — `writesTree: true` (generates `source-rag/` in the workspace; watch pauses during the run, same as package), build timeout.
- **`Commands.swift`** + **`docs/help.md`** — menu verb + the Help row (HelpAuditTests pins verbs ↔ help).

Not in this PR: embedding `boris-source-rag` into the app bundle (ship-lane / embed-boris.sh) — the locate path already checks `Resources/`, so that's a release-pipeline follow-up. `Sources/Engine/**` additions are additive only (#160/#161 own the boundary).

Gate check: `SKIP_EMBED_BORIS=1 make build` ✅, `make test` ✅ (ContractTests), spike scheme builds ✅. To try it live: point `SOLIPSIST_SOURCE_RAG_BIN` at a kit binary, open a workspace, Boris → Export Source RAG….
