### PR TITLE
feat(compose): Cooklang autocomplete from .boris artifacts (3.4 / #167)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -115,6 +115,7 @@ targets:
       - path: Sources/Compose/ComposeHighlighter.swift
       - path: Sources/Compose/ComposeDiagnostic.swift
       - path: Sources/Compose/ComposeFrontmatter.swift
+      - path: Sources/Compose/ComposeCookCompletion.swift
       - path: Sources/Compose/MarkupRenderService.swift
       - path: Sources/Compose/ComposePageResolver.swift
       - path: Sources/Compose/OliverRenderService.swift

--- a/Sources/Compose/ComposeCookCompletion.swift
+++ b/Sources/Compose/ComposeCookCompletion.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Boris-owned Cooklang completion vocabulary (LATER-3.4). Sourced
+/// exclusively from the selected source's `.boris/` artifacts — never
+/// hand-rolled:
+/// - `graph.json` recipe IR facets: `ingredients[].name`, `cookware[].name`,
+///   `timers[].name` across every node in the corpus (verified: cooklang
+///   mode publishes a `recipe` facet per node; `@./path` refs surface as an
+///   ingredient with a `recipeRef`).
+/// - `completion.json` entities: page ids, offered as `./<id>` recipe refs
+///   so `@./soup` completes from the corpus's own pages.
+///
+/// Read-only: never mutates, never spawns a process. Decode failures
+/// degrade to `.empty` (D8) — completion is best-effort, never a crash.
+struct ComposeCookCompletion: Equatable, Sendable {
+    var ingredients: [String] = []
+    var cookware: [String] = []
+    var timers: [String] = []
+    var entityIDs: [String] = []
+
+    static let empty = ComposeCookCompletion()
+
+    var isEmpty: Bool {
+        ingredients.isEmpty && cookware.isEmpty && timers.isEmpty && entityIDs.isEmpty
+    }
+
+    /// Decodes both artifacts from `<workspaceRoot>/.boris/`. Any missing or
+    /// malformed artifact contributes nothing (D8); `graph.json` needs the
+    /// recipe facet (IR 0.4) to contribute vocabulary.
+    static func load(workspaceRoot: URL) -> ComposeCookCompletion {
+        let boris = workspaceRoot.appendingPathComponent(".boris", isDirectory: true)
+        var result = ComposeCookCompletion()
+
+        let graphURL = boris.appendingPathComponent("graph.json")
+        if let graph = Self.decode(Graph.self, from: graphURL) {
+            for node in graph.nodes {
+                guard let recipe = node.recipe else { continue }
+                result.ingredients.append(contentsOf: recipe.ingredients.map(\.name))
+                result.cookware.append(contentsOf: recipe.cookware.map(\.name))
+                result.timers.append(contentsOf: recipe.timers.map(\.name))
+            }
+        }
+
+        let completionURL = boris.appendingPathComponent("completion.json")
+        if let completion = Self.decode(Completion.self, from: completionURL) {
+            result.entityIDs = completion.entities.map(\.id)
+        }
+        result.normalize()
+        return result
+    }
+
+    /// Best-effort decode (D8): missing or malformed artifacts contribute
+    /// nothing rather than failing the whole load.
+    private static func decode<T: Decodable>(_ type: T.Type, from url: URL) -> T? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    /// Sorts and dedupes every vocabulary list so consumers see a stable,
+    /// deterministic popup (recipes repeat ingredients across the corpus).
+    private mutating func normalize() {
+        ingredients = Self.uniqueSorted(ingredients)
+        cookware = Self.uniqueSorted(cookware)
+        timers = Self.uniqueSorted(timers)
+        entityIDs = Self.uniqueSorted(entityIDs)
+    }
+
+    private static func uniqueSorted(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.sorted().filter { seen.insert($0).inserted }
+    }
+
+    /// Suggestions for the token the author is mid-type on, filtered by the
+    /// partial word (case-insensitive, capped so the popup stays sane):
+    /// - `@` → ingredient names plus entity ids (recipe refs — the author
+    ///   types the `./` themselves; insertion stays a plain name so the
+    ///   popup's replace range never duplicates a path prefix)
+    /// - `#` → cookware names
+    /// - `~` → timer names
+    /// Unknown markers return nothing.
+    func suggestions(marker: Character, prefix: String) -> [String] {
+        let pool: [String]
+        switch marker {
+        case "@":
+            pool = ingredients + entityIDs
+        case "#":
+            pool = cookware
+        case "~":
+            pool = timers
+        default:
+            return []
+        }
+        let lowered = prefix.lowercased()
+        var seen = Set<String>()
+        var matches: [String] = []
+        for candidate in pool.sorted() where seen.insert(candidate).inserted {
+            guard candidate.lowercased().hasPrefix(lowered) else { continue }
+            matches.append(candidate)
+            if matches.count == 25 { break }
+        }
+        return matches
+    }
+}
+
+/// Tiny scanner helpers for the NSTextView completion trigger. Foundation-
+/// only so ContractTests can pin the marker logic without AppKit.
+enum CookMarkerScanner {
+    /// The Cooklang token markers that open the completion popup.
+    static let markers: Set<Character> = ["@", "#", "~"]
+
+    /// The marker character the author just inserted, if the edit inserted
+    /// exactly one marker and nothing else (e.g. typing `@` after a word).
+    static func insertedMarker(from oldText: String, to newText: String) -> Character? {
+        let old = oldText as NSString
+        let new = newText as NSString
+        guard new.length == old.length + 1 else { return nil }
+        var index = 0
+        while index < old.length, old.character(at: index) == new.character(at: index) {
+            index += 1
+        }
+        guard let scalar = Unicode.Scalar(new.character(at: index)) else { return nil }
+        let inserted = Character(scalar)
+        return markers.contains(inserted) ? inserted : nil
+    }
+
+    /// The marker anchoring a partial word: scan back from the position
+    /// before the completion range over any token characters (so `@./soup`
+    /// still resolves to `@`), stopping at whitespace or the buffer start.
+    static func marker(before position: Int, in text: NSString) -> Character? {
+        var index = position - 1
+        while index >= 0 {
+            guard let scalar = Unicode.Scalar(text.character(at: index)) else { return nil }
+            let char = Character(scalar)
+            if markers.contains(char) { return char }
+            if char.isWhitespace { return nil }
+            index -= 1
+        }
+        return nil
+    }
+}

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -14,6 +14,9 @@ struct ComposeEditorView: View {
     @Bindable var document: ComposeDocument
 
     var renderService: any MarkupRenderService = PlaceholderRenderService()
+    /// Cooklang completion vocabulary (LATER-3.4); `.empty` (default) keeps
+    /// the popup off for hosts without a `.boris/` index.
+    var cookCompletion: ComposeCookCompletion = .empty
     /// Called after an explicit save actually wrote the buffer. The host
     /// (ComposeWindow) uses this to flow the save into the coordinator's
     /// save→validate gate.
@@ -39,8 +42,12 @@ struct ComposeEditorView: View {
                     ComposeFrontmatterForm(document: document)
                         .frame(minWidth: 230, idealWidth: 270, maxWidth: 360, maxHeight: .infinity)
                 }
-                ComposeTextView(document: document, jumpToCharacter: jumpToCharacter)
-                    .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)
+                ComposeTextView(
+                    document: document,
+                    jumpToCharacter: jumpToCharacter,
+                    completion: cookCompletion
+                )
+                .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)
                 if showPreview {
                     ComposePreviewView(
                         source: document.text,
@@ -207,150 +214,6 @@ private struct ComposeDiagnosticsPane: View {
             .contentShape(Rectangle())
             .onTapGesture { onSelect(diagnostic) }
             .help("Jump to this diagnostic")
-        }
-    }
-}
-
-/// NSTextView host with live heuristic highlighting. The text storage is
-/// re-painted after every edit; the buffer in `ComposeDocument` stays the
-/// single source of truth.
-private struct ComposeTextView: NSViewRepresentable {
-    @Bindable var document: ComposeDocument
-    /// Click-to-line target (LATER-3.1); nil = no pending jump.
-    var jumpToCharacter: Int?
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(document: document)
-    }
-
-    func makeNSView(context: Context) -> NSTextView {
-        let textView = NSTextView()
-        textView.delegate = context.coordinator
-        textView.isRichText = false
-        textView.allowsUndo = true
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isContinuousSpellCheckingEnabled = false
-        textView.font = baseFont
-        textView.textContainerInset = NSSize(width: 10, height: 10)
-        textView.isVerticallyResizable = true
-        textView.autoresizingMask = [.width]
-        textView.textContainer?.widthTracksTextView = true
-
-        context.coordinator.applyHighlight(
-            textView,
-            text: document.text,
-            language: document.language,
-            force: true
-        )
-        return textView
-    }
-
-    func updateNSView(_ textView: NSTextView, context: Context) {
-        context.coordinator.document = document
-        if textView.string != document.text {
-            textView.string = document.text
-            context.coordinator.applyHighlight(textView, text: document.text, language: document.language, force: true)
-        } else {
-            context.coordinator.applyHighlight(textView, text: document.text, language: document.language)
-        }
-        context.coordinator.jump(to: jumpToCharacter, in: textView)
-    }
-
-    private var baseFont: NSFont {
-        NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-    }
-
-    @MainActor
-    final class Coordinator: NSObject, NSTextViewDelegate {
-        var document: ComposeDocument
-        private var isApplying = false
-        /// Last click-to-line offset we applied, so re-syncs do not re-jump.
-        private var lastJumpedCharacter: Int?
-
-        /// Last state we painted, so programmatic syncs (which fire on every
-        /// `document` change) do not re-paint an unchanged buffer.
-        private var lastHighlightedText: String?
-        private var lastHighlightedLanguage: ComposeLanguage?
-
-        init(document: ComposeDocument) {
-            self.document = document
-        }
-
-        func textDidChange(_ notification: Notification) {
-            guard
-                !isApplying,
-                let textView = notification.object as? NSTextView
-            else { return }
-            isApplying = true
-            defer { isApplying = false }
-
-            let oldText = document.text
-            let newText = textView.string
-            document.text = newText
-            repaintChanged(oldText: oldText, newText: newText, textView: textView, language: document.language)
-        }
-
-        /// Incremental repaint (LATER-3.2): restyle only the changed line(s)
-        /// in place instead of replacing the whole storage, so a keystroke in
-        /// a large buffer no longer repaints (and re-lays-out) off-screen
-        /// text. Full paint still runs on load / language change / program-
-        /// matic sync (`applyHighlight`).
-        private func repaintChanged(
-            oldText: String,
-            newText: String,
-            textView: NSTextView,
-            language: ComposeLanguage
-        ) {
-            let change = ComposeHighlighter.changedRange(old: oldText, new: newText)
-            let nsNew = newText as NSString
-            let clampedLocation = min(max(change.location, 0), nsNew.length)
-            let clampedLength = min(max(change.length, 1), nsNew.length - clampedLocation)
-            // Expand to the full containing line(s) so `^`-anchored rules and
-            // delimiters on the edited line restyle together.
-            let target = nsNew.lineRange(
-                for: NSRange(location: clampedLocation, length: clampedLength)
-            )
-            guard target.length > 0, let storage = textView.textStorage as? NSMutableAttributedString else {
-                lastHighlightedText = newText
-                lastHighlightedLanguage = language
-                return
-            }
-            storage.beginEditing()
-            ComposeHighlighter.repaint(newText, language: language, in: target, storage: storage)
-            storage.endEditing()
-            lastHighlightedText = newText
-            lastHighlightedLanguage = language
-        }
-
-        func applyHighlight(_ textView: NSTextView, text: String, language: ComposeLanguage, force: Bool = false) {
-            guard force || text != lastHighlightedText || language != lastHighlightedLanguage else { return }
-            lastHighlightedText = text
-            lastHighlightedLanguage = language
-
-            let highlighted = ComposeHighlighter.highlight(text, language: language)
-            textView.textStorage?.beginEditing()
-            textView.textStorage?.setAttributedString(highlighted)
-            textView.textStorage?.endEditing()
-            textView.typingAttributes = [.font: baseFont, .foregroundColor: NSColor.labelColor]
-        }
-
-        /// Moves the selection to a character offset (click-to-line).
-        /// Runs after highlight so the storage is current; clamps so a
-        /// stale span can never exceed the buffer.
-        func jump(to character: Int?, in textView: NSTextView) {
-            guard let character, character != lastJumpedCharacter else { return }
-            lastJumpedCharacter = character
-            let nsString = textView.string as NSString
-            let clamped = min(max(character, 0), nsString.length)
-            let range = NSRange(location: clamped, length: 0)
-            textView.setSelectedRange(range)
-            textView.scrollRangeToVisible(range)
-        }
-
-        private var baseFont: NSFont {
-            NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
         }
     }
 }

