### PR TITLE
docs(github): M15 design gate — GitHub OAuth / SourceKind.github

### DIFF
--- a/docs/GITHUB-OAUTH-DESIGN.md
+++ b/docs/GITHUB-OAUTH-DESIGN.md
@@ -1,0 +1,269 @@
+# GitHub OAuth / `SourceKind.github` — Design Specification
+
+**Status:** design gate for
+[#179](https://github.com/drawmeanelephant/solipsist/issues/179)
+(card [`cards/GITHUB-OAUTH.md`](cards/GITHUB-OAUTH.md)). Drafted by the
+dispatcher to jump-start the GitHub-source lane; the lane owns this file
+and the implementation. This is the ROADMAP §3 "Later" item — *"GitHub
+as its own `SourceKind` (OAuth / app password, not just a clone)"* —
+kicked off now that the board is empty of grind cards. The clone slice
+(M12 / #131 → PRs #152/#153) stays exactly what it is: URL → folder →
+Local source. This design is the authenticated remote **payload** the
+clone was explicitly not.
+
+## 1. What exists today (do not redo)
+
+| Piece | Current behavior |
+|-------|------------------|
+| `SourceKind` (`Sources/Workspace/Source.swift`) | Enum already has a `.github` case with symbol `chevron.left.forwardslash.chevron.right` and displayName `GitHub` — **no payload behind it**. Chrome reads only `id` / `title` / `kind`, so a payload lands without chrome changes. |
+| `SourceItem` | Only `.local(LocalSource)` today. Add `.github(GithubSource)`; every `switch` in the enum gains one case. |
+| `WorkspaceStore` | `addLocal` / `relocate` / `remove` / `beginAccess` (security-scoped bookmark + start/stop access) / `persist` (UserDefaults via `WorkspacePersistence`, locals only). |
+| `GitClone` (`Sources/Workspace/Git/GitClone.swift`) | Proven one-shot `/usr/bin/git` runner with the **sandbox trap solved**: the real CLT/Xcode git is resolved (`gitExecutableURL`), xcrun shim refused. `CloneSession` for SIGTERM-cancel, `currentBranch` / porcelain parsing, URL validation. Reuse, do not re-derive. |
+| `CREDENTIAL-LIFECYCLE.md` | Approved design spec (#60): `SecureBuffer` (zeroing), `KeychainStore` (service `dev.drawmeanelephant.solipsist`), `EphemeralSecretStore`, stdin delivery, the zero-leak invariant (no argv / env / logs / plaintext files). GitHub tokens are secrets — same discipline. |
+| Coordinator (#58, `docs/COORDINATOR.md`) | `WatchServer.suspend()` / `resume()` (SIGSTOP/SIGCONT) + weak registry. Tree-writing one-shots suspend watch. **Git is not boris** — git verbs are settings-adjacent one-shots (clone precedent), never the engine's `Process?` slot. |
+
+## 2. What a GitHub source is
+
+A `GithubSource` is an **authenticated remote publication**: identity
+(`owner/repo`, default branch, granted scopes) plus a **local working
+copy** the way every other source is a folder. Boris is a subprocess
+that reads a filesystem tree — it cannot talk to GitHub. So the payload
+wraps a sandbox-bookmarked working copy, and **every existing surface
+(play, mailboxes, inspector, compose, watch, plan/validate/build)
+operates on the working copy exactly as it does for a Local source.**
+
+```swift
+struct GithubSource: PublicationSource, Hashable, Sendable, Codable {
+    var id: SourceID
+    var title: String              // "owner/repo"
+    var owner: String
+    var repository: String
+    var defaultBranch: String      // from the remote, not guessed
+    var bookmarkData: Data         // working-copy folder, LocalSource-style
+    var displayPath: String
+    var grantedScopes: [String]    // display-only; never the token
+    // Transient (not persisted): resolved at load, like LocalSource.
+    var isAvailable: Bool = true
+    var branch: String? = nil
+    var isSyncing: Bool = false
+    var lastSyncError: String? = nil
+}
+```
+
+`SourceItem` gains `.github(GithubSource)`; `kind` returns `.github`
+(already in the enum). Persistence: `WorkspacePersistence` gains a
+`github: [GithubSource]` array beside `sources: [LocalSource]` (the
+token itself never touches UserDefaults — see §4).
+
+**The fence from M12 still holds:** a *clone* of a public repo into a
+folder is Local-source business and stays that way. `GithubSource` is
+chosen deliberately in Settings ("Add GitHub Account…"), not inferred
+from a folder's `.git/config`.
+
+## 3. OAuth: GitHub device flow (primary) + fine-grained PAT (fallback)
+
+The roadmap names "OAuth / app password". Both are supported; the
+primary is **device flow** because it needs no redirect URI, no
+`ASWebAuthenticationSession`, and no secret on the client — built for
+CLI/native apps, and it works even when the confirmation happens on
+another device.
+
+### Device flow steps (app-owned; boris has no GitHub OAuth surface)
+
+1. `POST https://github.com/login/device/code` (form: `client_id`,
+   `scope=repo`) → `device_code`, `user_code`, `verification_uri`,
+   `expires_in`, `interval`. Accept `application/json`.
+2. `NSWorkspace.shared.open(verification_uri)` — sandbox-safe (URL
+   open is permitted; `network.client` covers the polling). Show the
+   `user_code` in the sheet too (the user may be confirming elsewhere).
+3. Poll `POST https://github.com/login/oauth/access_token` (form:
+   `client_id`, `device_code`,
+   `grant_type=urn:ietf:params:oauth:grant-type:device_code`) every
+   `interval` until success or error:
+   - `authorization_pending` → keep polling (respect `interval`).
+   - `slow_down` → increase interval by 5 s (server's contract).
+   - `expired_token` / `access_denied` → surface, never retry silently.
+4. On success: `GET https://api.github.com/user` with
+   `Authorization: Bearer <token>` → `login`, `name`, `id`, avatar.
+   The login becomes the account title; then `GET /repos/owner/repo`
+   for `default_branch`.
+5. Token → Keychain (§4). Any step's non-2xx / error body is surfaced
+   (D11: never swallow), and the poll loop cancels with the sheet.
+
+**`client_id` is an operator step** (like #110/#111): register a GitHub
+OAuth App (device flow, no secret) and put the client id in the app's
+Info.plist. The client id is public by design — it is not a secret and
+not a credential. The seam reads it from the bundle so tests inject a
+stub id and CI never touches GitHub.
+
+**Fallback — app password / PAT:** a fine-grained personal access token
+pasted into the sheet (the "app password" the roadmap names). Same
+storage + git delivery as the device-flow token, zero scopes required
+for public repos, `repo` for private. The sheet offers "Use a token
+instead".
+
+### Scopes
+
+Request `repo` (covers public + private read for clone/sync; no write
+scope exists in that grant beyond the user's choice). The granted
+scopes returned by GitHub are stored in `grantedScopes` (display-only)
+and shown in Settings — the user sees exactly what the source can do.
+No `workflow`/`admin` scopes, ever.
+
+## 4. Credential lifecycle (reuse, extend)
+
+The token is a `SecureBuffer` at rest and in memory; the Keychain is the
+only persistence. CREDENTIAL-LIFECYCLE.md invariants hold verbatim:
+never argv, never env, never logs, never plaintext files.
+
+- **Keychain:** `kSecClassGenericPassword`, service
+  `dev.drawmeanelephant.solipsist`, account `github:<owner>/<repo>`.
+  `GithubTokenStore` (new, `Sources/Security/`) wraps `KeychainStore`
+  + `SecureBuffer`; the source payload stores only the account name,
+  never the token. Restart → source persists and the token is still
+  there (B3-2-style gate: no re-auth on relaunch).
+- **Ephemeral vs remembered:** unlike publish secrets, a *source*
+  token must survive relaunch — the source IS the account. So the
+  default is Keychain persistence with the existing opt-out pattern;
+  "sign out" deletes the Keychain item (and, for PAT, offers to delete
+  the credential on GitHub — device-flow tokens cannot be revoked via
+  API; the user is pointed at github.com/settings/security).
+- **Git delivery — `git-credential-solipsist`, helper mode of the app
+  binary.** Git verbs authenticate via
+  `git -c credential.helper=<app> …`, where `<app>` is the app's own
+  executable launched with a `--git-credential-helper` flag (early
+  exit path in `main`, like `xcodebuild -runFirstLaunch`). Git invokes
+  the helper with `get`, the helper reads the Keychain and prints
+  `username=x-access-token\npassword=<token>` on **stdout** (git's own
+  pipe). The token travels Keychain → helper stdout → git pipe: never
+  argv, never env, never on disk. This mirrors
+  `git-credential-osxkeychain`, is sandbox-safe (the app already holds
+  keychain-access), and avoids embedding a second binary.
+  Rejected: `GIT_ASKPASS` scripts that must *know* the token, and
+  `https://x-access-token:<token>@…` URLs (token in argv, visible to
+  `ps` — zero-leak violation).
+
+## 5. Git verbs (v1 scope)
+
+| Verb | Mechanism | Arbitrates with watch? | Engine slot? |
+|------|-----------|------------------------|--------------|
+| **Add GitHub Account…** | Device-flow sheet → clone the default branch into a user-chosen sandbox folder via `GitClone.clone` with `credential.helper` (private repos) → `WorkspaceStore.addGithub(...)` | no (new source, no watch yet) | **no** — Settings one-shot, clone precedent |
+| **Sync** (Remote mailbox verb) | `git -C <worktree> fetch` then `git -C <worktree> pull --ff-only` (same helper), one-shot `Process` + `SyncSession` cancel like `CloneSession` | **yes** — the working copy is the tree watch serves: SIGSTOP watch (COORDINATOR.md §3 primitives), pull, SIGCONT | **no** — git is not boris; parallel one-shot is the established pattern |
+| Branch / ahead-behind | Reuse `GitClone.currentBranch` porcelain parsing | n/a | n/a |
+
+**Out of v1 (roadmap §3 "Later" keeps them later):** commit, push, pull
+request authoring, issue mailboxes. The deferral said *"Fetch / pull /
+commit / push on a checkout (clone is M12; remotes stay later)"* — the
+design decision here is that **Sync is load-bearing for a GitHub
+source** (a mailbox that never refreshes is not a mailbox), so fetch +
+`pull --ff-only` move up with this lane; everything that *writes* the
+remote (push, PRs, issues) stays out. If the lane disagrees, it must
+say why in the issue — this is the one deliberate re-scope.
+
+## 6. Files and lanes
+
+| File | Lane | Owns |
+|------|------|------|
+| `Sources/Workspace/GitHub/GithubSource.swift` | workspace | payload, `SourceItem.github` case (all switches) |
+| `Sources/Workspace/GitHub/GithubOAuth.swift` | workspace | device-flow state machine (injectable HTTP transport + clock for tests) |
+| `Sources/Workspace/GitHub/GithubAPIClient.swift` | workspace | `GET /user`, `GET /repos/owner/repo`, `GET /repos/…/pulls` (later) |
+| `Sources/Workspace/GitHub/GithubSync.swift` | workspace | fetch + `pull --ff-only` one-shot, `SyncSession` |
+| `Sources/Security/GithubTokenStore.swift` | security | Keychain + `SecureBuffer` token lifecycle |
+| `git-credential-solipsist` helper mode | security | `--git-credential-helper` early-exit path in `main` |
+| `Sources/App/Settings/SourcesSettingsPane.swift` | settings | Add GitHub Account… sheet, scopes + sign-out rows |
+| `Sources/Play/GitHub/RemoteMailboxView.swift` | play | Remote mailbox: branch, ahead/behind, last-synced, Sync verb, Open on GitHub |
+| `Sources/Workspace/WorkspacePersistence.swift` | workspace | `github: [GithubSource]` array; token never persisted here |
+| `Sources/Workspace/WorkspaceStore.swift` | workspace | `addGithub`, `syncGithub`, `remove` (token delete), `beginAccess` reuse |
+
+**Untouched:** `Sources/Engine/**` (boris never talks to GitHub; the
+working copy is the tree), `Sources/Compose/**`,
+`Sources/Chrome/MainWindow.swift`, entitlements (`network.client`
+already exists; keychain-access already granted).
+
+## 7. Mailboxes
+
+A GitHub source is an account header like any other. Its children:
+
+- **Pages / Outputs / Publish / Plan / Activity** — identical to Local,
+  off the working copy's graph/contracts. No new code path: the source
+  resolves to a folder.
+- **Remote** (new mailbox token, `Sources/Play/GitHub/`) — read-only
+  sync state: branch, ahead/behind (existing porcelain), last-synced,
+  **Sync** verb, and **Open on GitHub** (`NSWorkspace.open` of the
+  repo URL — an Open-Recent-style convenience, not an API client).
+
+## 8. Do not
+
+- Reimplement git in Swift; re-derive `gitExecutableURL`; invent a
+  second credential seam (reuse `SecureBuffer` / `KeychainStore`).
+- Put the token in `WorkspacePersistence`, `boris.json`, plists,
+  `UserDefaults`, argv, env, or logs (zero-leak invariant).
+- Use `ASWebAuthenticationSession` / redirect URIs (device flow has
+  none) or `https://token@…` clone URLs.
+- Request `workflow` / `admin` / `delete_repo` scopes.
+- Treat a GitHub source as a second engine surface — boris runs
+  against the working copy, period.
+- Grow `Sources/Chrome/MainWindow.swift`; touch `Sources/Engine/**`.
+- Auto-add a default GitHub account or fetch a repo list without the
+  user's pick.
+- Build commit / push / PR / issues mailboxes (roadmap "Later").
+
+## 9. Gate (how the lane proves it)
+
+Manual, against the real app (`make build`):
+
+1. Settings → **Add GitHub Account…** → device-flow sheet shows the
+   code, the browser opens, the user confirms → the sheet polls to a
+   token, `GET /user` names the account, the default branch is cloned
+   into a user-chosen sandbox folder.
+2. The source appears as an account header with the GitHub symbol;
+   Pages/Outputs/Publish/Plan/Activity work off the working copy
+   (45-page dogfood clone → 7 trunks, same as Local).
+3. **Remote** mailbox shows branch + sync state; **Sync** pulls
+   (watch suspended during the pull, resumed after — same port, same
+   URL, SSE reload fires).
+4. Quit and relaunch: source persists, **no re-auth**, token intact in
+   Keychain.
+5. Sign out: Keychain item deleted; the working copy stays on disk
+   (user-owned folder; nothing removed without an explicit prompt).
+6. A private repo with a PAT pasted in works through the same path.
+7. `SKIP_EMBED_BORIS=1 make build` + `make test` green — **no live
+   GitHub in CI**.
+
+Automated (unit, injected transport + clock, no network):
+
+- Device-flow state machine: code → poll → token; `slow_down` backoff;
+  `expired_token` / `access_denied` surfaced; sheet cancel stops the
+  poller; browser-open recorded.
+- Token lifecycle: Keychain CRUD + toggle, `SecureBuffer` redaction
+  (mirror `SecurityTests`), helper-mode stdout format.
+- Persistence: encode/decode round trip of `GithubSource` (mirror
+  `WorkspacePersistenceTests`); token absent from the payload.
+- Sync: invocation shape + porcelain ahead/behind parsing against a
+  stub script (`SOLIPSIST_GIT_BIN`-style seam, clone precedent).
+- Source-item switches: `SourceItem.github` id/title/kind/branch
+  exhaustiveness.
+
+## 10. Edge cases
+
+- **Polling while the user walks away:** `expires_in` (900 s) →
+  surface "code expired" and re-open the sheet; never poll forever.
+- **Token revoked on GitHub while the app is open:** next Sync fails
+  with 401 → surface the git exit + stderr, mark the source
+  `needsAuth` (non-blocking badge, B3-2 posture), offer re-auth.
+- **Device flow vs. `slow_down`:** server's interval is the contract;
+  honor it exactly (no faster-than-asked polling).
+- **Private repo, no scope granted:** clone fails with git's
+  authentication error — shown verbatim, with a hint that the token
+  needs `repo` scope. Never a silent retry.
+- **Working copy deleted / moved:** `beginAccess` marks unavailable
+  (existing badge behavior); Settings offers Relocate (existing verb)
+  and Sync re-clones on demand (`git clone` again into the same path).
+- **Watch serving during Sync:** SIGSTOP before `pull`, SIGCONT after
+  (§5) — the frozen-window guarantee from COORDINATOR.md §3 holds; a
+  subsequent SSE reload reflects the new tree.
+- **Two GitHub sources, same repo:** allowed (two working copies,
+  distinct `SourceID`s); token accounts collide only if owner/repo
+  match — the second add reuses the existing Keychain item.
+- **Client id missing (dev build):** sheet explains the operator step,
+  then falls back to the PAT path — the flow is never dead.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -114,6 +114,11 @@ No scraped prose. No homegrown graph. No third settings store.
   [#131](https://github.com/drawmeanelephant/solipsist/issues/131)
   → PRs #152/#153 (URL → folder → Local source). OAuth / app
   password remains. Pages as a *target* does not require either.
+  **M15:** device-flow OAuth + PAT fallback, Keychain token, working
+  copy, Remote mailbox Sync (fetch + `pull --ff-only`;
+  commit/push/PR stay later). Design gate:
+  [`docs/GITHUB-OAUTH-DESIGN.md`](GITHUB-OAUTH-DESIGN.md) —
+  [#179](https://github.com/drawmeanelephant/solipsist/issues/179).
 - Content-audit mailbox (`boris-content-audit`)
 - Source-RAG export for AI assist
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)
@@ -146,6 +151,7 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M12** Clone | ✅ Add Git Repository… → Local source ([#131](https://github.com/drawmeanelephant/solipsist/issues/131); PRs #152/#153) |
 | **M13** Graph folders | ✅ trunk mailboxes from `graph.parent` ([#142](https://github.com/drawmeanelephant/solipsist/issues/142); #144–#146 → PRs #154/#155/#156) |
 | **M14** Watch contract | ✅ A1 `--watch-json` + letter SSE ([#143](https://github.com/drawmeanelephant/solipsist/issues/143); #147/#148 → PRs #157/#158) |
+| **M15** GitHub source | filed — OAuth device flow + `SourceKind.github` payload ([#179](https://github.com/drawmeanelephant/solipsist/issues/179); design [`GITHUB-OAUTH-DESIGN.md`](GITHUB-OAUTH-DESIGN.md)) |
 
 **Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
 batch then landed: first-run and problem→page (#88/#94), graph filter /
@@ -598,22 +604,20 @@ here, it is not a v1 promise.
 
 ## 8. Pickup (what to do next)
 
-M10 and M11 landed. Remaining **ship** is Apple-account only.
-Next **product** slice is M12 clone. M13 and M14 are filed; pick
-them in their own worktrees once the lanes are free.
+M10–M14 and the post-ship batch (#165/#166/#167 — content-audit,
+source-rag, compose depth) landed. Remaining **ship** is Apple-account
+only. Next **product** slice is M15, the GitHub source (the deferred
+ROADMAP §3 item) — design gate
+[`docs/GITHUB-OAUTH-DESIGN.md`](GITHUB-OAUTH-DESIGN.md).
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
-| 1 | M12 Clone | [#131](https://github.com/drawmeanelephant/solipsist/issues/131) | Settings → Add Git Repository… clone URL → folder → `addLocal`. |
-| 2 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. Parallel with #131. |
+| 1 | M15 GitHub source | [#179](https://github.com/drawmeanelephant/solipsist/issues/179) | Board is empty; the deferred OAuth/`SourceKind.github` payload is the only named product item left. Device flow → Keychain → working copy → Remote mailbox. |
+| 2 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. Parallel with #179. |
 | 3 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
-| 4 | M13 Graph folders | [#142](https://github.com/drawmeanelephant/solipsist/issues/142) | After M12, or parallel if it stays out of Settings / `Workspace/Git/`. First pick #144. |
-| 5 | M14 Watch contract | [#143](https://github.com/drawmeanelephant/solipsist/issues/143) | Parallel with M13 (Engine / Preview / Reading). First pick #147. |
 
-[#131](https://github.com/drawmeanelephant/solipsist/issues/131) is
-clone-as-local, not GitHub OAuth. Do not start `SourceKind.github`
-payload work in that PR. #136 (splitter crash) stays parked on
-macOS 27 beta.
+#179 is OAuth + `SourceKind.github` payload, not the M12 clone
+(clone-as-local stays landed and untouched).
 
 ### Landed depth (do not redo)
 

--- a/docs/cards/GITHUB-OAUTH.md
+++ b/docs/cards/GITHUB-OAUTH.md
@@ -1,0 +1,70 @@
+# Card — GitHub source (OAuth device flow + `SourceKind.github` payload)
+
+**Milestone:** M15 (first post-batch milestone) · **Issue:**
+[#179](https://github.com/drawmeanelephant/solipsist/issues/179)
+**Lane:** workspace / settings / play (see ownership table below).
+One worktree, one PR against `main`; branch suggestion
+`feat/github-source`.
+
+Design gate: [`docs/GITHUB-OAUTH-DESIGN.md`](../GITHUB-OAUTH-DESIGN.md)
+— the lane owns that file and the implementation. The design doc is the
+spec; this card is the dispatch brief.
+
+## Owns
+
+- `Sources/Workspace/GitHub/` (new folder): `GithubSource.swift`,
+  `GithubOAuth.swift` (device flow), `GithubAPIClient.swift`,
+  `GithubSync.swift`
+- `Sources/Security/GithubTokenStore.swift` + `--git-credential-helper`
+  mode of the app binary (early-exit in `main`)
+- `Sources/App/Settings/SourcesSettingsPane.swift` — **Add GitHub
+  Account…** sheet (device flow + PAT fallback, scopes, sign out)
+- `Sources/Play/GitHub/RemoteMailboxView.swift` — Remote mailbox:
+  branch, ahead/behind, last-synced, Sync verb, Open on GitHub
+- `SourceItem.github` case (all switches in `Sources/Workspace/Source.swift`)
+- `Sources/Workspace/WorkspaceStore.swift` + `WorkspacePersistence.swift`
+  — `addGithub` / `syncGithub` / remove-with-token-delete; token never
+  persisted in the payload
+
+## Do not touch
+
+- `Sources/Engine/**` — boris never talks to GitHub; the working copy
+  is the tree (D11)
+- `Sources/Compose/**`, `Sources/Chrome/MainWindow.swift`
+- Entitlements — `network.client` + keychain-access already exist
+- Commit / push / PR / issues mailboxes (roadmap "Later")
+- The M12 clone path (`GitClone`, Local sources) — a public clone into
+  a folder stays Local business
+
+## Do
+
+1. **Device flow first** (`docs/GITHUB-OAUTH-DESIGN.md` §3): code →
+   browser → poll (`interval`/`slow_down`/`expired_token` honored) →
+   token → `GET /user` names the account → `GET /repos/owner/repo`
+   gives `default_branch`. `client_id` from Info.plist (operator step),
+   PAT paste as fallback.
+2. **Credential discipline** (§4): `SecureBuffer` + `KeychainStore`
+   (account `github:<owner>/<repo>`), never argv/env/logs/plist. Git
+   auth via `git -c credential.helper=<app> …` helper mode.
+3. **Add**: clone the default branch into a user-chosen sandbox folder
+   (reuse `GitClone.clone`, `credential.helper` for private) →
+   `WorkspaceStore.addGithub`.
+4. **Remote mailbox**: branch + ahead/behind from the existing
+   porcelain parsing; **Sync** = `fetch` + `pull --ff-only`, one-shot
+   `Process` (not the engine slot), watch suspended via the
+   COORDINATOR.md §3 primitives during the pull.
+5. **Tests** (no network in CI): device-flow state machine with
+   injected transport + clock; token lifecycle (mirror
+   `SecurityTests`); `GithubSource` persistence round trip (token
+   absent); sync invocation + porcelain parsing against a stub script;
+   `SourceItem.github` exhaustiveness.
+
+## Gate
+
+Settings → **Add GitHub Account…** → device-flow confirm in the
+browser → token in Keychain → default branch cloned → account header
+with the GitHub symbol; Pages/Outputs/Publish/Plan/Activity work off
+the working copy; **Remote** shows sync state and **Sync** pulls
+(watch suspended/resumed, same port); relaunch → source persists with
+no re-auth; sign out deletes the Keychain item. `SKIP_EMBED_BORIS=1
+make build` + `make test` green; no live GitHub in CI.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -120,10 +120,21 @@ All three run through the coordinator's single `Process?` slot.
 | [Source-RAG export](LATER-source-rag.md) | [#166](https://github.com/drawmeanelephant/solipsist/issues/166) | export / menu | #165 | menu verb → pack revealed in Finder |
 | Compose depth (tracker — issue only) | [#167](https://github.com/drawmeanelephant/solipsist/issues/167) | compose | after #165/#166 | one slice per PR; Oliver span diagnostics first |
 
+## M15 — GitHub source (pickable)
+
+The deferred ROADMAP §3 "Later" item — GitHub as its own
+`SourceKind` (OAuth device flow + PAT fallback, not just a clone).
+Design gate: [`docs/GITHUB-OAUTH-DESIGN.md`](../GITHUB-OAUTH-DESIGN.md).
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [GitHub source](GITHUB-OAUTH.md) | [#179](https://github.com/drawmeanelephant/solipsist/issues/179) | workspace / settings / play | — | device flow → Keychain → working copy; Remote mailbox Sync; restart keeps the source |
+
 ## Do not start yet
 
-GitHub OAuth / `SourceKind.github` payload. Wasm in the app. The
-fart app. Fetch / pull / commit / push.
+Wasm in the app. The fart app. Commit / push / PR authoring / issues
+mailboxes (fetch + `pull --ff-only` moved up with the GitHub source;
+remote *writes* stay later).
 
 ## Shared noun kinds (play writes, inspector reads)
 


### PR DESCRIPTION
## What

Design gate for **M15 — GitHub source** (the deferred ROADMAP §3 item:
*GitHub as its own `SourceKind` (OAuth / app password, not just a
clone)*), opened as a new lane on #179.

- **`docs/GITHUB-OAUTH-DESIGN.md`** — the spec, in the house style of
  `docs/COORDINATOR.md`: what exists today, the payload + working-copy
  rule, device-flow OAuth (with PAT fallback), the credential
  lifecycle reuse (`SecureBuffer` / Keychain / zero-leak), the
  `git-credential-solipsist` helper-mode delivery seam, the v1 git
  verb table, file/lane ownership, mailboxes, fences, gate, edge
  cases. The lane owns the file and the implementation.
- **`docs/cards/GITHUB-OAUTH.md`** — dispatch brief (owns / do-not /
  do / gate) so the conveyor can pick it.
- **`docs/cards/README.md`** — board row under a new **M15 — GitHub
  source (pickable)** section; "Do not start yet" trimmed to what
  genuinely stays later (remote *writes* — commit/push/PR/issues).
- **`docs/ROADMAP.md`** — Later bullet updated with the M15 pointer,
  M15 row in the milestone table, §8 pickup re-ordered.

## Key decisions the lane inherits

1. **Device flow, not redirect OAuth** — no redirect URI, no
   `ASWebAuthenticationSession`, browser confirm works from any
   device; PAT paste is the app-password fallback the roadmap names.
2. **A GitHub source wraps a sandbox-bookmarked working copy** — boris
   is a subprocess over a filesystem tree; every existing surface
   (play, mailboxes, compose, watch) operates on the working copy
   unchanged. `SourceKind.github` already exists in the enum — only
   the payload is new.
3. **Zero-leak token delivery to git** via `git -c credential.helper=`
   helper mode of the app binary (Keychain → helper stdout → git
   pipe), never argv/env/logs — reusing the approved
   CREDENTIAL-LIFECYCLE.md discipline.
4. **Sync moves up; writes stay later** — the one deliberate re-scope:
   fetch + `pull --ff-only` is load-bearing for a remote mailbox, so
   it comes with the lane; commit/push/PR/issues mailboxes stay in
   ROADMAP §3 "Later". Flagged in the doc for the lane to contest if
   it disagrees.
5. **`client_id` is an operator step** (like #110/#111) — public by
   design, read from Info.plist, PAT path keeps the flow alive
   without it; CI never touches GitHub (injected transport + clock).

## Gate

Design doc reviewed; issue #179 opened with the lane brief. No Swift
in this PR — docs only.

