### PR TITLE
docs(cards): slice #167 compose depth into five pickable cards

### DIFF
--- a/docs/cards/LATER-compose-bundle-oliver.md
+++ b/docs/cards/LATER-compose-bundle-oliver.md
@@ -1,0 +1,36 @@
+# Card LATER-3.5 — Compose depth: bundle `oliver` next to `boris`
+
+**Tracker:** [#167](https://github.com/drawmeanelephant/solipsist/issues/167)
+· **Lane:** ship / build (`scripts/` + `Project.yml` only) — **parallel
+with the compose slices**, different lanes, no file overlap.
+
+## Owns
+
+- `scripts/embed-boris.sh` — extend to also embed `oliver` into
+  `Resources/oliver`.
+- `Project.yml` — embed step wiring if needed.
+- `Sources/Engine/OliverBinary.swift` — the locate order already checks
+  `Resources/oliver`; verify, don't rewrite.
+
+## Do
+
+1. Embed `oliver` next to `boris` (same universal/lipo + codesign path),
+   so the release app ships the compose preview renderer.
+2. Keep `SKIP_EMBED_BORIS=1` honored and the existing boris embed path
+   byte-identical.
+3. Note: `oliver` is **not** in the boris agent kit — source it from the
+   oliver repo build (`../oliver/zig-out/bin/oliver`) or a kit that
+   ships it; record the provenance in the script comment.
+
+## Do not
+
+- Touch `Sources/Compose/**` or `Sources/Engine/**` beyond a locate-order
+  verify.
+- Break the B3-4 entitlements matrix (`Project.yml`).
+
+## Gate
+
+A built app bundle contains `Resources/boris` **and** `Resources/oliver`
+when the sources are present; the compose preview renders without
+`SOLIPSIST_OLIVER_BIN`. `SKIP_EMBED_BORIS=1 make build` + `make test`
+green (embed-skipped path unchanged).

--- a/docs/cards/LATER-compose-cooklang.md
+++ b/docs/cards/LATER-compose-cooklang.md
@@ -1,0 +1,31 @@
+# Card LATER-3.4 — Compose depth: Cooklang autocomplete
+
+**Tracker:** [#167](https://github.com/drawmeanelephant/solipsist/issues/167)
+· **Lane:** compose (`Sources/Compose/**` single-owner). **Slice order:**
+after 3.3.
+
+## Owns
+
+- `Sources/Compose/ComposeEditorView.swift` / `ComposeDocument.swift` —
+  the completion UI and insertion path.
+- The completion **source** — from `completion.json` / recipe IR only
+  (Boris-owned surface; completion is never hand-rolled).
+
+## Do
+
+1. In Cooklang buffers, autocomplete `@ingredient` / `#cookware` / step
+   tokens from the corpus's `completion.json` (read-only over the
+   selected source's `.boris/` artifacts).
+2. Insert completions into the buffer; explicit save stays the only disk
+   writer.
+
+## Do not
+
+- Reimplement Cooklang parsing or completion semantics — Boris owns them.
+- Spawn a process — the Engine lane owns `Process` (and recipe-scale
+  stays the inspector's verb).
+
+## Gate
+
+Typing `@` in a Cooklang buffer suggests corpus ingredients;
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/LATER-compose-diagnostics.md
+++ b/docs/cards/LATER-compose-diagnostics.md
@@ -1,0 +1,36 @@
+# Card LATER-3.1 — Compose depth: Oliver span diagnostics
+
+**Tracker:** [#167](https://github.com/drawmeanelephant/solipsist/issues/167)
+· **Lane:** compose (`Sources/Compose/**` is single-owner — one worktree,
+one PR, one slice at a time). **Slice order:** first.
+
+## Owns
+
+- `Sources/Compose/ComposeEditorView.swift` — the `ComposeDiagnostic` seam
+  and `ComposeDiagnosticsPane` already exist and render **empty** by
+  design; this slice wires them up.
+- `Sources/Compose/OliverRenderService.swift` — mapping Oliver's
+  structured diagnostics (exact source spans) into `ComposeDiagnostic`.
+- `Sources/Engine/OliverRenderer.swift` — **additive only**: expose
+  diagnostics from the render result (the Engine boundary stays single-owner).
+
+## Do
+
+1. Oliver diagnostics carry **exact spans** (per the M10 review: "the
+   problems seam is a span-based model, not a line list"). Map them into
+   `ComposeDiagnostic` (severity / line / message) with source spans.
+2. **Click-to-line**: clicking a diagnostic moves the `NSTextView`
+   selection to the span.
+3. Surface render-time diagnostics on save/preview, never swallowed.
+
+## Do not
+
+- Parse in Swift — Oliver owns the grammar (D11); the highlighter is
+  heuristic paint, not a parse.
+- Touch the other compose slices' seams ahead of them.
+- Grow `Sources/Chrome/MainWindow.swift`.
+
+## Gate
+
+A broken buffer shows the diagnostic in the compose problems pane with
+click-to-line. `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/LATER-compose-frontmatter.md
+++ b/docs/cards/LATER-compose-frontmatter.md
@@ -1,0 +1,34 @@
+# Card LATER-3.3 — Compose depth: front-matter form
+
+**Tracker:** [#167](https://github.com/drawmeanelephant/solipsist/issues/167)
+· **Lane:** compose (`Sources/Compose/**` single-owner). **Slice order:**
+after 3.2.
+
+## Owns
+
+- `Sources/Compose/ComposeEditorView.swift` (or a new
+  `ComposeFrontmatterForm.swift` in `Sources/Compose/`) — the form section.
+- `Sources/Compose/ComposeDocument.swift` — read/write of the front-matter
+  block on **explicit save only**.
+
+## Do
+
+1. A form over the **closed 8-key grammar** (`id`, `parent`, `title`,
+   `role`, `status`, `tags`, `relations`, Cooklang `servings`) —
+   `boris-frontmatter-1.schema.json` is the authority; every other key is
+   `EFRONTMATTER` and is not offered.
+2. Write-back overlays the existing front matter (never destroys unknown
+   keys the form doesn't edit).
+3. The compose window's save seam is the only writer (boundary 4).
+
+## Do not
+
+- Invent keys or a second vocabulary.
+- Parse frontmatter in Swift beyond the existing boundary scanner —
+  Oliver owns the pre-pass.
+- Touch `Sources/Models/**` contracts.
+
+## Gate
+
+Editing the form and saving updates the buffer's front matter; unknown
+keys survive. `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/LATER-compose-highlight.md
+++ b/docs/cards/LATER-compose-highlight.md
@@ -1,0 +1,30 @@
+# Card LATER-3.2 — Compose depth: incremental highlight
+
+**Tracker:** [#167](https://github.com/drawmeanelephant/solipsist/issues/167)
+· **Lane:** compose (`Sources/Compose/**` single-owner). **Slice order:**
+after 3.1 (diagnostics) — both touch the same repaint path.
+
+## Owns
+
+- `Sources/Compose/ComposeHighlighter.swift` — the heuristic rule engine
+  (regex rules, region rules painted last).
+- `Sources/Compose/ComposeEditorView.swift` — the repaint path
+  (`NSTextView` host, repaint-on-edit).
+
+## Do
+
+1. Repaint only the **visible range** (and the changed region) instead of
+   the whole buffer on every keystroke.
+2. Keep the existing rule tables and the not-a-parse contract in the file
+   header — this is a performance slice, not a grammar change.
+
+## Do not
+
+- Rewrite the highlight rules or add grammar semantics.
+- Touch `Sources/Engine/**`.
+
+## Gate
+
+Editing a large buffer no longer repaints text off-screen; highlight
+paint contract tests stay green. `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -107,18 +107,24 @@ letter-URL contract tests pin the recut. Do not pick.
 
 ## Post-ship — Later promotions (pickable)
 
-Promoted from ROADMAP §3 "Later" — unblocked because the agent kit ships
-the binaries. Probed contracts are recorded in `docs/ENGINE-CONTRACTS.md`
-§8–§9 (PR #168); the short versions are posted on the issues
-([#165](https://github.com/drawmeanelephant/solipsist/issues/165#issuecomment-5341401505),
+Promoted from ROADMAP §3 "Later" — #165/#166 unblocked because the agent
+kit ships the binaries; probed contracts are recorded in
+`docs/ENGINE-CONTRACTS.md` §8–§9 (PR #168; short versions on the issues,
+[#165](https://github.com/drawmeanelephant/solipsist/issues/165#issuecomment-5341401505),
 [#166](https://github.com/drawmeanelephant/solipsist/issues/166#issuecomment-5341401629)).
-All three run through the coordinator's single `Process?` slot.
+The two tool cards run through the coordinator's single `Process?` slot;
+#167 compose depth is the M10 depth slice, one slice per worktree/PR.
 
 | Card | Issue | Lane | Parallel with | Gate |
 |------|-------|------|----------------|------|
 | [Content-audit mailbox](LATER-content-audit.md) | [#165](https://github.com/drawmeanelephant/solipsist/issues/165) | workspace / mailbox | #166 | findings render; exit codes surfaced |
 | [Source-RAG export](LATER-source-rag.md) | [#166](https://github.com/drawmeanelephant/solipsist/issues/166) | export / menu | #165 | menu verb → pack revealed in Finder |
-| Compose depth (tracker — issue only) | [#167](https://github.com/drawmeanelephant/solipsist/issues/167) | compose | after #165/#166 | one slice per PR; Oliver span diagnostics first |
+| Compose depth (tracker) | [#167](https://github.com/drawmeanelephant/solipsist/issues/167) | compose / ship | after #165/#166 | five slices below — one worktree, one PR each |
+| [3.1 Span diagnostics](LATER-compose-diagnostics.md) | #167 | compose | **first** | Oliver spans land in the problems seam; click-to-line |
+| [3.2 Incremental highlight](LATER-compose-highlight.md) | #167 | compose | after 3.1 | visible-range repaint only |
+| [3.3 Front-matter form](LATER-compose-frontmatter.md) | #167 | compose | after 3.2 | 8-key form over the closed grammar; unknown keys survive |
+| [3.4 Cooklang autocomplete](LATER-compose-cooklang.md) | #167 | compose | after 3.3 | `@` suggests corpus ingredients from completion.json |
+| [3.5 Bundle oliver](LATER-compose-bundle-oliver.md) | #167 | ship | parallel | Resources/oliver next to boris; preview without env override |
 
 ## Do not start yet
 


### PR DESCRIPTION
Slice the #167 compose-depth tracker into five pickable cards on the board so the conveyor can run one worktree per slice.

- **`LATER-compose-diagnostics.md`** (3.1, first) — wire Oliver's exact-span diagnostics into the existing (empty) `ComposeDiagnostic` seam + click-to-line; Engine touch additive-only.
- **`LATER-compose-highlight.md`** (3.2) — visible-range repaint; performance slice, rule tables untouched.
- **`LATER-compose-frontmatter.md`** (3.3) — form over the closed 8-key front-matter grammar; unknown keys survive; explicit-save-only writer.
- **`LATER-compose-cooklang.md`** (3.4) — `@` autocomplete from `completion.json` / recipe IR only.
- **`LATER-compose-bundle-oliver.md`** (3.5, parallel) — ship lane: embed `Resources/oliver` next to boris; notes oliver is not in the boris kit.
- **`docs/cards/README.md`** — Post-ship board section now lists the tracker + five slices with ordering and gates; intro corrected (only the tool cards use the coordinator's `Process?` slot).

Docs-only, no `Sources/**` or scripts touched. Slices carry the `Sources/Compose/**` single-owner lane rule and do-not-grow-MainWindow fences.
