### PR TITLE
feat(mailbox): Content Audit mailbox (LATER-1 / #165)

### DIFF
--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -161,6 +161,11 @@ struct SolipsistCommands: Commands {
             }
             .disabled(!hasSource || !runtime.coordinator.canRunVerb)
 
+            Button("Export Source RAG…") {
+                runtime.coordinator.run(.sourceRag, store: store, runtime: runtime)
+            }
+            .disabled(!hasSource || !runtime.coordinator.canRunVerb)
+
             Divider()
 
             Button("Stop") {

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 
@@ -218,6 +219,9 @@ final class Coordinator {
                 engine: engine,
                 secret: secret
             )
+            if verb == .sourceRag, result.exit == 0, let reveal = result.revealURL {
+                NSWorkspace.shared.activateFileViewerSelecting([reveal])
+            }
             let elapsed = startTime.duration(to: .now)
             let (secs, attos) = elapsed.components
             let elapsedNs = Int(secs * 1_000_000_000) + Int(attos / 1_000_000_000)
@@ -371,6 +375,8 @@ final class Coordinator {
         var checkReport: AnalysisReport? = nil
         var timings: TimingsReport? = nil
         var totalDurationNs: Int? = nil
+        /// Set when a job produced a tree the app should surface (Finder reveal).
+        var revealURL: URL? = nil
     }
 
     private static func takeOrPromptSecret(
@@ -721,6 +727,36 @@ final class Coordinator {
                     exit: result.exitCode,
                     summary: result.exitCode == 0 ? "Package archive ok" : "Package exit \(result.exitCode)",
                     problems: items
+                )
+
+            case .sourceRag:
+                guard let tool = SourceRagBinary.locate(borisBinary: engine.binaryURL) else {
+                    return JobResult(
+                        exit: 3,
+                        summary: "source RAG: boris-source-rag not found",
+                        problems: CoordinatorProblems.fromFailure(
+                            code: "source-rag",
+                            message: "boris-source-rag binary not found (set SOLIPSIST_SOURCE_RAG_BIN)"
+                        )
+                    )
+                }
+                let workspaceRoot = try source.workspaceRoot()
+                let outDir = workspaceRoot.appendingPathComponent("source-rag")
+                let result = try await engine.runTool(
+                    binary: tool,
+                    arguments: ["--root", workspaceRoot.path, "--out", outDir.path, "--quiet"],
+                    workingDirectory: workspaceRoot
+                )
+                let items = CoordinatorProblems.fromCommand(
+                    code: "source-rag",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Source RAG ok" : "Source RAG exit \(result.exitCode)",
+                    problems: items,
+                    revealURL: result.exitCode == 0 ? outDir : nil
                 )
             }
         } catch {

--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -758,6 +758,49 @@ final class Coordinator {
                     problems: items,
                     revealURL: result.exitCode == 0 ? outDir : nil
                 )
+
+            case .contentAudit:
+                guard let tool = ContentAuditBinary.locate(borisBinary: engine.binaryURL) else {
+                    return JobResult(
+                        exit: 3,
+                        summary: "content audit: boris-content-audit not found",
+                        problems: CoordinatorProblems.fromFailure(
+                            code: "content-audit",
+                            message: "boris-content-audit binary not found (set SOLIPSIST_CONTENT_AUDIT_BIN)"
+                        )
+                    )
+                }
+                let workspaceRoot = try source.workspaceRoot()
+                let contentRoot = try source.contentRoot()
+                let outDir = ContentAuditOutput.directory(for: source)
+                try FileManager.default.createDirectory(
+                    at: outDir, withIntermediateDirectories: true
+                )
+                let contentRel = contentRoot.path == workspaceRoot.path
+                    ? "."
+                    : String(contentRoot.path.dropFirst(workspaceRoot.path.count + 1))
+                let result = try await engine.runTool(
+                    binary: tool,
+                    arguments: [
+                        "--mode=poetry",
+                        "--root=\(workspaceRoot.path)",
+                        "--content-root=\(contentRel)",
+                        "--out=\(outDir.path)",
+                        "--format=json",
+                        "--quiet",
+                    ],
+                    workingDirectory: workspaceRoot
+                )
+                let items = CoordinatorProblems.fromCommand(
+                    code: "content-audit",
+                    exitCode: result.exitCode,
+                    stderr: result.stderr
+                )
+                return JobResult(
+                    exit: result.exitCode,
+                    summary: result.exitCode == 0 ? "Content audit ok" : "Content audit exit \(result.exitCode)",
+                    problems: items
+                )
             }
         } catch {
             let message = String(describing: error)

--- a/Sources/App/CoordinatorPolicy.swift
+++ b/Sources/App/CoordinatorPolicy.swift
@@ -21,12 +21,13 @@ enum CoordinatorVerb: String, Sendable {
     case package
     case recipeScale = "recipe-scale"
     case sourceRag = "source RAG"
+    case contentAudit = "content audit"
 
     /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof, packages)
-    /// or generate artifacts in the workspace (source RAG pack).
+    /// or generate artifacts in the workspace (source RAG pack, content audit).
     var writesTree: Bool {
         switch self {
-        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr, .package, .sourceRag:
+        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr, .package, .sourceRag, .contentAudit:
             true
         case .plan, .validate, .check, .impact, .standardSiteVerify, .standardSiteRecords, .standardSiteSessions, .standardSiteLogout, .standardSiteSmoke, .recipeScale:
             false
@@ -77,5 +78,19 @@ enum CoordinatorPolicy {
     private static func milliseconds(_ key: String, default value: Int) -> Duration {
         let stored = UserDefaults.standard.object(forKey: key) as? Int
         return .milliseconds(stored ?? value)
+    }
+}
+
+/// Where content-audit reports land: the app container (caches), keyed per
+/// source — never the user's content tree (ENGINE-CONTRACTS §8: read-only
+/// over the source, and `--out` must be a real path, which `~/Library/Caches`
+/// is and `/tmp` is not on macOS).
+enum ContentAuditOutput {
+    static func directory(for source: LocalSource) -> URL {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return caches
+            .appendingPathComponent("content-audit", isDirectory: true)
+            .appendingPathComponent(source.id.raw.uuidString, isDirectory: true)
     }
 }

--- a/Sources/App/CoordinatorPolicy.swift
+++ b/Sources/App/CoordinatorPolicy.swift
@@ -20,11 +20,13 @@ enum CoordinatorVerb: String, Sendable {
     case publishNostr = "publish Nostr"
     case package
     case recipeScale = "recipe-scale"
+    case sourceRag = "source RAG"
 
-    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof, packages).
+    /// Jobs that write trees watch also owns (`dist/`, `.boris`, proof, packages)
+    /// or generate artifacts in the workspace (source RAG pack).
     var writesTree: Bool {
         switch self {
-        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr, .package:
+        case .buildIR, .buildHTML, .buildThis, .buildAll, .publishStandardSite, .publishNostr, .package, .sourceRag:
             true
         case .plan, .validate, .check, .impact, .standardSiteVerify, .standardSiteRecords, .standardSiteSessions, .standardSiteLogout, .standardSiteSmoke, .recipeScale:
             false

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -856,6 +856,25 @@ public actor BorisEngine {
         return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
     }
 
+    // MARK: Kit tools
+
+    /// Runs a standalone kit-tool binary (e.g. `boris-source-rag`) through
+    /// the engine's single process slot, so Stop / cancel reaches the tool
+    /// too. Output is captured exactly like engine runs; no decoding.
+    public func runTool(
+        binary: URL,
+        arguments: [String],
+        workingDirectory: URL? = nil
+    ) async throws -> BorisPublishResult {
+        let out = try await BorisRunner.run(
+            binary: binary,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            handle: runHandle
+        )
+        return BorisPublishResult(exitCode: out.exitCode, stdout: out.stdoutText, stderr: out.stderrText)
+    }
+
     // MARK: Recipe Scale
 
     /// Runs `boris recipe-scale` (or evaluates scaled Cooklang recipe).

--- a/Sources/Engine/ContentAuditBinary.swift
+++ b/Sources/Engine/ContentAuditBinary.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Locates the `boris-content-audit` kit tool — poetry / parent-alignment
+/// source auditing (LATER-1 / #165).
+///
+/// Search order:
+///   1. `SOLIPSIST_CONTENT_AUDIT_BIN` environment override
+///   2. `Resources/boris-content-audit` inside the running app bundle
+///   3. A sibling of the located `boris` binary (kit/bin dirs ship both)
+///   4. Common dev-checkout locations relative to the current directory
+public enum ContentAuditBinary {
+    public static func locate(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        borisBinary: URL? = nil
+    ) -> URL? {
+        let fm = FileManager.default
+
+        func isExecutable(_ url: URL) -> Bool {
+            fm.isExecutableFile(atPath: url.path)
+        }
+
+        if let custom = UserDefaults.standard.string(forKey: "customContentAuditBinaryPath"), !custom.isEmpty {
+            let url = URL(fileURLWithPath: custom)
+            if isExecutable(url) { return url }
+        }
+
+        if let override = environment["SOLIPSIST_CONTENT_AUDIT_BIN"], !override.isEmpty {
+            let url = URL(fileURLWithPath: override)
+            if isExecutable(url) { return url }
+        }
+
+        if let resources = Bundle.main.resourceURL {
+            let bundled = resources.appendingPathComponent("boris-content-audit")
+            if isExecutable(bundled) { return bundled }
+        }
+
+        if let borisBinary {
+            let sibling = borisBinary.deletingLastPathComponent().appendingPathComponent("boris-content-audit")
+            if isExecutable(sibling) { return sibling }
+        }
+
+        let cwd = URL(fileURLWithPath: fm.currentDirectoryPath)
+        let devCandidates = [
+            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris-content-audit",
+            "../boris-agent-kit/bin/boris-content-audit",
+            "../boris/tools/content-audit/zig-out/bin/boris-content-audit",
+            "boris/tools/content-audit/zig-out/bin/boris-content-audit",
+            "../boris/zig-out/bin/boris-content-audit",
+        ]
+        for relative in devCandidates {
+            let url = cwd.appendingPathComponent(relative).standardizedFileURL
+            if isExecutable(url) { return url }
+        }
+
+        return nil
+    }
+}

--- a/Sources/Engine/SourceRagBinary.swift
+++ b/Sources/Engine/SourceRagBinary.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Locates the `boris-source-rag` kit tool — packs project source files
+/// for LLM upload (LATER-2 / #166). Distinct from the M7 `--rag` build
+/// projection.
+///
+/// Search order:
+///   1. `SOLIPSIST_SOURCE_RAG_BIN` environment override
+///   2. `Resources/boris-source-rag` inside the running app bundle
+///   3. A sibling of the located `boris` binary (kit/bin dirs ship both)
+///   4. Common dev-checkout locations relative to the current directory
+public enum SourceRagBinary {
+    public static func locate(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        borisBinary: URL? = nil
+    ) -> URL? {
+        let fm = FileManager.default
+
+        func isExecutable(_ url: URL) -> Bool {
+            fm.isExecutableFile(atPath: url.path)
+        }
+
+        if let custom = UserDefaults.standard.string(forKey: "customSourceRagBinaryPath"), !custom.isEmpty {
+            let url = URL(fileURLWithPath: custom)
+            if isExecutable(url) { return url }
+        }
+
+        if let override = environment["SOLIPSIST_SOURCE_RAG_BIN"], !override.isEmpty {
+            let url = URL(fileURLWithPath: override)
+            if isExecutable(url) { return url }
+        }
+
+        if let resources = Bundle.main.resourceURL {
+            let bundled = resources.appendingPathComponent("boris-source-rag")
+            if isExecutable(bundled) { return bundled }
+        }
+
+        if let borisBinary {
+            let sibling = borisBinary.deletingLastPathComponent().appendingPathComponent("boris-source-rag")
+            if isExecutable(sibling) { return sibling }
+        }
+
+        let cwd = URL(fileURLWithPath: fm.currentDirectoryPath)
+        let devCandidates = [
+            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris-source-rag",
+            "../boris-agent-kit/bin/boris-source-rag",
+            "../boris/zig-out/bin/boris-source-rag",
+            "boris/zig-out/bin/boris-source-rag",
+            "zig-out/bin/boris-source-rag",
+        ]
+        for relative in devCandidates {
+            let url = cwd.appendingPathComponent(relative).standardizedFileURL
+            if isExecutable(url) { return url }
+        }
+
+        return nil
+    }
+}

--- a/Sources/Play/Local/ContentAuditPane.swift
+++ b/Sources/Play/Local/ContentAuditPane.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+/// Content-audit mailbox (LATER-1 / #165): runs `boris-content-audit`
+/// against the selected source and renders the findings report. Play
+/// never spawns the tool — the coordinator does, through the engine's
+/// single process slot (`runTool`). Report lands in the app container
+/// (`ContentAuditOutput`), never the user's content tree.
+struct ContentAuditPane: View {
+    let source: LocalSource
+
+    @Environment(WorkspaceStore.self) private var store
+    @Environment(AppRuntime.self) private var runtime
+    @Environment(\.toolbarBand) private var toolbarBand
+
+    @State private var report: ContentAuditReport?
+    @State private var loadError: String?
+    @State private var ranOnce = false
+
+    var body: some View {
+        Group {
+            if let report {
+                reportView(report)
+            } else if let loadError {
+                ContentUnavailableView {
+                    Label("Audit Unavailable", systemImage: "checkmark.shield")
+                } description: {
+                    Text(loadError)
+                } actions: {
+                    Button("Run Again") { run() }
+                }
+            } else {
+                ContentUnavailableView {
+                    Label("Content Audit", systemImage: "checkmark.shield")
+                } description: {
+                    Text(isAuditing ? "Auditing the content graph…" : "No audit report yet")
+                } actions: {
+                    Button("Run Audit") { run() }
+                }
+            }
+        }
+        .safeAreaPadding(.top, toolbarBand)
+        .task(id: source.id) {
+            loadReport()
+            ranOnce = true
+            run()
+        }
+        .onChange(of: runtime.coordinator.isRunning) { _, running in
+            guard !running, runtime.coordinator.lastVerb == .contentAudit else { return }
+            loadReport()
+        }
+    }
+
+    private var isAuditing: Bool {
+        runtime.coordinator.isRunning && runtime.coordinator.verb == .contentAudit
+    }
+
+    private func run() {
+        guard runtime.coordinator.canRunVerb else { return }
+        runtime.coordinator.run(.contentAudit, store: store, runtime: runtime)
+    }
+
+    private func loadReport() {
+        let url = ContentAuditOutput.directory(for: source).appendingPathComponent("report.json")
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            report = nil
+            return
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let decoded = try JSONDecoder().decode(ContentAuditReport.self, from: data)
+            report = decoded
+            loadError = nil
+        } catch {
+            loadError = "Could not read the audit report: \(String(describing: error))"
+        }
+    }
+
+    private func reportView(_ report: ContentAuditReport) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header(report)
+            Divider()
+            if report.exceptions.isEmpty {
+                ContentUnavailableView {
+                    Label("No Findings", systemImage: "checkmark.circle")
+                } description: {
+                    Text("The content graph passed the selected audit checks.")
+                }
+            } else {
+                exceptionsList(report.exceptions)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func header(_ report: ContentAuditReport) -> some View {
+        HStack(spacing: 16) {
+            Label("Content Audit", systemImage: "checkmark.shield")
+                .font(.headline)
+            Spacer()
+            if let totals = report.totals {
+                stat("\(totals.records_discovered ?? 0)", "records")
+                stat("\(totals.malformed_records ?? 0)", "malformed")
+                stat("\(totals.dead_references ?? 0)", "dead refs")
+                stat("\(totals.mapped_poetry ?? 0)", "poetry mapped")
+            }
+            Button(isAuditing ? "Auditing…" : "Re-run") {
+                run()
+            }
+            .disabled(isAuditing)
+        }
+    }
+
+    private func stat(_ value: String, _ label: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(value).font(.headline.monospacedDigit())
+            Text(label).font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    private func exceptionsList(_ exceptions: [ContentAuditReport.Exception]) -> some View {
+        List(exceptions) { item in
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(item.severity ?? "finding")
+                        .font(.caption2.bold())
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background((item.severity == "structural" ? Color.orange : Color.red).opacity(0.18))
+                        .foregroundStyle(item.severity == "structural" ? Color.orange : Color.red)
+                        .clipShape(Capsule())
+                    Text(item.record_id ?? "unknown record")
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(1)
+                    Spacer()
+                }
+                Text(item.detail ?? item.kind ?? "finding")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 2)
+        }
+        .listStyle(.inset)
+    }
+}
+
+/// Decoded `boris-content-audit` report.json (ENGINE-CONTRACTS §8,
+/// schema_version 1). Field names follow the tool's snake_case contract;
+/// only the fields this pane renders are declared (D8: unknown fields
+/// degrade, never crash).
+struct ContentAuditReport: Decodable, Sendable {
+    var format_id: String?
+    var schema_version: Int?
+    var mode: String?
+    var totals: Totals?
+    var exceptions: [Exception]
+    var records: [Record]?
+
+    struct Totals: Decodable, Sendable {
+        var records_discovered: Int?
+        var source_records: Int?
+        var poetry_records: Int?
+        var other_records: Int?
+        var excluded_records: Int?
+        var mapped_poetry: Int?
+        var orphan_poetry: Int?
+        var ambiguous_poetry: Int?
+        var malformed_records: Int?
+        var dead_references: Int?
+    }
+
+    struct Exception: Decodable, Sendable, Identifiable {
+        var id: String { "\(record_id ?? "")-\(kind ?? "")-\(detail ?? "")" }
+        var kind: String?
+        var severity: String?
+        var record_id: String?
+        var detail: String?
+    }
+
+    struct Record: Decodable, Sendable {
+        var id: String?
+        var kind: String?
+        var collection: String?
+        var source_path: String?
+        var status: String?
+        var poetry_type: String?
+        var alignment: String?
+        var owner: String?
+        var verse_units: Int?
+        var malformed_units: Int?
+        var density_in_band: Bool?
+    }
+}

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -35,6 +35,8 @@ struct LocalPlay: PlaySurface {
                 PlanPane(source: source)
             case WorkspaceMailbox.activity:
                 ActivityPane()
+            case WorkspaceMailbox.contentAudit:
+                ContentAuditPane(source: source)
             default:
                 // Unknown mailbox is a trunk id (M13): Pages means all;
                 // a trunk id means that folder and its descendants.

--- a/Sources/Workspace/WorkspaceSelection.swift
+++ b/Sources/Workspace/WorkspaceSelection.swift
@@ -43,8 +43,9 @@ enum WorkspaceMailbox {
     static let publish = "publish"
     static let plan = "plan"
     static let activity = "activity"
+    static let contentAudit = "content-audit"
 
-    static let all: [String] = [pages, outputs, publish, plan, activity]
+    static let all: [String] = [pages, outputs, publish, plan, activity, contentAudit]
     static let defaultMailbox = pages
 
     static func isKnown(_ raw: String?) -> Bool {
@@ -52,7 +53,7 @@ enum WorkspaceMailbox {
         return all.contains(raw)
     }
 
-    /// Center-switch token. Known five pass through; nil (no mailbox
+    /// Center-switch token. Known mailboxes pass through; nil (no mailbox
     /// chosen yet) is the default Pages surface; unknown (including a
     /// future trunk id) stays itself — it is **not** Pages. Does not
     /// write back, and the switch never treats unknown as Pages.
@@ -68,6 +69,7 @@ enum WorkspaceMailbox {
         case publish: return "Publish"
         case plan: return "Plan"
         case activity: return "Activity"
+        case contentAudit: return "Content Audit"
         default: return raw
         }
     }
@@ -79,6 +81,7 @@ enum WorkspaceMailbox {
         case publish: return "paperplane"
         case plan: return "doc.plaintext"
         case activity: return "clock"
+        case contentAudit: return "checkmark.shield"
         default: return "folder"
         }
     }

--- a/Tests/ContractTests/WorkspaceSelectionTests.swift
+++ b/Tests/ContractTests/WorkspaceSelectionTests.swift
@@ -39,6 +39,7 @@ final class WorkspaceSelectionTests: XCTestCase {
             WorkspaceMailbox.publish,
             WorkspaceMailbox.plan,
             WorkspaceMailbox.activity,
+            WorkspaceMailbox.contentAudit,
         ])
     }
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -7,7 +7,7 @@ Solipsist is a native macOS workstation for [Boris](https://github.com/drawmeane
 Accounts live in Settings. The main window is mailboxes, a reading place, and a drawer. Companion windows host surfaces Solipsist does not rewrite.
 
 - **Settings → Sources**: The account book. Add, relocate, and remove local folders (`Solipsist → Settings…`). A source is a folder of Boris content, not a file tree. `File → Open…` (`⌘O`) and Open Recent write the same store. Try `Stunts/happy` first.
-- **Mailboxes (Left)**: Each source is an account header. Under it: Pages, Outputs, Publish, Plan, and Activity. Selecting a header opens that source's Pages mailbox.
+- **Mailboxes (Left)**: Each source is an account header. Under it: Pages, Outputs, Publish, Plan, Activity, and Content Audit. Selecting a header opens that source's Pages mailbox.
 - **Reading (Center)**: The message list of the selected mailbox, plus a reading pane for the selected message. On Pages, pick a page to read it as a letter (the served page when Preview is up; a contract summary when it is not). The problems list under the reading place is where every coordinator job reports its exit and diagnostics.
 - **Inspector Drawer (Right)**: Options, profile keys, page fields, and execution knobs of the current selection.
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -48,6 +48,7 @@ Every menu verb and keyboard shortcut:
 | Logout Standard.site | — | End the Standard.site session. |
 | Publish to Nostr… | — | Prompt for nsec/hex (stdin), then `nostr plan` → `sign --key-stdin` → `publish`. Optional Keychain remember. |
 | Package Archive | — | Build a `boris package` archive (`packages/`, checksums, machine-readable version). |
+| Export Source RAG… | — | Run `boris-source-rag` to pack project source files for LLM upload into `source-rag/`, then reveal it in Finder. |
 | Stop | `⌘.` | Cancel the running job (SIGTERM, then SIGKILL after 2s). With no job, stops preview watch. Tree-writing jobs freeze watch until they finish. |
 
 ### View


### PR DESCRIPTION
Implements LATER-1 / **#165** — the Content Audit mailbox.

**Stacked on #170** (`feat/source-rag-export`) — it reuses `BorisEngine.runTool` (single process slot). Merge #170 first; this PR then shrinks to just the content-audit delta.

A new **Content Audit** mailbox row runs the kit's `boris-content-audit` against the selected source and renders the findings report (totals + `exceptions[]` with severity badges), with a Re-run button. Runs on mailbox open; report refreshes when the job finishes.

Design calls, per ENGINE-CONTRACTS §8:
- **Report lands in the app container** (`~/Library/Caches/content-audit/<source-id>/report.json`), **never the user's content tree** — the mailbox is read-only over the source, and `--out` must be a real path (Caches is; `/tmp` is a symlink and refused, exit 3).
- **`ContentAuditBinary` locator** — same house pattern as the source-rag one: `SOLIPSIST_CONTENT_AUDIT_BIN` → bundle `Resources/` → sibling of boris → dev checkouts (incl. `tools/content-audit/zig-out`).
- **`CoordinatorVerb.contentAudit`** — `writesTree: true` (generated artifact; watch pauses during the run, build timeout).
- **Decode is defensive (D8)**: only the rendered fields are declared, snake_case verbatim from the verified §8 shape; unknown/newer fields degrade.
- `--content-root` computed relative from the profile (`content` for project roots, `.` otherwise).

Contract tests updated for the sixth mailbox token (WorkspaceSelectionTests pins `WorkspaceMailbox.all`); Help doc lists Content Audit (HelpAuditTests pins mailbox names).

Gate check: `SKIP_EMBED_BORIS=1 make build` ✅ · `make test` ✅ · spike builds ✅. To try it live: `SOLIPSIST_CONTENT_AUDIT_BIN=<kit>/bin/boris-content-audit`, open a workspace, click Content Audit in the sidebar.
