### PR TITLE
feat(compose): Oliver span diagnostics in the problems pane (3.1 / #167)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -113,6 +113,7 @@ targets:
       - path: Sources/Compose/ComposeLanguage.swift
       - path: Sources/Compose/ComposeDocument.swift
       - path: Sources/Compose/ComposeHighlighter.swift
+      - path: Sources/Compose/ComposeDiagnostic.swift
       - path: Sources/Compose/MarkupRenderService.swift
       - path: Sources/Compose/ComposePageResolver.swift
       - path: Sources/Compose/OliverRenderService.swift

--- a/Sources/Compose/ComposeDiagnostic.swift
+++ b/Sources/Compose/ComposeDiagnostic.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// One diagnostic for the compose element's problems seam (LATER-3.1).
+/// Oliver's span-based diagnostics map into this shape; the element only
+/// renders what it is given. Foundation-only so the ContractTests target
+/// can pin the mapping without a SwiftUI import.
+struct ComposeDiagnostic: Identifiable, Equatable {
+    enum Severity: Equatable {
+        case warning
+        case error
+    }
+
+    let id = UUID()
+    let severity: Severity
+    let message: String
+    let line: Int?
+    /// Absolute character offset (Oliver's `span.start`) for click-to-line.
+    let characterIndex: Int?
+
+    init(severity: Severity, message: String, line: Int? = nil, characterIndex: Int? = nil) {
+        self.severity = severity
+        self.message = message
+        self.line = line
+        self.characterIndex = characterIndex
+    }
+}

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -1,27 +1,6 @@
 import AppKit
 import SwiftUI
 
-/// One diagnostic for the compose element's problems seam. The hook-in card
-/// maps Oliver's structured diagnostics (exact source spans) into this
-/// shape; the element itself only renders what it is given.
-struct ComposeDiagnostic: Identifiable, Equatable {
-    enum Severity: Equatable {
-        case warning
-        case error
-    }
-
-    let id = UUID()
-    let severity: Severity
-    let message: String
-    let line: Int?
-
-    init(severity: Severity, message: String, line: Int? = nil) {
-        self.severity = severity
-        self.message = message
-        self.line = line
-    }
-}
-
 /// The compose element: a full-featured Markdown / Textile / Cooklang
 /// editing surface that will be hooked into the app by a later card.
 ///
@@ -35,12 +14,16 @@ struct ComposeEditorView: View {
     @Bindable var document: ComposeDocument
 
     var renderService: any MarkupRenderService = PlaceholderRenderService()
-    var diagnostics: [ComposeDiagnostic] = []
     /// Called after an explicit save actually wrote the buffer. The host
     /// (ComposeWindow) uses this to flow the save into the coordinator's
     /// save→validate gate.
     var onSave: (() -> Void)?
 
+    /// Problems from the live preview render (LATER-3.1). Computed from the
+    /// render, not injected by the host.
+    @State private var diagnostics: [ComposeDiagnostic] = []
+    /// Character offset to jump the editor selection to (click-to-line).
+    @State private var jumpToCharacter: Int?
     @State private var showPreview = true
     @State private var previewOptions = MarkupRenderOptions()
     @State private var saveError: String?
@@ -50,25 +33,55 @@ struct ComposeEditorView: View {
             toolbar
             Divider()
             HSplitView {
-                ComposeTextView(document: document)
+                ComposeTextView(document: document, jumpToCharacter: jumpToCharacter)
                     .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)
                 if showPreview {
                     ComposePreviewView(
                         source: document.text,
                         language: document.language,
                         options: previewOptions,
-                        renderService: renderService
+                        renderService: renderService,
+                        onDiagnostics: { diagnostics = $0 }
                     )
                     .frame(minWidth: 240, maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
             if !diagnostics.isEmpty {
                 Divider()
-                ComposeDiagnosticsPane(diagnostics: diagnostics)
-                    .frame(minHeight: 72, idealHeight: 110, maxHeight: 180)
+                ComposeDiagnosticsPane(diagnostics: diagnostics) { selected in
+                    if let index = characterIndex(for: selected, in: document.text) {
+                        jumpToCharacter = index
+                    }
+                }
+                .frame(minHeight: 72, idealHeight: 110, maxHeight: 180)
             }
         }
         .navigationTitle(document.statusText)
+    }
+
+    /// Resolve a diagnostic to a character offset: Oliver's `span.start`
+    /// when present, else the start of the reported line. UTF-16 offsets
+    /// (NSRange units) — a best-effort jump like the highlighter, clamped
+    /// so it can never exceed the buffer.
+    private func characterIndex(for diagnostic: ComposeDiagnostic, in text: String) -> Int? {
+        if let index = diagnostic.characterIndex {
+            return min(max(index, 0), text.utf16.count)
+        }
+        guard let line = diagnostic.line, line >= 1 else { return nil }
+        let ns = text as NSString
+        var found: Int?
+        var currentLine = 1
+        ns.enumerateSubstrings(
+            in: NSRange(location: 0, length: ns.length),
+            options: [.byLines, .substringNotRequired]
+        ) { _, range, _, stop in
+            if currentLine == line {
+                found = range.location
+                stop.pointee = true
+            }
+            currentLine += 1
+        }
+        return found
     }
 
     private var toolbar: some View {
@@ -160,10 +173,11 @@ struct ComposeEditorView: View {
     }
 }
 
-/// The problems seam: renders diagnostics the host injects. Empty by design
-/// until the hook-in card wires Oliver's structured diagnostics through.
+/// The problems seam: renders the diagnostics the editor computed from the
+/// live render (LATER-3.1). Clicking a row jumps the editor to the span.
 private struct ComposeDiagnosticsPane: View {
     let diagnostics: [ComposeDiagnostic]
+    var onSelect: (ComposeDiagnostic) -> Void = { _ in }
 
     var body: some View {
         List(diagnostics) { diagnostic in
@@ -178,6 +192,9 @@ private struct ComposeDiagnosticsPane: View {
                 Text(diagnostic.message)
                     .textSelection(.enabled)
             }
+            .contentShape(Rectangle())
+            .onTapGesture { onSelect(diagnostic) }
+            .help("Jump to this diagnostic")
         }
     }
 }
@@ -187,6 +204,8 @@ private struct ComposeDiagnosticsPane: View {
 /// single source of truth.
 private struct ComposeTextView: NSViewRepresentable {
     @Bindable var document: ComposeDocument
+    /// Click-to-line target (LATER-3.1); nil = no pending jump.
+    var jumpToCharacter: Int?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(document: document)
@@ -224,6 +243,7 @@ private struct ComposeTextView: NSViewRepresentable {
         } else {
             context.coordinator.applyHighlight(textView, text: document.text, language: document.language)
         }
+        context.coordinator.jump(to: jumpToCharacter, in: textView)
     }
 
     private var baseFont: NSFont {
@@ -234,6 +254,8 @@ private struct ComposeTextView: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         var document: ComposeDocument
         private var isApplying = false
+        /// Last click-to-line offset we applied, so re-syncs do not re-jump.
+        private var lastJumpedCharacter: Int?
 
         /// Last state we painted, so programmatic syncs (which fire on every
         /// `document` change) do not re-paint an unchanged buffer.
@@ -266,6 +288,19 @@ private struct ComposeTextView: NSViewRepresentable {
             textView.textStorage?.setAttributedString(highlighted)
             textView.textStorage?.endEditing()
             textView.typingAttributes = [.font: baseFont, .foregroundColor: NSColor.labelColor]
+        }
+
+        /// Moves the selection to a character offset (click-to-line).
+        /// Runs after highlight so the storage is current; clamps so a
+        /// stale span can never exceed the buffer.
+        func jump(to character: Int?, in textView: NSTextView) {
+            guard let character, character != lastJumpedCharacter else { return }
+            lastJumpedCharacter = character
+            let ns = textView.string as NSString
+            let clamped = min(max(character, 0), ns.length)
+            let range = NSRange(location: clamped, length: 0)
+            textView.setSelectedRange(range)
+            textView.scrollRangeToVisible(range)
         }
 
         private var baseFont: NSFont {

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -68,11 +68,11 @@ struct ComposeEditorView: View {
             return min(max(index, 0), text.utf16.count)
         }
         guard let line = diagnostic.line, line >= 1 else { return nil }
-        let ns = text as NSString
+        let nsString = text as NSString
         var found: Int?
         var currentLine = 1
-        ns.enumerateSubstrings(
-            in: NSRange(location: 0, length: ns.length),
+        nsString.enumerateSubstrings(
+            in: NSRange(location: 0, length: nsString.length),
             options: [.byLines, .substringNotRequired]
         ) { _, range, _, stop in
             if currentLine == line {
@@ -296,8 +296,8 @@ private struct ComposeTextView: NSViewRepresentable {
         func jump(to character: Int?, in textView: NSTextView) {
             guard let character, character != lastJumpedCharacter else { return }
             lastJumpedCharacter = character
-            let ns = textView.string as NSString
-            let clamped = min(max(character, 0), ns.length)
+            let nsString = textView.string as NSString
+            let clamped = min(max(character, 0), nsString.length)
             let range = NSRange(location: clamped, length: 0)
             textView.setSelectedRange(range)
             textView.scrollRangeToVisible(range)

--- a/Sources/Compose/ComposePreview.swift
+++ b/Sources/Compose/ComposePreview.swift
@@ -8,6 +8,9 @@ struct ComposePreviewView: View {
     let language: ComposeLanguage
     let options: MarkupRenderOptions
     let renderService: any MarkupRenderService
+    /// Receives the mapped diagnostics after each render (LATER-3.1). The
+    /// editor owns the problems pane; the preview only renders HTML.
+    var onDiagnostics: ([ComposeDiagnostic]) -> Void = { _ in }
 
     @State private var html: String?
     @State private var renderError: String?
@@ -35,12 +38,15 @@ struct ComposePreviewView: View {
                 guard !Task.isCancelled else { return }
                 let rendered = try await renderService.render(source, language: language, options: options)
                 guard !Task.isCancelled else { return }
-                html = rendered
+                html = rendered.html
                 renderError = nil
+                onDiagnostics(rendered.diagnostics)
             } catch is CancellationError {
                 // A newer request superseded this one; keep the last frame.
             } catch {
                 renderError = String(describing: error)
+                // Never swallow: the problems pane sees the render failure too.
+                onDiagnostics([ComposeDiagnostic(severity: .error, message: String(describing: error))])
             }
         }
     }

--- a/Sources/Compose/ComposeWindow.swift
+++ b/Sources/Compose/ComposeWindow.swift
@@ -29,7 +29,6 @@ struct ComposeWindow: View {
                 ComposeEditorView(
                     document: document,
                     renderService: OliverRenderService(),
-                    diagnostics: [],
                     onSave: save
                 )
                 .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/Sources/Compose/MarkupRenderService.swift
+++ b/Sources/Compose/MarkupRenderService.swift
@@ -49,25 +49,40 @@ protocol MarkupRenderService: Sendable {
         _ source: String,
         language: ComposeLanguage,
         options: MarkupRenderOptions
-    ) async throws -> String
+    ) async throws -> MarkupRenderResult
+}
+
+/// What a renderer returns: the HTML fragment plus any parse diagnostics
+/// (LATER-3.1 — Oliver's span-based diagnostics mapped into the compose
+/// seam). The editor shows diagnostics in the problems pane; the preview
+/// shows only the HTML.
+struct MarkupRenderResult: Sendable {
+    let html: String
+    let diagnostics: [ComposeDiagnostic]
+
+    init(html: String, diagnostics: [ComposeDiagnostic] = []) {
+        self.html = html
+        self.diagnostics = diagnostics
+    }
 }
 
 /// Placeholder: HTML-escapes the source so the preview is safe and shows
 /// exactly what was authored. Same escape policy as Oliver's text writer
 /// (`& < > "` and NUL → U+FFFD) so the swap to the real renderer changes
-/// content, not posture.
+/// content, not posture. No diagnostics — the placeholder has no parser.
 struct PlaceholderRenderService: MarkupRenderService {
     func render(
         _ source: String,
         language: ComposeLanguage,
         options: MarkupRenderOptions
-    ) async throws -> String {
+    ) async throws -> MarkupRenderResult {
         let escaped = source
             .replacingOccurrences(of: "&", with: "&amp;")
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
             .replacingOccurrences(of: "\"", with: "&quot;")
             .replacingOccurrences(of: "\u{0}", with: "\u{FFFD}")
-        return "<pre style=\"white-space: pre-wrap; font: 12px ui-monospace;\">\(escaped)</pre>"
+        let html = "<pre style=\"white-space: pre-wrap; font: 12px ui-monospace;\">\(escaped)</pre>"
+        return MarkupRenderResult(html: html)
     }
 }

--- a/Sources/Compose/OliverRenderService.swift
+++ b/Sources/Compose/OliverRenderService.swift
@@ -15,13 +15,33 @@ struct OliverRenderService: MarkupRenderService {
         _ source: String,
         language: ComposeLanguage,
         options: MarkupRenderOptions
-    ) async throws -> String {
+    ) async throws -> MarkupRenderResult {
+        var engineOptions = Self.engineOptions(options)
+        engineOptions.diagnostics = true
         let result = try await renderer.render(
             source: source,
             frontend: Self.frontend(for: language),
-            options: Self.engineOptions(options)
+            options: engineOptions
         )
-        return result.html
+        return MarkupRenderResult(
+            html: result.html,
+            diagnostics: Self.composeDiagnostics(from: result.diagnostics)
+        )
+    }
+
+    /// Maps Oliver's span-based diagnostics into the compose problems seam.
+    /// Only the rendered fields are read; unknown severities degrade to a
+    /// warning (D8) and `span.start` becomes the click-to-line character
+    /// index.
+    static func composeDiagnostics(from diagnostics: [OliverDiagnostic]) -> [ComposeDiagnostic] {
+        diagnostics.map { diagnostic in
+            ComposeDiagnostic(
+                severity: diagnostic.severity == "error" ? .error : .warning,
+                message: diagnostic.message ?? diagnostic.code ?? "render diagnostic",
+                line: diagnostic.line,
+                characterIndex: diagnostic.span?.start
+            )
+        }
     }
 
     // MARK: - Mapping (pure, tested)

--- a/Sources/Engine/OliverRenderer.swift
+++ b/Sources/Engine/OliverRenderer.swift
@@ -42,6 +42,10 @@ public struct OliverRenderOptions: Sendable, Equatable {
     public var taskLists = false
     public var rawHTML: OliverRawHTMLPolicy = .allowed
     public var frontmatter: OliverFrontmatterPolicy = .none
+    /// Emit `--diagnostics json`: the parse diagnostics side channel. Oliver
+    /// serializes them to **stderr** as a JSON array (exact source spans) so
+    /// stdout stays pure HTML (probed against the built CLI).
+    public var diagnostics = false
 
     public init() {}
 
@@ -67,7 +71,52 @@ public struct OliverRenderOptions: Sendable, Equatable {
         if frontmatter != .none {
             args += ["--frontmatter", frontmatter.rawValue]
         }
+        if diagnostics {
+            args += ["--diagnostics", "json"]
+        }
         return args
+    }
+}
+
+/// One parse diagnostic from Oliver's `--diagnostics json` side channel.
+/// All fields optional — decode defensively (D8): unknown/newer shapes
+/// degrade to `[]`, never crash. `span.start` is the absolute character
+/// offset in the source buffer (verified against the built CLI).
+public struct OliverDiagnostic: Codable, Sendable, Equatable {
+    public struct Span: Codable, Sendable, Equatable {
+        public var start: Int?
+        public var end: Int?
+
+        public init(start: Int? = nil, end: Int? = nil) {
+            self.start = start
+            self.end = end
+        }
+    }
+
+    public var severity: String?
+    public var code: String?
+    public var offset: Int?
+    public var line: Int?
+    public var column: Int?
+    public var span: Span?
+    public var message: String?
+
+    public init(
+        severity: String? = nil,
+        code: String? = nil,
+        offset: Int? = nil,
+        line: Int? = nil,
+        column: Int? = nil,
+        span: Span? = nil,
+        message: String? = nil
+    ) {
+        self.severity = severity
+        self.code = code
+        self.offset = offset
+        self.line = line
+        self.column = column
+        self.span = span
+        self.message = message
     }
 }
 
@@ -76,6 +125,16 @@ public struct OliverRenderResult: Sendable {
     public let html: String
     public let exitCode: Int32
     public let stderr: String
+    /// Parsed `--diagnostics json` payload (empty when the flag was off or
+    /// the side channel did not decode).
+    public let diagnostics: [OliverDiagnostic]
+
+    public init(html: String, exitCode: Int32, stderr: String, diagnostics: [OliverDiagnostic] = []) {
+        self.html = html
+        self.exitCode = exitCode
+        self.stderr = stderr
+        self.diagnostics = diagnostics
+    }
 }
 
 public enum OliverRenderError: Error, Sendable, CustomStringConvertible {
@@ -128,9 +187,25 @@ public struct OliverRenderer: Sendable {
             guard output.exitCode == 0 else {
                 throw OliverRenderError.renderFailed(exitCode: output.exitCode, stderr: output.stderrText)
             }
-            return OliverRenderResult(html: output.stdoutText, exitCode: output.exitCode, stderr: output.stderrText)
+            let diagnostics = options.diagnostics
+                ? Self.decodeDiagnostics(from: output.stderrText)
+                : []
+            return OliverRenderResult(
+                html: output.stdoutText,
+                exitCode: output.exitCode,
+                stderr: output.stderrText,
+                diagnostics: diagnostics
+            )
         } onCancel: {
             handle.terminate()
         }
+    }
+
+    /// Decodes the `--diagnostics json` stderr side channel. Not JSON (or
+    /// a newer shape) → `[]`, never a throw (D8).
+    static func decodeDiagnostics(from stderr: String) -> [OliverDiagnostic] {
+        let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return [] }
+        return (try? JSONDecoder().decode([OliverDiagnostic].self, from: data)) ?? []
     }
 }

--- a/Tests/ContractTests/ComposePreviewTests.swift
+++ b/Tests/ContractTests/ComposePreviewTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 final class ComposePreviewTests: XCTestCase {
-    private func render(_ source: String, language: ComposeLanguage) async throws -> String {
+    private func render(_ source: String, language: ComposeLanguage) async throws -> MarkupRenderResult {
         try await PlaceholderRenderService().render(
             source,
             language: language,
@@ -10,36 +10,41 @@ final class ComposePreviewTests: XCTestCase {
     }
 
     func testPlaceholderEscapesHTML() async throws {
-        let html = try await render("<b>&\"</b>", language: .markdown)
-        XCTAssertTrue(html.contains("&lt;b&gt;&amp;&quot;&lt;/b&gt;"))
-        XCTAssertFalse(html.contains("<b>"))
-        XCTAssertFalse(html.contains("&amp;lt;")) // no double-escape
+        let result = try await render("<b>&\"</b>", language: .markdown)
+        XCTAssertTrue(result.html.contains("&lt;b&gt;&amp;&quot;&lt;/b&gt;"))
+        XCTAssertFalse(result.html.contains("<b>"))
+        XCTAssertFalse(result.html.contains("&amp;lt;")) // no double-escape
     }
 
     func testPlaceholderEscapesPerLanguage() async throws {
         let markdown = try await render("1 < 2", language: .markdown)
         let textile = try await render("1 < 2", language: .textile)
         let cooklang = try await render("1 < 2", language: .cooklang)
-        XCTAssertEqual(markdown, textile)
-        XCTAssertEqual(markdown, cooklang)
-        XCTAssertTrue(markdown.contains("&lt;"))
+        XCTAssertEqual(markdown.html, textile.html)
+        XCTAssertEqual(markdown.html, cooklang.html)
+        XCTAssertTrue(markdown.html.contains("&lt;"))
     }
 
     func testPlaceholderReplacesNUL() async throws {
-        let html = try await render("a\u{0}b", language: .cooklang)
-        XCTAssertTrue(html.contains("\u{FFFD}"))
-        XCTAssertFalse(html.contains("\u{0}"))
+        let result = try await render("a\u{0}b", language: .cooklang)
+        XCTAssertTrue(result.html.contains("\u{FFFD}"))
+        XCTAssertFalse(result.html.contains("\u{0}"))
     }
 
     func testPlaceholderIgnoresOptions() async throws {
         var options = MarkupRenderOptions()
         options.wikilinks = true
         options.profile = .xhtml
-        let html = try await PlaceholderRenderService().render(
+        let result = try await PlaceholderRenderService().render(
             "See [[Notes]].",
             language: .markdown,
             options: options
         )
-        XCTAssertTrue(html.contains("[[Notes]]"))
+        XCTAssertTrue(result.html.contains("[[Notes]]"))
+    }
+
+    func testPlaceholderCarriesNoDiagnostics() async throws {
+        let result = try await render("# fine", language: .markdown)
+        XCTAssertTrue(result.diagnostics.isEmpty)
     }
 }

--- a/Tests/ContractTests/OliverDiagnosticTests.swift
+++ b/Tests/ContractTests/OliverDiagnosticTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+/// LATER-3.1: Oliver's `--diagnostics json` side channel, decoded defensively.
+/// Shapes pinned from a live probe of the built CLI (2026-08-19) — stderr is
+/// a JSON array with exact source spans; stdout stays pure HTML.
+final class OliverDiagnosticTests: XCTestCase {
+    private let probeFrontmatter = #"[{"severity":"warning","code":"unclosed-frontmatter","offset":1,"line":1,"column":1,"span":{"start":0,"end":4},"message":"front matter fence `---` never closed"}]"#
+
+    private let probeCooklang = #"[{"severity":"warning","code":"unclosed-braces","offset":12,"line":1,"column":12,"span":{"start":11,"end":12},"message":"unclosed `{` (no `}` on the line)"}]"#
+
+    func testDecodesProbedFrontmatterDiagnostic() {
+        let decoded = OliverRenderer.decodeDiagnostics(from: probeFrontmatter)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0].severity, "warning")
+        XCTAssertEqual(decoded[0].code, "unclosed-frontmatter")
+        XCTAssertEqual(decoded[0].line, 1)
+        XCTAssertEqual(decoded[0].column, 1)
+        XCTAssertEqual(decoded[0].span?.start, 0)
+        XCTAssertEqual(decoded[0].span?.end, 4)
+    }
+
+    func testDecodesProbedCooklangDiagnostic() {
+        let decoded = OliverRenderer.decodeDiagnostics(from: probeCooklang)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0].code, "unclosed-braces")
+        XCTAssertEqual(decoded[0].offset, 12)
+        XCTAssertEqual(decoded[0].span?.start, 11)
+        XCTAssertEqual(decoded[0].message, "unclosed `{` (no `}` on the line)")
+    }
+
+    func testEmptyArrayDecodes() {
+        XCTAssertTrue(OliverRenderer.decodeDiagnostics(from: "[]").isEmpty)
+    }
+
+    func testProseStderrDegradesToEmpty() {
+        // The side channel is absent (flag off) or the CLI printed prose —
+        // never a throw (D8).
+        XCTAssertTrue(OliverRenderer.decodeDiagnostics(from: "").isEmpty)
+        XCTAssertTrue(OliverRenderer.decodeDiagnostics(from: "oliver: RawHtmlRejected\n").isEmpty)
+        XCTAssertTrue(OliverRenderer.decodeDiagnostics(from: "not json at all").isEmpty)
+    }
+
+    func testUnknownFieldsDecodeDefensively() {
+        // Newer shapes may add fields; the known ones must still decode.
+        let newer = #"[{"severity":"error","code":"future-thing","line":7,"span":{"start":10,"end":20},"message":"hi","extra":{"nested":true}}]"#
+        let decoded = OliverRenderer.decodeDiagnostics(from: newer)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0].severity, "error")
+        XCTAssertEqual(decoded[0].line, 7)
+        XCTAssertEqual(decoded[0].span?.start, 10)
+    }
+}

--- a/Tests/ContractTests/OliverDiagnosticTests.swift
+++ b/Tests/ContractTests/OliverDiagnosticTests.swift
@@ -4,9 +4,11 @@ import XCTest
 /// Shapes pinned from a live probe of the built CLI (2026-08-19) — stderr is
 /// a JSON array with exact source spans; stdout stays pure HTML.
 final class OliverDiagnosticTests: XCTestCase {
-    private let probeFrontmatter = #"[{"severity":"warning","code":"unclosed-frontmatter","offset":1,"line":1,"column":1,"span":{"start":0,"end":4},"message":"front matter fence `---` never closed"}]"#
+    private let probeFrontmatter = #"[{"severity":"warning","code":"unclosed-frontmatter","offset":1,"line":1,"column":1,""#
+        + #"span":{"start":0,"end":4},"message":"front matter fence `---` never closed"}]"#
 
-    private let probeCooklang = #"[{"severity":"warning","code":"unclosed-braces","offset":12,"line":1,"column":12,"span":{"start":11,"end":12},"message":"unclosed `{` (no `}` on the line)"}]"#
+    private let probeCooklang = #"[{"severity":"warning","code":"unclosed-braces","offset":12,"line":1,"column":12,""#
+        + #"span":{"start":11,"end":12},"message":"unclosed `{` (no `}` on the line)"}]"#
 
     func testDecodesProbedFrontmatterDiagnostic() {
         let decoded = OliverRenderer.decodeDiagnostics(from: probeFrontmatter)

--- a/Tests/ContractTests/OliverRenderOptionsTests.swift
+++ b/Tests/ContractTests/OliverRenderOptionsTests.swift
@@ -58,4 +58,11 @@ final class OliverRenderOptionsTests: XCTestCase {
         let args = options.arguments(frontend: .markdown)
         XCTAssertEqual(args.suffix(2), ["--to", "xhtml"])
     }
+
+    func testDiagnosticsFlagEmitsWhenSet() {
+        XCTAssertFalse(OliverRenderOptions().arguments(frontend: .markdown).contains("--diagnostics"))
+        var options = OliverRenderOptions()
+        options.diagnostics = true
+        XCTAssertEqual(options.arguments(frontend: .markdown).suffix(2), ["--diagnostics", "json"])
+    }
 }

--- a/Tests/ContractTests/OliverRenderServiceTests.swift
+++ b/Tests/ContractTests/OliverRenderServiceTests.swift
@@ -72,8 +72,55 @@ final class OliverRenderServiceTests: XCTestCase {
             throw XCTSkip("SOLIPSIST_OLIVER_BIN not set")
         }
         let service = OliverRenderService(renderer: OliverRenderer(binaryURL: URL(fileURLWithPath: bin)))
-        let html = try await service.render("h1. Title", language: .textile, options: MarkupRenderOptions())
-        XCTAssertTrue(html.contains("<h1>Title</h1>"))
+        let result = try await service.render("h1. Title", language: .textile, options: MarkupRenderOptions())
+        XCTAssertTrue(result.html.contains("<h1>Title</h1>"))
+    }
+
+    func testServiceSurfaceDiagnosticsThroughOliver() async throws {
+        guard let bin = ProcessInfo.processInfo.environment["SOLIPSIST_OLIVER_BIN"], !bin.isEmpty else {
+            throw XCTSkip("SOLIPSIST_OLIVER_BIN not set")
+        }
+        let service = OliverRenderService(renderer: OliverRenderer(binaryURL: URL(fileURLWithPath: bin)))
+        var options = MarkupRenderOptions()
+        options.frontmatter = .yaml
+        let result = try await service.render(
+            "---\ntitle: x\n\n# Hi\n",
+            language: .markdown,
+            options: options
+        )
+        XCTAssertFalse(result.diagnostics.isEmpty)
+        XCTAssertEqual(result.diagnostics.first?.severity, .warning)
+        XCTAssertEqual(result.diagnostics.first?.line, 1)
+    }
+
+    // MARK: - Diagnostic mapping (pure)
+
+    func testComposeDiagnosticsMappingCarriesSpans() {
+        let oliver = [
+            OliverDiagnostic(
+                severity: "warning",
+                code: "unclosed-frontmatter",
+                offset: 1,
+                line: 1,
+                column: 1,
+                span: OliverDiagnostic.Span(start: 0, end: 4),
+                message: "front matter fence `---` never closed"
+            )
+        ]
+        let mapped = OliverRenderService.composeDiagnostics(from: oliver)
+        XCTAssertEqual(mapped.count, 1)
+        XCTAssertEqual(mapped[0].severity, .warning)
+        XCTAssertEqual(mapped[0].message, "front matter fence `---` never closed")
+        XCTAssertEqual(mapped[0].line, 1)
+        XCTAssertEqual(mapped[0].characterIndex, 0)
+    }
+
+    func testComposeDiagnosticsMappingDefaultsUnknownSeverityToWarning() {
+        let mapped = OliverRenderService.composeDiagnostics(from: [
+            OliverDiagnostic(severity: "info", code: "whatever", message: nil)
+        ])
+        XCTAssertEqual(mapped[0].severity, .warning)
+        XCTAssertEqual(mapped[0].message, "whatever") // code fallback
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Implements compose-depth slice **3.1 — Oliver span diagnostics** (#167).

The compose problems pane now shows live render diagnostics with **click-to-line**. Probed the oliver CLI first: `render --diagnostics json` emits parse diagnostics to **stderr** as a JSON array with exact source spans (`severity` / `code` / `line` / `column` / `span{start,end}` / `message`), stdout stays pure HTML — verified against the built binary (`unclosed-frontmatter` → line 1 span 0–4; `unclosed-braces` in cooklang → span 11–12).

Changes:
- **Engine (additive only)** — `OliverRenderOptions.diagnostics` emits `--diagnostics json`; new `OliverDiagnostic` (all fields optional, D8-degrading decode); `OliverRenderResult.diagnostics` parsed from the side channel on success, `[]` on any decode failure.
- **Compose seam** — `MarkupRenderService` returns `MarkupRenderResult(html, diagnostics)`; `OliverRenderService` always asks for diagnostics and maps spans → `ComposeDiagnostic` (severity + line + `characterIndex` from `span.start`; unknown severities → warning). Placeholder stays diagnostic-free.
- **Editor** — diagnostics are now **computed from the live preview render** (no longer a host-injected empty array); the problems pane rows are clickable and jump the `NSTextView` selection to the span (span offset, line-start fallback, clamped). Render failures also surface as an error diagnostic — never swallowed.
- **Tests** — new `OliverDiagnosticTests` (decode of both probed shapes, empty/prose degradation, unknown-field tolerance), mapping tests, `--diagnostics json` flag test, preview-test updates for the result type. `ComposeDiagnostic` moved to a Foundation-only file so ContractTests pins it without SwiftUI.

Verified: `SKIP_EMBED_BORIS=1 make build` ✅ · `make test` ✅ (full suite, incl. the new decode/mapping tests) · spike ✅. E2E oliver tests run when `SOLIPSIST_OLIVER_BIN` reaches the test env (they skip otherwise, unchanged behavior).

Gate: a buffer with unclosed front matter shows the `unclosed-frontmatter` warning in the problems pane; clicking jumps the cursor to the span.
