### PR TITLE
feat(compose): incremental highlight repaint (3.2 / #167)

### DIFF
--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -274,8 +274,42 @@ private struct ComposeTextView: NSViewRepresentable {
             isApplying = true
             defer { isApplying = false }
 
-            document.text = textView.string
-            applyHighlight(textView, text: textView.string, language: document.language)
+            let oldText = document.text
+            let newText = textView.string
+            document.text = newText
+            repaintChanged(oldText: oldText, newText: newText, textView: textView, language: document.language)
+        }
+
+        /// Incremental repaint (LATER-3.2): restyle only the changed line(s)
+        /// in place instead of replacing the whole storage, so a keystroke in
+        /// a large buffer no longer repaints (and re-lays-out) off-screen
+        /// text. Full paint still runs on load / language change / program-
+        /// matic sync (`applyHighlight`).
+        private func repaintChanged(
+            oldText: String,
+            newText: String,
+            textView: NSTextView,
+            language: ComposeLanguage
+        ) {
+            let change = ComposeHighlighter.changedRange(old: oldText, new: newText)
+            let nsNew = newText as NSString
+            let clampedLocation = min(max(change.location, 0), nsNew.length)
+            let clampedLength = min(max(change.length, 1), nsNew.length - clampedLocation)
+            // Expand to the full containing line(s) so `^`-anchored rules and
+            // delimiters on the edited line restyle together.
+            let target = nsNew.lineRange(
+                for: NSRange(location: clampedLocation, length: clampedLength)
+            )
+            guard target.length > 0, let storage = textView.textStorage as? NSMutableAttributedString else {
+                lastHighlightedText = newText
+                lastHighlightedLanguage = language
+                return
+            }
+            storage.beginEditing()
+            ComposeHighlighter.repaint(newText, language: language, in: target, storage: storage)
+            storage.endEditing()
+            lastHighlightedText = newText
+            lastHighlightedLanguage = language
         }
 
         func applyHighlight(_ textView: NSTextView, text: String, language: ComposeLanguage, force: Bool = false) {

--- a/Sources/Compose/ComposeHighlighter.swift
+++ b/Sources/Compose/ComposeHighlighter.swift
@@ -86,8 +86,10 @@ enum ComposeHighlighter {
         }
         let maxSuffix = min(nsOld.length - prefix, nsNew.length - prefix)
         var suffix = 0
-        while suffix < maxSuffix,
-              nsOld.character(at: nsOld.length - 1 - suffix) == nsNew.character(at: nsNew.length - 1 - suffix) {
+        while suffix < maxSuffix {
+            let oldIndex = nsOld.length - 1 - suffix
+            let newIndex = nsNew.length - 1 - suffix
+            guard nsOld.character(at: oldIndex) == nsNew.character(at: newIndex) else { break }
             suffix += 1
         }
         return NSRange(location: prefix, length: nsNew.length - prefix - suffix)

--- a/Sources/Compose/ComposeHighlighter.swift
+++ b/Sources/Compose/ComposeHighlighter.swift
@@ -71,6 +71,79 @@ enum ComposeHighlighter {
         }
     }
 
+    // MARK: - Incremental repaint (LATER-3.2)
+
+    /// The minimal changed range between two buffer versions (common prefix
+    /// + common suffix diff). `location`/`length` are UTF-16 offsets in
+    /// `new`. Pure and deterministic for tests.
+    static func changedRange(old: String, new: String) -> NSRange {
+        let nsOld = old as NSString
+        let nsNew = new as NSString
+        let maxPrefix = min(nsOld.length, nsNew.length)
+        var prefix = 0
+        while prefix < maxPrefix, nsOld.character(at: prefix) == nsNew.character(at: prefix) {
+            prefix += 1
+        }
+        let maxSuffix = min(nsOld.length - prefix, nsNew.length - prefix)
+        var suffix = 0
+        while suffix < maxSuffix,
+              nsOld.character(at: nsOld.length - 1 - suffix) == nsNew.character(at: nsNew.length - 1 - suffix) {
+            suffix += 1
+        }
+        return NSRange(location: prefix, length: nsNew.length - prefix - suffix)
+    }
+
+    /// Restyles only `range` against the existing full-buffer paint. Rules
+    /// are matched over the **whole** buffer (anchors and multi-line regions
+    /// need context) but only the intersection with `range` is painted, so a
+    /// keystroke in a large buffer no longer restyles (and re-lays-out) text
+    /// off-screen. Callers wrap the storage edits in begin/endEditing and
+    /// pass the buffer the storage currently holds.
+    static func repaint(
+        _ text: String,
+        language: ComposeLanguage,
+        in range: NSRange,
+        storage: NSMutableAttributedString
+    ) {
+        guard range.location != NSNotFound, range.length > 0,
+              range.upperBound <= (text as NSString).length
+        else { return }
+
+        storage.addAttributes(
+            [.font: baseFont, .foregroundColor: NSColor.labelColor],
+            range: range
+        )
+
+        let full = NSRange(location: 0, length: (text as NSString).length)
+        for rule in rules(for: language) {
+            guard let regex = try? NSRegularExpression(pattern: rule.pattern, options: rule.options) else {
+                continue
+            }
+            regex.enumerateMatches(in: text, range: full) { match, _, _ in
+                guard let match else { return }
+                let hit = NSIntersectionRange(match.range, range)
+                guard hit.length > 0 else { return }
+                paint(rule.style, over: hit, in: storage)
+            }
+        }
+
+        // Front matter is data, not content: paint it last (same rule as
+        // the full paint) when the repaint range touches it.
+        if let frontmatter = ComposeDocument.Frontmatter.parse(in: text) {
+            let lower = text.utf16.distance(from: text.utf16.startIndex, to: frontmatter.range.lowerBound)
+            let upper = text.utf16.distance(from: text.utf16.startIndex, to: frontmatter.range.upperBound)
+            let fmRange = NSRange(location: lower, length: upper - lower)
+            let hit = NSIntersectionRange(fmRange, range)
+            if hit.length > 0 {
+                paint(
+                    ComposeHighlightStyle(color: .systemGray, italic: true),
+                    over: hit,
+                    in: storage
+                )
+            }
+        }
+    }
+
     // MARK: - Palette
 
     private static let heading = ComposeHighlightStyle(color: .systemPurple, bold: true)

--- a/Tests/ContractTests/ComposeHighlighterTests.swift
+++ b/Tests/ContractTests/ComposeHighlighterTests.swift
@@ -214,7 +214,7 @@ final class ComposeHighlighterTests: XCTestCase {
         XCTAssertEqual(color(at: boldOffset, in: storage), NSColor.labelColor)
     }
 
-    func testRepaintFrontmatterLineMatchesFullPaint() throws {
+    func testRepaintFrontmatterLineMatchesFullPaint() {
         let text = "---\ntitle: x\n---\n\n# Body\n"
         let full = ComposeHighlighter.highlight(text, language: .markdown)
         let storage = baseStorage(text)

--- a/Tests/ContractTests/ComposeHighlighterTests.swift
+++ b/Tests/ContractTests/ComposeHighlighterTests.swift
@@ -154,10 +154,90 @@ final class ComposeHighlighterTests: XCTestCase {
         XCTAssertEqual(color(at: 8, in: attributed), NSColor.secondaryLabelColor)
     }
 
+    // MARK: - Incremental repaint (LATER-3.2)
+
+    func testChangedRangeInsertion() {
+        let range = ComposeHighlighter.changedRange(old: "hello world", new: "hello big world")
+        XCTAssertEqual(range.location, 6)
+        XCTAssertEqual(range.length, 4) // "big "
+    }
+
+    func testChangedRangeDeletion() {
+        let range = ComposeHighlighter.changedRange(old: "hello big world", new: "hello world")
+        XCTAssertEqual(range.location, 6)
+        XCTAssertEqual(range.length, 0)
+    }
+
+    func testChangedRangeReplacement() {
+        let range = ComposeHighlighter.changedRange(old: "abc", new: "axc")
+        XCTAssertEqual(range.location, 1)
+        XCTAssertEqual(range.length, 1)
+    }
+
+    func testChangedRangeNoChange() {
+        let range = ComposeHighlighter.changedRange(old: "same", new: "same")
+        XCTAssertEqual(range.location, 4)
+        XCTAssertEqual(range.length, 0)
+    }
+
+    func testRepaintLineMatchesFullPaint() throws {
+        let text = "# Title\n\nSome **bold** and `code`.\n\n# Later\n"
+        let full = ComposeHighlighter.highlight(text, language: .markdown)
+        let storage = baseStorage(text)
+        // Repaint only the bold/code line.
+        let line = try XCTUnwrap(text.range(of: "Some **bold** and `code`."))
+        let location = text.utf16.distance(from: text.startIndex, to: line.lowerBound)
+        let length = text.utf16.distance(from: line.lowerBound, to: line.upperBound)
+        let target = NSRange(location: location, length: length)
+        ComposeHighlighter.repaint(text, language: .markdown, in: target, storage: storage)
+        for offset in 0..<length {
+            XCTAssertEqual(
+                color(at: target.location + offset, in: storage),
+                color(at: target.location + offset, in: full),
+                "offset \(offset)"
+            )
+        }
+        // Bold painted by the incremental path too.
+        let boldStart = try XCTUnwrap(text.range(of: "**bold**"))
+        let boldOffset = text.utf16.distance(from: text.startIndex, to: boldStart.lowerBound) + 2
+        XCTAssertEqual(color(at: boldOffset, in: storage), NSColor.systemRed)
+    }
+
+    func testRepaintLeavesOutsideRangeUntouched() throws {
+        let text = "# Title\n\nSome **bold**.\n"
+        let storage = baseStorage(text)
+        let target = (text as NSString).lineRange(for: NSRange(location: 0, length: 1))
+        ComposeHighlighter.repaint(text, language: .markdown, in: target, storage: storage)
+        // The bold line was never repainted: still plain base color.
+        let boldStart = try XCTUnwrap(text.range(of: "**bold**"))
+        let boldOffset = text.utf16.distance(from: text.startIndex, to: boldStart.lowerBound) + 2
+        XCTAssertEqual(color(at: boldOffset, in: storage), NSColor.labelColor)
+    }
+
+    func testRepaintFrontmatterLineMatchesFullPaint() throws {
+        let text = "---\ntitle: x\n---\n\n# Body\n"
+        let full = ComposeHighlighter.highlight(text, language: .markdown)
+        let storage = baseStorage(text)
+        let target = (text as NSString).lineRange(for: NSRange(location: 0, length: 1))
+        ComposeHighlighter.repaint(text, language: .markdown, in: target, storage: storage)
+        XCTAssertEqual(color(at: 1, in: storage), color(at: 1, in: full))
+        XCTAssertEqual(color(at: 1, in: storage), NSColor.systemGray)
+    }
+
     // MARK: - Helpers
 
     private func color(at location: Int, in attributed: NSAttributedString) -> NSColor? {
         guard location < attributed.length else { return nil }
         return attributed.attribute(.foregroundColor, at: location, effectiveRange: nil) as? NSColor
+    }
+
+    private func baseStorage(_ text: String) -> NSMutableAttributedString {
+        NSMutableAttributedString(
+            string: text,
+            attributes: [
+                .font: NSFont.monospacedSystemFont(ofSize: 13, weight: .regular),
+                .foregroundColor: NSColor.labelColor,
+            ]
+        )
     }
 }


### PR DESCRIPTION
Implements compose-depth slice **3.2 — incremental highlight** (#167).

Per-keystroke edits now restyle only the **changed line(s) in place** instead of replacing the whole `NSTextStorage`, so editing a large buffer no longer repaints — and re-lays-out — text off-screen. The layout manager only re-typesets the edited range.

How:
- **`ComposeHighlighter.changedRange(old:new:)`** — pure common-prefix/suffix diff (tested: insertion/deletion/replacement/no-change).
- **`ComposeHighlighter.repaint(_:language:in:storage:)`** — restyles only `range`: base reset, then each rule is matched over the **whole** buffer (anchors + multi-line regions like fenced code need the context) but only the intersection is painted; front matter paints last when touched, same as the full paint.
- **Editor** — `textDidChange` expands the changed range to its full containing line(s) (so `^`-anchored rules and delimiters restyle together), then calls `repaint` with `beginEditing/endEditing`. Full paint still runs on load, language change, and programmatic sync (`applyHighlight`); `lastHighlighted*` bookkeeping keeps the two paths coherent.

Rule tables and the not-a-parse contract are untouched. Tests pin: the diff function, repaint == full-paint color-for-color within a line, out-of-range isolation, and front-matter lines repainted correctly.

Verified: `SKIP_EMBED_BORIS=1 make build` ✅ · `make test` ✅ (full suite) · spike ✅ · SwiftLint clean.
