### PR TITLE
feat(compose): front-matter form over the closed key set (3.3 / #167)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -114,6 +114,7 @@ targets:
       - path: Sources/Compose/ComposeDocument.swift
       - path: Sources/Compose/ComposeHighlighter.swift
       - path: Sources/Compose/ComposeDiagnostic.swift
+      - path: Sources/Compose/ComposeFrontmatter.swift
       - path: Sources/Compose/MarkupRenderService.swift
       - path: Sources/Compose/ComposePageResolver.swift
       - path: Sources/Compose/OliverRenderService.swift

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -25,6 +25,8 @@ struct ComposeEditorView: View {
     /// Character offset to jump the editor selection to (click-to-line).
     @State private var jumpToCharacter: Int?
     @State private var showPreview = true
+    /// LATER-3.3: leading pane editing the closed front-matter key set.
+    @State private var showFrontmatter = false
     @State private var previewOptions = MarkupRenderOptions()
     @State private var saveError: String?
 
@@ -33,6 +35,10 @@ struct ComposeEditorView: View {
             toolbar
             Divider()
             HSplitView {
+                if showFrontmatter {
+                    ComposeFrontmatterForm(document: document)
+                        .frame(minWidth: 230, idealWidth: 270, maxWidth: 360, maxHeight: .infinity)
+                }
                 ComposeTextView(document: document, jumpToCharacter: jumpToCharacter)
                     .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)
                 if showPreview {
@@ -106,6 +112,12 @@ struct ComposeEditorView: View {
                 Label("Preview", systemImage: "eye")
             }
             .toggleStyle(.button)
+
+            Toggle(isOn: $showFrontmatter) {
+                Label("Front Matter", systemImage: "doc.text.magnifyingglass")
+            }
+            .toggleStyle(.button)
+            .help("Edit the front-matter block (closed key set)")
 
             Menu {
                 previewOptionsContent

--- a/Sources/Compose/ComposeFrontmatter.swift
+++ b/Sources/Compose/ComposeFrontmatter.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+/// The closed front-matter key set, per `boris-frontmatter-1.schema.json`
+/// at the pinned kit (`6b930b7`): nine keys, `additionalProperties: false`
+/// is normative. NOTE: the ROADMAP / capabilities "8-key (…role…)" line is
+/// stale — the schema has no `role`; it has `published_at` and `summary`.
+/// Servings is the one Cooklang-convention exception (authored string).
+enum ComposeFrontmatter {
+    static let scalarKeys = ["id", "title", "parent", "status", "published_at", "summary", "servings"]
+    static let keys = scalarKeys + ["tags", "relations"]
+
+    struct Relation: Equatable, Hashable, Sendable {
+        var kind: String
+        var target: String
+    }
+
+    struct Fields: Equatable, Sendable {
+        var id = ""
+        var title = ""
+        var parent = ""
+        var status = ""
+        var publishedAt = ""
+        var summary = ""
+        var servings = ""
+        var tags: [String] = []
+        var relations: [Relation] = []
+
+        static let empty = Fields()
+    }
+
+    // MARK: - Parse (minimal YAML subset for the closed keys)
+
+    /// Reads the closed keys out of a front-matter payload. Unknown keys are
+    /// ignored (never guessed); both flow (`tags: [a, b]`) and block
+    /// (`tags:\n  - a`) list styles are accepted, matching the corpora.
+    static func parse(payload: String) -> Fields {
+        var fields = Fields()
+        let lines = payload.components(separatedBy: "\n")
+        var lineIndex = 0
+        while lineIndex < lines.count {
+            let raw = lines[lineIndex]
+            guard !raw.isEmpty, !raw.hasPrefix(" "), !raw.hasPrefix("\t"),
+                  let colon = raw.firstIndex(of: ":")
+            else {
+                lineIndex += 1
+                continue
+            }
+            let key = String(raw[..<colon]).trimmingCharacters(in: .whitespaces)
+            let value = String(raw[raw.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+            lineIndex += consume(key: key, value: value, lines: lines, startIndex: lineIndex, fields: &fields)
+        }
+        return fields
+    }
+
+    /// Applies one `key: value` line to the fields, returning the number of
+    /// lines consumed (1 for scalars and flow lists; the whole block for
+    /// block lists).
+    private static func consume(
+        key: String,
+        value: String,
+        lines: [String],
+        startIndex: Int,
+        fields: inout Fields
+    ) -> Int {
+        switch key {
+        case "tags", "relations":
+            return consumeList(key: key, value: value, lines: lines, startIndex: startIndex, fields: &fields)
+        case "id": fields.id = value
+        case "title": fields.title = value
+        case "parent": fields.parent = value
+        case "status": fields.status = value
+        case "published_at": fields.publishedAt = value
+        case "summary": fields.summary = value
+        case "servings": fields.servings = value
+        default:
+            break
+        }
+        return 1
+    }
+
+    /// Handles `tags:` / `relations:` in either flow or block style.
+    private static func consumeList(
+        key: String,
+        value: String,
+        lines: [String],
+        startIndex: Int,
+        fields: inout Fields
+    ) -> Int {
+        if isFlowList(value) {
+            let body = String(value.dropFirst().dropLast())
+            if key == "tags" {
+                fields.tags = flowList(body)
+            } else {
+                fields.relations = flowRelations(body)
+            }
+            return 1
+        }
+        if key == "tags" {
+            fields.tags = parseBlockList(lines, startIndex: startIndex + 1)
+            return fields.tags.count + 1
+        }
+        let result = parseBlockRelations(lines, startIndex: startIndex + 1)
+        fields.relations = result.relations
+        return result.nextIndex - startIndex
+    }
+
+    // MARK: - Apply (overlay write-back)
+
+    /// Rewrites only the closed keys in a payload, preserving every other
+    /// line (unknown keys survive — the schema rejects them, but the form
+    /// never destroys them). Blocks are emitted in canonical block style;
+    /// empty fields omit their key entirely (absence == null per the schema).
+    static func apply(_ fields: Fields, to payload: String) -> String {
+        let lines = payload.isEmpty ? [] : payload.components(separatedBy: "\n")
+        var seen = Set<String>()
+        var out: [String] = []
+        var remaining = lines[...]
+        while let head = remaining.first {
+            remaining = remaining.dropFirst(rewriteLine(head, remaining: remaining, fields: fields, seen: &seen, out: &out))
+        }
+        appendUnseen(fields, seen: seen, into: &out)
+        return out.joined(separator: "\n")
+    }
+
+    /// Rewrites one source line, returning how many lines it consumed.
+    private static func rewriteLine(
+        _ raw: String,
+        remaining: ArraySlice<String>,
+        fields: Fields,
+        seen: inout Set<String>,
+        out: inout [String]
+    ) -> Int {
+        guard
+            !raw.isEmpty,
+            !raw.hasPrefix(" "),
+            !raw.hasPrefix("\t"),
+            let colon = raw.firstIndex(of: ":")
+        else {
+            out.append(raw)
+            return 1
+        }
+        let key = String(raw[..<colon]).trimmingCharacters(in: .whitespaces)
+        guard keys.contains(key) else {
+            out.append(raw)
+            return 1
+        }
+        seen.insert(key)
+        if let block = block(for: key, fields: fields) {
+            out.append(contentsOf: block)
+        }
+        if key == "tags" || key == "relations" {
+            // The key line plus its old block lines.
+            return skipOldBlock(remaining.dropFirst()) + 1
+        }
+        return 1
+    }
+
+    /// Appends blocks for closed keys absent from the source, preserving the
+    /// canonical key order.
+    private static func appendUnseen(_ fields: Fields, seen: Set<String>, into out: inout [String]) {
+        for key in keys where !seen.contains(key) {
+            if let block = block(for: key, fields: fields) {
+                out.append(contentsOf: block)
+            }
+        }
+    }
+
+    // MARK: - Block emission
+
+    static func block(for key: String, fields: Fields) -> [String]? {
+        switch key {
+        case "tags", "relations":
+            return listBlock(key: key, fields: fields)
+        case "id": return scalarBlock(key, fields.id)
+        case "title": return scalarBlock(key, fields.title)
+        case "parent": return scalarBlock(key, fields.parent)
+        case "status": return scalarBlock(key, fields.status)
+        case "published_at": return scalarBlock(key, fields.publishedAt)
+        case "summary": return scalarBlock(key, fields.summary)
+        case "servings": return scalarBlock(key, fields.servings)
+        default:
+            return nil
+        }
+    }
+
+    /// Canonical block emission for the two list keys.
+    private static func listBlock(key: String, fields: Fields) -> [String]? {
+        if key == "tags" {
+            guard !fields.tags.isEmpty else { return nil }
+            return ["tags:"] + fields.tags.map { "  - \($0)" }
+        }
+        guard !fields.relations.isEmpty else { return nil }
+        var lines = ["relations:"]
+        for relation in fields.relations {
+            lines.append("  - kind: \(relation.kind)")
+            lines.append("    target: \(relation.target)")
+        }
+        return lines
+    }
+
+    private static func scalarBlock(_ key: String, _ value: String) -> [String]? {
+        value.isEmpty ? nil : ["\(key): \(value)"]
+    }
+
+    // MARK: - Subset helpers
+
+    /// `[a, b]`-style list value?
+    private static func isFlowList(_ value: String) -> Bool {
+        value.hasPrefix("[") && value.hasSuffix("]")
+    }
+
+    /// Splits a flow list body: `a, b` → `["a", "b"]`.
+    private static func flowList(_ body: String) -> [String] {
+        body.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    /// `kind=target` (the corpus's relations flow pair) → Relation.
+    private static func flowRelations(_ body: String) -> [Relation] {
+        flowList(body).map { pair in
+            let parts = pair.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2 else {
+                return Relation(kind: pair, target: "")
+            }
+            return Relation(
+                kind: String(parts[0]).trimmingCharacters(in: .whitespaces),
+                target: String(parts[1]).trimmingCharacters(in: .whitespaces)
+            )
+        }
+    }
+
+    /// Consumes `- item` lines after a `tags:` key; returns the items.
+    private static func parseBlockList(_ lines: [String], startIndex: Int) -> [String] {
+        var items: [String] = []
+        var index = startIndex
+        while index < lines.count {
+            let item = lines[index].trimmingCharacters(in: .whitespaces)
+            guard item.hasPrefix("-") else { break }
+            items.append(String(item.dropFirst()).trimmingCharacters(in: .whitespaces))
+            index += 1
+        }
+        return items
+    }
+
+    /// Consumes a `relations:` block (`- kind: x` / `target: y` pairs) and
+    /// returns the relations plus the first unconsumed line index.
+    private static func parseBlockRelations(_ lines: [String], startIndex: Int) -> (relations: [Relation], nextIndex: Int) {
+        var relations: [Relation] = []
+        var index = startIndex
+        while index < lines.count {
+            let dashLine = lines[index].trimmingCharacters(in: .whitespaces)
+            guard dashLine.hasPrefix("-") else { break }
+            var kind = ""
+            var target = ""
+            inlineKV(String(dashLine.dropFirst()), into: &kind, target: &target)
+            index += 1
+            while index < lines.count {
+                let sub = lines[index]
+                let trimmed = sub.trimmingCharacters(in: .whitespaces)
+                // Sub-lines are deeper-indented `kind:` / `target:` pairs; a
+                // shallower dash starts the next relation.
+                guard (sub.hasPrefix(" ") || sub.hasPrefix("\t")), !trimmed.hasPrefix("-") else { break }
+                if trimmed.hasPrefix("kind:") { kind = afterColon(trimmed) }
+                if trimmed.hasPrefix("target:") { target = afterColon(trimmed) }
+                index += 1
+            }
+            relations.append(Relation(kind: kind, target: target))
+        }
+        return (relations, index)
+    }
+
+    /// Counts the old block lines (`- item` / indented sub-lines) after a
+    /// replaced `tags:` / `relations:` key.
+    private static func skipOldBlock(_ remaining: ArraySlice<String>) -> Int {
+        var count = 0
+        for raw in remaining {
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("-") || raw.hasPrefix(" ") || raw.hasPrefix("\t") || trimmed.isEmpty {
+                count += 1
+            } else {
+                break
+            }
+        }
+        return count
+    }
+
+    /// Parses `kind: x` / `target: y` off a dash line (`- kind: x`).
+    private static func inlineKV(_ text: String, into kind: inout String, target: inout String) {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("kind:") { kind = afterColon(trimmed) }
+        if trimmed.hasPrefix("target:") { target = afterColon(trimmed) }
+    }
+
+    private static func afterColon(_ line: String) -> String {
+        guard let colon = line.firstIndex(of: ":") else { return "" }
+        return String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Sources/Compose/ComposeFrontmatterForm.swift
+++ b/Sources/Compose/ComposeFrontmatterForm.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+/// The front-matter form (LATER-3.3): edits the closed key set
+/// (`boris-frontmatter-1.schema.json`) and overlays it back onto the
+/// buffer on Apply. Boundary 4 holds — Apply touches only the buffer;
+/// the explicit Save / ⌘S is the only disk writer. Unknown keys in the
+/// payload are preserved (never destroyed by the form).
+struct ComposeFrontmatterForm: View {
+    @Bindable var document: ComposeDocument
+
+    @State private var fields = ComposeFrontmatter.Fields()
+    @State private var fence = "---"
+    /// Payload the form was last synced from, so editor-side edits refresh
+    /// the form but Apply's own write-back does not clobber it.
+    @State private var appliedPayload: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Front Matter", systemImage: "doc.text.magnifyingglass")
+                    .font(.headline)
+                Spacer()
+                Button("Apply") { apply() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .help("Overlay these fields onto the buffer's front matter")
+            }
+            .padding(10)
+            Divider()
+            Form {
+                Section("Identity") {
+                    TextField("ID", text: $fields.id)
+                    TextField("Title", text: $fields.title)
+                    TextField("Parent", text: $fields.parent)
+                    Picker("Status", selection: $fields.status) {
+                        Text("—").tag("")
+                        Text("Draft").tag("draft")
+                        Text("Published").tag("published")
+                        Text("Archived").tag("archived")
+                    }
+                }
+                Section("Publication") {
+                    TextField("Published At", text: $fields.publishedAt)
+                    TextField("Summary", text: $fields.summary)
+                    TextField("Servings", text: $fields.servings)
+                }
+                Section("Tags") {
+                    TextField("Comma-separated", text: tagsText)
+                }
+                Section("Relations") {
+                    ForEach(Array($fields.relations.enumerated()), id: \.offset) { _, $relation in
+                        HStack(spacing: 6) {
+                            TextField("kind", text: $relation.kind)
+                                .frame(minWidth: 70)
+                            TextField("target", text: $relation.target)
+                        }
+                    }
+                    Button("Add Relation") {
+                        fields.relations.append(ComposeFrontmatter.Relation(kind: "", target: ""))
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .font(.callout)
+        }
+        .frame(minWidth: 230, idealWidth: 260)
+        .task(id: document.fileURL) {
+            syncFromBuffer()
+        }
+        .onChange(of: document.text) { _, _ in
+            syncFromBuffer()
+        }
+    }
+
+    private var tagsText: Binding<String> {
+        Binding(
+            get: { fields.tags.joined(separator: ", ") },
+            set: { newValue in
+                fields.tags = newValue
+                    .split(separator: ",")
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty }
+            }
+        )
+    }
+
+    private func syncFromBuffer() {
+        if let frontmatter = document.frontmatter {
+            let payload = frontmatter.payloadString
+            guard payload != appliedPayload else { return }
+            fields = ComposeFrontmatter.parse(payload: payload)
+            fence = frontmatter.kind == .toml ? "+++" : "---"
+            appliedPayload = payload
+        } else if appliedPayload != nil {
+            // The buffer lost its front matter (or never had any on first load).
+            fields = ComposeFrontmatter.Fields()
+            fence = "---"
+            appliedPayload = nil
+        }
+    }
+
+    private func apply() {
+        let current = document.frontmatter?.payloadString ?? ""
+        let newPayload = ComposeFrontmatter.apply(fields, to: current)
+        if document.frontmatter == nil, newPayload.isEmpty {
+            return // nothing to create
+        }
+        let newBlock = "\(fence)\n\(newPayload)\n\(fence)\n"
+        if let frontmatter = document.frontmatter {
+            document.text.replaceSubrange(frontmatter.range, with: newBlock)
+        } else {
+            document.text = newBlock + document.text
+        }
+        appliedPayload = newPayload
+    }
+}

--- a/Tests/ContractTests/ComposeFrontmatterTests.swift
+++ b/Tests/ContractTests/ComposeFrontmatterTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+
+/// Contract for LATER-3.3's front-matter core: the closed 9-key grammar
+/// (`boris-frontmatter-1.schema.json` at pin `6b930b7`), minimal-YAML
+/// parse, and overlay write-back. Pure Foundation — no SwiftUI.
+final class ComposeFrontmatterTests: XCTestCase {
+    // MARK: - Parse
+
+    func testParseClosedKeys() {
+        let payload = """
+        id: pancakes
+        title: Perfect Pancakes
+        parent: breakfast
+        status: published
+        published_at: 2026-08-19
+        summary: Fluffy and fast
+        servings: 4
+        tags: [breakfast, quick]
+        relations: [kind=child, kind=variant]
+        """
+        let fields = ComposeFrontmatter.parse(payload: payload)
+        XCTAssertEqual(fields.id, "pancakes")
+        XCTAssertEqual(fields.title, "Perfect Pancakes")
+        XCTAssertEqual(fields.parent, "breakfast")
+        XCTAssertEqual(fields.status, "published")
+        XCTAssertEqual(fields.publishedAt, "2026-08-19")
+        XCTAssertEqual(fields.summary, "Fluffy and fast")
+        XCTAssertEqual(fields.servings, "4")
+        XCTAssertEqual(fields.tags, ["breakfast", "quick"])
+        XCTAssertEqual(fields.relations.count, 2)
+        XCTAssertEqual(fields.relations[0], ComposeFrontmatter.Relation(kind: "kind", target: "child"))
+        XCTAssertEqual(fields.relations[1], ComposeFrontmatter.Relation(kind: "kind", target: "variant"))
+    }
+
+    func testParseBlockLists() {
+        let payload = """
+        tags:
+          - breakfast
+          - quick
+        relations:
+          - kind: child
+            target: crepes
+          - kind: variant
+            target: american
+        """
+        let fields = ComposeFrontmatter.parse(payload: payload)
+        XCTAssertEqual(fields.tags, ["breakfast", "quick"])
+        XCTAssertEqual(fields.relations.count, 2)
+        XCTAssertEqual(fields.relations[1], ComposeFrontmatter.Relation(kind: "variant", target: "american"))
+    }
+
+    func testParseIgnoresUnknownKeys() {
+        let payload = """
+        id: x
+        custom_thing: keep me
+        nested:
+          a: 1
+        """
+        let fields = ComposeFrontmatter.parse(payload: payload)
+        XCTAssertEqual(fields.id, "x")
+        XCTAssertEqual(fields.title, "")
+        XCTAssertEqual(fields.tags, [])
+    }
+
+    func testParseEmptyPayload() {
+        let fields = ComposeFrontmatter.parse(payload: "")
+        XCTAssertEqual(fields, .empty)
+    }
+
+    // MARK: - Apply
+
+    func testApplyOverlaysOnlyClosedKeysAndPreservesUnknown() {
+        let payload = """
+        id: old
+        custom_thing: untouched
+        status: draft
+        """
+        let fields = ComposeFrontmatter.Fields(id: "new", title: "A Title", status: "published")
+        let result = ComposeFrontmatter.apply(fields, to: payload)
+        XCTAssertTrue(result.contains("id: new"))
+        XCTAssertTrue(result.contains("title: A Title"))
+        XCTAssertTrue(result.contains("status: published"))
+        XCTAssertTrue(result.contains("custom_thing: untouched"))
+        XCTAssertFalse(result.contains("id: old"))
+    }
+
+    func testApplyEmitsBlockLists() {
+        let fields = ComposeFrontmatter.Fields(
+            tags: ["a", "b"],
+            relations: [ComposeFrontmatter.Relation(kind: "child", target: "x")]
+        )
+        let result = ComposeFrontmatter.apply(fields, to: "id: x")
+        XCTAssertTrue(result.contains("tags:"))
+        XCTAssertTrue(result.contains("  - a"))
+        XCTAssertTrue(result.contains("  - b"))
+        XCTAssertTrue(result.contains("relations:"))
+        XCTAssertTrue(result.contains("  - kind: child"))
+        XCTAssertTrue(result.contains("    target: x"))
+    }
+
+    func testApplyOmitsEmptyKeys() {
+        // The form overlays the whole closed set, so a field the user clears
+        // drops its key (absence == null per the schema). `id` survives only
+        // because the form still carries it.
+        let fields = ComposeFrontmatter.Fields(id: "x")
+        let result = ComposeFrontmatter.apply(fields, to: "id: x\nsummary: keep")
+        XCTAssertEqual(result, "id: x")
+        XCTAssertFalse(result.contains("title:"))
+        XCTAssertFalse(result.contains("published_at:"))
+        XCTAssertFalse(result.contains("summary:")) // owned key, emptied
+    }
+
+    func testApplyCreatesBlockFromScratch() {
+        let fields = ComposeFrontmatter.Fields(id: "fresh", tags: ["new"])
+        let result = ComposeFrontmatter.apply(fields, to: "")
+        XCTAssertEqual(
+            result,
+            "id: fresh\ntags:\n  - new"
+        )
+    }
+
+    func testApplyRoundTripsParse() {
+        let payload = """
+        id: pancakes
+        title: Perfect Pancakes
+        tags: [breakfast, quick]
+        relations: [kind=child target=crepes]
+        """
+        let fields = ComposeFrontmatter.parse(payload: payload)
+        let rewritten = ComposeFrontmatter.apply(fields, to: payload)
+        let reparsed = ComposeFrontmatter.parse(payload: rewritten)
+        XCTAssertEqual(fields, reparsed)
+    }
+}


### PR DESCRIPTION
## Slice 3.3 / #167: front-matter form (compose depth)

The **Front Matter** toolbar toggle in the compose window opens a leading form pane over the **closed nine-key grammar** (`boris-frontmatter-1.schema.json` at pin `6b930b7`): `id, title, parent, status, published_at, summary, servings, tags, relations`.

### What lands
- `Sources/Compose/ComposeFrontmatter.swift` — Foundation-only core: minimal-YAML parse (flow *and* block list styles, matching the corpora) + overlay write-back. Unknown keys survive; blocks emit in canonical block style; empty fields drop their key (`absence == null` per the schema).
- `Sources/Compose/ComposeFrontmatterForm.swift` — the SwiftUI form (Identity / Publication / Tags / Relations sections), synced from the buffer on open and on editor edits; **Apply** overlays onto the buffer only.
- `ComposeEditorView` — `showFrontmatter` state, the toolbar toggle, and the leading HSplitView pane.
- `Tests/ContractTests/ComposeFrontmatterTests.swift` — 9 tests pinning the grammar: closed-key parse, block/flow lists, unknown-key tolerance, overlay preserving unknown keys, block emission, empty-key omission, create-from-scratch, and a parse→apply→reparse round trip.

### Fences honored
- **Boundary 4**: Apply touches only the buffer; the explicit Save / ⌘S is the only disk writer.
- **No Swift parse reimplementation**: the core is a subset reader/writer for the closed keys only — unknown keys are ignored on read, preserved on write.
- **Schema-authority**: key set from the pinned kit's schema, not the stale ROADMAP "8-key" line (noted in the file doc).

### Verified
`make build` ✅ · full ContractTests suite (274 tests, 0 failures) ✅ · SwiftLint 0 violations ✅ · SwiftFormat clean ✅ · spike scheme ✅.