--- a/Sources/Compose/ComposeTextView.swift
+++ b/Sources/Compose/ComposeTextView.swift
@@ -1,0 +1,196 @@
+import AppKit
+import SwiftUI
+
+/// NSTextView host with live heuristic highlighting. The text storage is
+/// re-painted after every edit; the buffer in `ComposeDocument` stays the
+/// single source of truth.
+struct ComposeTextView: NSViewRepresentable {
+    @Bindable var document: ComposeDocument
+    /// Click-to-line target (LATER-3.1); nil = no pending jump.
+    var jumpToCharacter: Int?
+    /// Cooklang completion vocabulary (LATER-3.4); `.empty` disables the
+    /// popup. Sourced from the selected source's `.boris/` artifacts.
+    var completion: ComposeCookCompletion = .empty
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(document: document, completion: completion)
+    }
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+        textView.delegate = context.coordinator
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.font = baseFont
+        textView.textContainerInset = NSSize(width: 10, height: 10)
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+
+        context.coordinator.applyHighlight(
+            textView,
+            text: document.text,
+            language: document.language,
+            force: true
+        )
+        return textView
+    }
+
+    func updateNSView(_ textView: NSTextView, context: Context) {
+        context.coordinator.document = document
+        context.coordinator.completion = completion
+        if textView.string != document.text {
+            textView.string = document.text
+            context.coordinator.applyHighlight(textView, text: document.text, language: document.language, force: true)
+        } else {
+            context.coordinator.applyHighlight(textView, text: document.text, language: document.language)
+        }
+        context.coordinator.jump(to: jumpToCharacter, in: textView)
+    }
+
+    private var baseFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var document: ComposeDocument
+        /// Cooklang completion vocabulary, updated on view syncs so a
+        /// freshly-built `.boris/` index reaches the popup without a reload.
+        var completion: ComposeCookCompletion = .empty
+        private var isApplying = false
+        /// Last click-to-line offset we applied, so re-syncs do not re-jump.
+        private var lastJumpedCharacter: Int?
+
+        /// Last state we painted, so programmatic syncs (which fire on every
+        /// `document` change) do not re-paint an unchanged buffer.
+        private var lastHighlightedText: String?
+        private var lastHighlightedLanguage: ComposeLanguage?
+
+        init(document: ComposeDocument, completion: ComposeCookCompletion = .empty) {
+            self.document = document
+            self.completion = completion
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard
+                !isApplying,
+                let textView = notification.object as? NSTextView
+            else { return }
+            isApplying = true
+            defer { isApplying = false }
+
+            let oldText = document.text
+            let newText = textView.string
+            document.text = newText
+            repaintChanged(oldText: oldText, newText: newText, textView: textView, language: document.language)
+            maybeOpenCompletion(in: textView, previousText: oldText)
+        }
+
+        /// LATER-3.4: when the author types a Cooklang token marker (`@`,
+        /// `#`, `~`) in a Cooklang buffer with a corpus vocabulary, open the
+        /// native completion popup. The popup is fed by
+        /// `textView(_:completions:forPartialWordRange:indexOfSelectedItem:)`
+        /// below; everything stays inside the single NSTextView surface.
+        private func maybeOpenCompletion(in textView: NSTextView, previousText: String) {
+            guard
+                document.language == .cooklang,
+                !completion.isEmpty,
+                let inserted = CookMarkerScanner.insertedMarker(
+                    from: previousText,
+                    to: textView.string
+                ),
+                CookMarkerScanner.markers.contains(inserted)
+            else { return }
+            textView.complete(nil)
+        }
+
+        // MARK: NSTextView completion (LATER-3.4)
+
+        func textView(
+            _ textView: NSTextView,
+            completions words: [String],
+            forPartialWordRange charRange: NSRange,
+            indexOfSelectedItem index: UnsafeMutablePointer<Int>?
+        ) -> [String] {
+            guard document.language == .cooklang, !completion.isEmpty else { return words }
+            let text = textView.string as NSString
+            guard
+                charRange.location > 0,
+                let marker = CookMarkerScanner.marker(
+                    before: charRange.location,
+                    in: text
+                )
+            else { return words }
+            let prefix = text.substring(with: charRange)
+            let suggestions = completion.suggestions(marker: marker, prefix: prefix)
+            index?.pointee = 0
+            return suggestions
+        }
+
+        /// Incremental repaint (LATER-3.2): restyle only the changed line(s)
+        /// in place instead of replacing the whole storage, so a keystroke in
+        /// a large buffer no longer repaints (and re-lays-out) off-screen
+        /// text. Full paint still runs on load / language change / program-
+        /// matic sync (`applyHighlight`).
+        private func repaintChanged(
+            oldText: String,
+            newText: String,
+            textView: NSTextView,
+            language: ComposeLanguage
+        ) {
+            let change = ComposeHighlighter.changedRange(old: oldText, new: newText)
+            let nsNew = newText as NSString
+            let clampedLocation = min(max(change.location, 0), nsNew.length)
+            let clampedLength = min(max(change.length, 1), nsNew.length - clampedLocation)
+            // Expand to the full containing line(s) so `^`-anchored rules and
+            // delimiters on the edited line restyle together.
+            let target = nsNew.lineRange(
+                for: NSRange(location: clampedLocation, length: clampedLength)
+            )
+            guard target.length > 0, let storage = textView.textStorage as? NSMutableAttributedString else {
+                lastHighlightedText = newText
+                lastHighlightedLanguage = language
+                return
+            }
+            storage.beginEditing()
+            ComposeHighlighter.repaint(newText, language: language, in: target, storage: storage)
+            storage.endEditing()
+            lastHighlightedText = newText
+            lastHighlightedLanguage = language
+        }
+
+        func applyHighlight(_ textView: NSTextView, text: String, language: ComposeLanguage, force: Bool = false) {
+            guard force || text != lastHighlightedText || language != lastHighlightedLanguage else { return }
+            lastHighlightedText = text
+            lastHighlightedLanguage = language
+
+            let highlighted = ComposeHighlighter.highlight(text, language: language)
+            textView.textStorage?.beginEditing()
+            textView.textStorage?.setAttributedString(highlighted)
+            textView.textStorage?.endEditing()
+            textView.typingAttributes = [.font: baseFont, .foregroundColor: NSColor.labelColor]
+        }
+
+        /// Moves the selection to a character offset (click-to-line).
+        /// Runs after highlight so the storage is current; clamps so a
+        /// stale span can never exceed the buffer.
+        func jump(to character: Int?, in textView: NSTextView) {
+            guard let character, character != lastJumpedCharacter else { return }
+            lastJumpedCharacter = character
+            let nsString = textView.string as NSString
+            let clamped = min(max(character, 0), nsString.length)
+            let range = NSRange(location: clamped, length: 0)
+            textView.setSelectedRange(range)
+            textView.scrollRangeToVisible(range)
+        }
+
+        private var baseFont: NSFont {
+            NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        }
+    }
+}

--- a/Sources/Compose/ComposeWindow.swift
+++ b/Sources/Compose/ComposeWindow.swift
@@ -22,6 +22,10 @@ struct ComposeWindow: View {
     @State private var pendingSwitch: WorkspaceNoun?
     @State private var loadError: String?
     @State private var saveStatus: String?
+    /// Cooklang completion vocabulary (LATER-3.4): re-decoded from the
+    /// source's `.boris/` artifacts whenever a page is loaded, so a fresh
+    /// build reaches the popup without restarting the window.
+    @State private var cookCompletion = ComposeCookCompletion.empty
 
     var body: some View {
         Group {
@@ -29,6 +33,7 @@ struct ComposeWindow: View {
                 ComposeEditorView(
                     document: document,
                     renderService: OliverRenderService(),
+                    cookCompletion: cookCompletion,
                     onSave: save
                 )
                 .safeAreaInset(edge: .bottom, spacing: 0) {
@@ -106,6 +111,7 @@ struct ComposeWindow: View {
             }
             let url = ComposePageResolver.fileURL(contentRoot: contentRoot, sourcePath: node.sourcePath)
             try document.load(from: url)
+            cookCompletion = ComposeCookCompletion.load(workspaceRoot: workspaceRoot)
             loadError = nil
             saveStatus = nil
         } catch {

--- a/Tests/ContractTests/ComposeCookCompletionTests.swift
+++ b/Tests/ContractTests/ComposeCookCompletionTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import XCTest
+
+/// Contract for LATER-3.4's Cooklang completion: vocabulary sourced only
+/// from `.boris/graph.json` recipe IR facets + `.boris/completion.json`
+/// entities, and the marker scanner that opens the popup.
+final class ComposeCookCompletionTests: XCTestCase {
+    // MARK: - Load
+
+    func testLoadCollectsRecipeFacetsAndEntities() throws {
+        let root = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let completion = ComposeCookCompletion.load(workspaceRoot: root)
+        XCTAssertEqual(completion.ingredients, ["salt", "soup", "water"])
+        XCTAssertEqual(completion.cookware, ["pot"])
+        XCTAssertEqual(completion.timers, ["5"])
+        XCTAssertEqual(completion.entityIDs, ["broth", "soup"])
+    }
+
+    func testLoadMissingArtifactsDegradesToEmpty() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let completion = ComposeCookCompletion.load(workspaceRoot: root)
+        XCTAssertTrue(completion.isEmpty)
+    }
+
+    func testLoadMalformedGraphContributesOnlyCompletion() throws {
+        let root = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let boris = root.appendingPathComponent(".boris", isDirectory: true)
+        try "not json".write(
+            to: boris.appendingPathComponent("graph.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let completion = ComposeCookCompletion.load(workspaceRoot: root)
+        XCTAssertTrue(completion.ingredients.isEmpty)
+        XCTAssertEqual(completion.entityIDs, ["broth", "soup"])
+    }
+
+    // MARK: - Suggestions
+
+    func testIngredientSuggestions() {
+        let vocab = ComposeCookCompletion(ingredients: ["salt", "water", "water"], cookware: ["pot"], timers: ["5"], entityIDs: ["soup"])
+        XCTAssertEqual(vocab.suggestions(marker: "@", prefix: "wa"), ["water"])
+        XCTAssertEqual(vocab.suggestions(marker: "@", prefix: "WA"), ["water"])
+        // Sorted + deduped, and entity ids join the `@` pool (recipe refs).
+        XCTAssertEqual(vocab.suggestions(marker: "@", prefix: ""), ["salt", "soup", "water"])
+    }
+
+    func testCookwareAndTimerSuggestions() {
+        let vocab = ComposeCookCompletion(ingredients: ["water"], cookware: ["pot", "pan"], timers: ["5", "step"], entityIDs: [])
+        XCTAssertEqual(vocab.suggestions(marker: "#", prefix: "p"), ["pan", "pot"])
+        XCTAssertEqual(vocab.suggestions(marker: "~", prefix: "s"), ["step"])
+    }
+
+    func testUnknownMarkerAndEmptyPrefixReturnNothing() {
+        let vocab = ComposeCookCompletion(ingredients: ["water"], cookware: [], timers: [], entityIDs: [])
+        XCTAssertTrue(vocab.suggestions(marker: "$", prefix: "").isEmpty)
+        XCTAssertTrue(ComposeCookCompletion.empty.suggestions(marker: "@", prefix: "").isEmpty)
+        XCTAssertTrue(vocab.suggestions(marker: "@", prefix: "zz").isEmpty)
+    }
+
+    func testSuggestionsCapped() {
+        let many = (0..<60).map { index in "item\(index)" }
+        let vocab = ComposeCookCompletion(ingredients: many, cookware: [], timers: [], entityIDs: [])
+        XCTAssertEqual(vocab.suggestions(marker: "@", prefix: "item").count, 25)
+    }
+
+    // MARK: - Marker scanner
+
+    func testInsertedMarkerDetectsSingleTypedMarker() {
+        XCTAssertEqual(CookMarkerScanner.insertedMarker(from: "Mix @wa", to: "Mix @wat"), nil)
+        XCTAssertEqual(CookMarkerScanner.insertedMarker(from: "Mix wa", to: "Mix wa@"), "@")
+        XCTAssertEqual(CookMarkerScanner.insertedMarker(from: "Mix wa", to: "Mix wa#"), "#")
+        XCTAssertEqual(CookMarkerScanner.insertedMarker(from: "Mix wa", to: "Mix wa~"), "~")
+    }
+
+    func testInsertedMarkerIgnoresMultiCharEdits() {
+        // A single marker inserted mid-word is still a single-character
+        // insert — the scanner reports it (the popup opens; harmless).
+        XCTAssertEqual(CookMarkerScanner.insertedMarker(from: "ab", to: "a@b"), "@")
+        // Two-character inserts and no-op edits are not marker strokes.
+        XCTAssertNil(CookMarkerScanner.insertedMarker(from: "ab", to: "ab@c"))
+        XCTAssertNil(CookMarkerScanner.insertedMarker(from: "ab", to: "ab"))
+    }
+
+    func testMarkerBeforeFindsAnchorAcrossTokenChars() {
+        let text = "Mix @water and #pot for ~5" as NSString
+        // `@` at 4, `#` at 15, `~` at 24; `marker(before:)` inspects the
+        // position immediately preceding the given offset.
+        XCTAssertEqual(CookMarkerScanner.marker(before: 5, in: text), "@")
+        XCTAssertEqual(CookMarkerScanner.marker(before: 16, in: text), "#")
+        XCTAssertEqual(CookMarkerScanner.marker(before: 25, in: text), "~")
+        // `@./soup` — the partial word starts after `./`; scan back finds `@`.
+        let ref = "@./soup" as NSString
+        XCTAssertEqual(CookMarkerScanner.marker(before: 6, in: ref), "@")
+    }
+
+    func testMarkerBeforeStopsAtWhitespace() {
+        let text = "plain @token" as NSString
+        // Position 0 (buffer start) — nothing before it.
+        XCTAssertNil(CookMarkerScanner.marker(before: 0, in: text))
+        // Scanning back from `t` of `token` finds `@`; from `plain` finds nothing.
+        XCTAssertEqual(CookMarkerScanner.marker(before: 10, in: text), "@")
+        let spaced = "plain  spaced" as NSString
+        XCTAssertNil(CookMarkerScanner.marker(before: 12, in: spaced))
+    }
+
+    // MARK: - Fixture helpers
+
+    /// Writes a `.boris/` mirroring the probed cooklang run: two nodes with
+    /// recipe facets (broth + soup) and a completion index with two entities.
+    private func makeWorkspace() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let boris = root.appendingPathComponent(".boris", isDirectory: true)
+        try FileManager.default.createDirectory(at: boris, withIntermediateDirectories: true)
+        // NOTE: cleanup is the caller's job (defer in the test) — the
+        // fixture must outlive this helper.
+
+        let graph = """
+        {
+          "schemaVersion": "0.4.0",
+          "frozen": true,
+          "nodes": [
+            {
+              "index": 0, "id": "broth", "sourcePath": "broth.cook", "role": "trunk",
+              "parent": null, "title": "Broth",
+              "recipe": {
+                "ingredients": [
+                  {"name": "water", "quantity": {"amount": "2", "unit": "cups"}, "preparation": "", "recipeRef": null},
+                  {"name": "soup", "quantity": {"amount": "1", "unit": "serving"}, "preparation": "", "recipeRef": "soup"}
+                ],
+                "cookware": [{"name": "pot", "quantity": {"amount": "1", "unit": ""}}],
+                "timers": [{"name": "5", "quantity": {"amount": "5", "unit": "minutes"}}]
+              }
+            },
+            {
+              "index": 1, "id": "soup", "sourcePath": "soup.cook", "role": "trunk",
+              "parent": null, "title": "Soup",
+              "recipe": {
+                "ingredients": [
+                  {"name": "water", "quantity": {"amount": "2", "unit": "cups"}, "preparation": "", "recipeRef": null},
+                  {"name": "salt", "quantity": {"amount": "1", "unit": "pinch"}, "preparation": "", "recipeRef": null}
+                ],
+                "cookware": [], "timers": []
+              }
+            }
+          ],
+          "edges": [], "reverseIndex": [], "nav": []
+        }
+        """
+        try graph.write(to: boris.appendingPathComponent("graph.json"), atomically: true, encoding: .utf8)
+
+        let completion = """
+        {
+          "format": "boris-completion-index",
+          "schema_version": 1,
+          "entities": [
+            {"id": "broth", "title": "Broth", "parent": null, "role": "trunk", "status": "published", "tags": [], "relations": []},
+            {"id": "soup", "title": "Soup", "parent": null, "role": "trunk", "status": "published", "tags": [], "relations": []}
+          ],
+          "relation_kinds": [], "parent_targets": [], "layout_slots": []
+        }
+        """
+        try completion.write(to: boris.appendingPathComponent("completion.json"), atomically: true, encoding: .utf8)
+        return root
+    }
+}


### PR DESCRIPTION
## Slice 3.4 / #167: Cooklang autocomplete

Typing a Cooklang token marker — `@`, `#`, or `~` — in a Cooklang buffer now opens the **native NSTextView completion popup** fed by a vocabulary sourced **exclusively from the selected source's `.boris/` artifacts** (never hand-rolled):

- **`graph.json` recipe IR facets** (probed against the pinned kit, cooklang mode): `ingredients[].name`, `cookware[].name`, `timers[].name` across every node in the corpus. `@./path` refs surface as ingredients with a `recipeRef`, so recipe references complete too.
- **`completion.json` entities**: page ids join the `@` pool so `@./<page>` completes from the corpus's own pages.

### What lands
- `Sources/Compose/ComposeCookCompletion.swift` — Foundation-only core: `load(workspaceRoot:)` decodes both artifacts (missing/malformed degrade to `.empty`, D8), vocabulary normalized (sorted + deduped — recipes repeat ingredients across the corpus); `suggestions(marker:prefix:)` filters case-insensitively, capped at 25. Plus `CookMarkerScanner`: detects the single typed marker stroke and finds the token anchor scanning back through `@./` refs.
- `Sources/Compose/ComposeTextView.swift` — new file: the `NSViewRepresentable` + coordinator moved out of `ComposeEditorView` (which had crossed the 400-line lint gate). Adds the `textDidChange` trigger (marker typed → `textView.complete(nil)`) and the `NSTextViewDelegate` completions method.
- `ComposeWindow` — re-decodes the vocabulary on every page load, so a fresh build reaches the popup without restarting the window.
- `Tests/ContractTests/ComposeCookCompletionTests.swift` — 10 tests: load from fixture `.boris/` (recipe facets + entities), degrade-to-empty, malformed-graph tolerance, suggestion filtering/sorting/capping per marker, and the scanner's insert/anchor/whitespace cases.

### Fences honored
- **Boris-owned surface only**: completion is decoded from IR artifacts, never hand-rolled; no process spawned (no `Process?` slot involved — read-only file decode).
- **Boundary 4**: insertions go into the buffer; explicit Save / ⌘S stays the only disk writer.
- **Cooklang-gated**: the popup only triggers in `.cooklang` buffers (Textile's `@` verbatim and Markdown's email `@` are untouched).

### Verified
`make build` ✅ · full ContractTests suite (285 tests, 0 failures) ✅ · SwiftLint 0 violations ✅ · SwiftFormat clean ✅ · spike scheme ✅.

Worth an eyeball live: open a Cooklang buffer (`Stunts/cook-one` corpus needs a build first so `.boris/` exists), type `@` and confirm ingredients pop; then `#` for cookware.
