### PR TITLE
feat(github): M15 seam — GithubSource payload + device-flow OAuth state machine (#179)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -107,6 +107,7 @@ targets:
       - path: Sources/Workspace/WorkspaceSelection.swift
       - path: Sources/Workspace/Local/LocalSource.swift
       - path: Sources/Workspace/Git
+      - path: Sources/Workspace/GitHub
       - path: Sources/Companions/CompanionID.swift
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Sources/Companions/Preview/PreviewURL.swift

--- a/Sources/Chrome/PlayHost.swift
+++ b/Sources/Chrome/PlayHost.swift
@@ -16,6 +16,8 @@ struct PlayHost: View {
                 switch item {
                 case .local(let source):
                     LocalPlay(source: source)
+                case .github(let source):
+                    GithubPlayPlaceholder(source: source)
                 }
             } else if store.sources.isEmpty {
                 EmptyStateView(
@@ -63,5 +65,19 @@ struct PlayHost: View {
                 )
             }
         }
+    }
+}
+
+/// M15 seam: the GitHub play surface (Pages/Outputs/Publish/Plan/
+/// Activity over the working copy) lands with the working-copy slice.
+private struct GithubPlayPlaceholder: View {
+    let source: GithubSource
+
+    var body: some View {
+        EmptyStateView(
+            title: source.title,
+            systemImage: "chevron.left.forwardslash.chevron.right",
+            message: "\(source.owner)/\(source.repository) is authenticated. The play surface lands with the working-copy slice."
+        )
     }
 }

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -71,6 +71,8 @@ struct EditorWindow: View {
                 projectRoot: projectRoot,
                 engine: runtime.engine
             )
+        case .github(let github):
+            session.fail("The editor for \(github.owner)/\(github.repository) lands with the working-copy slice.")
         }
     }
 

--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -71,6 +71,10 @@ struct PreviewWindow: View {
                 engine: runtime.engine,
                 coordinator: runtime.coordinator
             )
+        case .github(let github):
+            // M15 seam: the working-copy slice resolves the bookmark and
+            // previews the GitHub source's working copy like a Local one.
+            session.fail("Preview for \(github.owner)/\(github.repository) lands with the working-copy slice.")
         }
     }
 

--- a/Sources/Workspace/GitHub/GithubOAuth.swift
+++ b/Sources/Workspace/GitHub/GithubOAuth.swift
@@ -1,0 +1,238 @@
+import Foundation
+
+/// GitHub device-flow OAuth (M15 / #179). The app owns this surface —
+/// boris has no GitHub OAuth. Primary auth for `GithubSource`; a pasted
+/// fine-grained PAT is the sheet-level fallback, not part of this flow.
+///
+/// Flow: `requestDeviceCode` → open `verificationURI` in the browser →
+/// `pollUntilToken` (the settings sheet runs it in a cancellable
+/// `Task`). The token crosses this boundary in a `SecureBuffer` — never
+/// a plain String (zero-leak invariant).
+enum GithubOAuth {
+    static let deviceCodeURL = URL(string: "https://github.com/login/device/code")!
+    static let accessTokenURL = URL(string: "https://github.com/login/oauth/access_token")!
+
+    /// The server's `slow_down` instruction: add this many seconds.
+    static let slowDownStep: TimeInterval = 5
+
+    /// One device-code grant. `interval` is the server's poll cadence —
+    /// honored exactly, never faster than asked.
+    struct DeviceCodeSession: Sendable, Equatable {
+        var deviceCode: String
+        var userCode: String
+        var verificationURI: URL
+        var expiresAt: Date
+        var interval: TimeInterval
+    }
+
+    /// The granted token. The access token rides in a `SecureBuffer`.
+    struct GithubToken: Sendable {
+        let token: SecureBuffer
+        let scopes: [String]
+        let tokenType: String
+    }
+
+    /// One poll round. `.pending` / `.slowDown` mean "poll again";
+    /// the rest are terminal.
+    enum TokenPoll: Sendable {
+        case success(GithubToken)
+        case pending
+        case slowDown
+        case expired
+        case denied
+        case failed(code: String, message: String)
+    }
+
+    /// Form-encoded POST transport. Tests inject a stub; CI never
+    /// touches GitHub.
+    protocol HTTPTransport: Sendable {
+        func post(_ url: URL, form: [String: String]) async throws -> Data
+    }
+
+    /// Clock seam: the poller sleeps and computes expiry through this,
+    /// so tests fast-forward without real sleeps.
+    protocol Clock: Sendable {
+        var now: Date { get }
+        func sleep(nanoseconds: UInt64) async throws
+    }
+
+    static func requestDeviceCode(
+        clientID: String,
+        scope: String,
+        transport: HTTPTransport,
+        clock: Clock
+    ) async throws -> DeviceCodeSession {
+        let data = try await transport.post(
+            deviceCodeURL,
+            form: ["client_id": clientID, "scope": scope]
+        )
+        let response = try decode(DeviceCodeResponse.self, from: data)
+        if let error = response.error {
+            throw GithubOAuthError.deviceCodeFailed(
+                code: error,
+                message: response.errorDescription ?? "GitHub rejected the device-code request."
+            )
+        }
+        guard
+            let deviceCode = response.deviceCode,
+            let userCode = response.userCode,
+            let verification = response.verificationUri,
+            let expiresIn = response.expiresIn,
+            let interval = response.interval
+        else {
+            throw GithubOAuthError.invalidResponse
+        }
+        return DeviceCodeSession(
+            deviceCode: deviceCode,
+            userCode: userCode,
+            verificationURI: URL(string: verification) ?? deviceCodeURL,
+            expiresAt: clock.now.addingTimeInterval(TimeInterval(expiresIn)),
+            interval: TimeInterval(interval)
+        )
+    }
+
+    /// One poll of the access-token endpoint. Errors map to `TokenPoll`
+    /// cases per GitHub's device-flow contract; nothing is swallowed.
+    static func pollForToken(
+        deviceCode: String,
+        clientID: String,
+        transport: HTTPTransport
+    ) async throws -> TokenPoll {
+        let data = try await transport.post(
+            accessTokenURL,
+            form: [
+                "client_id": clientID,
+                "device_code": deviceCode,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            ]
+        )
+        let response = try decode(TokenResponse.self, from: data)
+        if let error = response.error {
+            switch error {
+            case "authorization_pending": return .pending
+            case "slow_down": return .slowDown
+            case "expired_token": return .expired
+            case "access_denied": return .denied
+            default:
+                return .failed(code: error, message: response.errorDescription ?? error)
+            }
+        }
+        guard let accessToken = response.accessToken else {
+            throw GithubOAuthError.invalidResponse
+        }
+        let scopes = (response.scope ?? "").split(separator: " ").map(String.init)
+        return .success(GithubToken(
+            token: SecureBuffer(utf8String: accessToken),
+            scopes: scopes,
+            tokenType: response.tokenType ?? "bearer"
+        ))
+    }
+
+    /// Poll loop the settings sheet runs in a `Task`: `.pending` sleeps
+    /// the session's interval, `.slowDown` bumps it by `slowDownStep`
+    /// (the server's contract), and `Task.checkCancellation()` stops
+    /// the poller when the sheet closes. Terminal results pass through.
+    static func pollUntilToken(
+        session: DeviceCodeSession,
+        clientID: String,
+        transport: HTTPTransport,
+        clock: Clock
+    ) async throws -> TokenPoll {
+        var current = session
+        while true {
+            try Task.checkCancellation()
+            let result = try await pollForToken(
+                deviceCode: current.deviceCode,
+                clientID: clientID,
+                transport: transport
+            )
+            switch result {
+            case .success, .expired, .denied, .failed:
+                return result
+            case .pending:
+                try await clock.sleep(nanoseconds: nanoseconds(current.interval))
+            case .slowDown:
+                current.interval += slowDownStep
+                try await clock.sleep(nanoseconds: nanoseconds(current.interval))
+            }
+        }
+    }
+
+    private static func nanoseconds(_ interval: TimeInterval) -> UInt64 {
+        UInt64(max(0, interval) * 1_000_000_000)
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        do {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try decoder.decode(type, from: data)
+        } catch {
+            throw GithubOAuthError.invalidResponse
+        }
+    }
+
+    private struct DeviceCodeResponse: Decodable {
+        let deviceCode: String?
+        let userCode: String?
+        // Camel-cased to match `.convertFromSnakeCase` of "verification_uri"
+        // ("verificationURI" would never match and silently decode nil).
+        let verificationUri: String?
+        let expiresIn: Int?
+        let interval: Int?
+        let error: String?
+        let errorDescription: String?
+    }
+
+    private struct TokenResponse: Decodable {
+        let accessToken: String?
+        let tokenType: String?
+        let scope: String?
+        let error: String?
+        let errorDescription: String?
+    }
+}
+
+enum GithubOAuthError: Error, Equatable, Sendable {
+    case deviceCodeFailed(code: String, message: String)
+    case invalidResponse
+    case httpStatus(Int)
+}
+
+/// Production transport: form-encoded POST over URLSession. Non-2xx
+/// responses throw `GithubOAuthError.httpStatus` — never swallowed.
+struct URLSessionGithubTransport: GithubOAuth.HTTPTransport {
+    func post(_ url: URL, form: [String: String]) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formBody(form)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw GithubOAuthError.httpStatus(status)
+        }
+        return data
+    }
+
+    private static func formBody(_ fields: [String: String]) -> Data {
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
+        let pairs = fields
+            .sorted { $0.key < $1.key }
+            .map { key, value in
+                let encoded = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? ""
+                return "\(key)=\(encoded)"
+            }
+        return pairs.joined(separator: "&").data(using: .utf8) ?? Data()
+    }
+}
+
+/// Wall-clock / real-sleep implementation of the seam.
+struct SystemGithubClock: GithubOAuth.Clock {
+    var now: Date { Date() }
+
+    func sleep(nanoseconds: UInt64) async throws {
+        try await Task.sleep(for: .nanoseconds(nanoseconds))
+    }
+}

--- a/Sources/Workspace/GitHub/GithubSource.swift
+++ b/Sources/Workspace/GitHub/GithubSource.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// An authenticated remote publication (M15 / #179): identity
+/// (`owner/repo`, default branch, granted scopes) plus a local working
+/// copy. Boris is a subprocess over a filesystem tree — every surface
+/// operates on the working copy exactly as it does for a Local source.
+///
+/// The token is never here. It lives in the Keychain under
+/// `tokenAccount`; only display-only granted scopes are carried.
+struct GithubSource: PublicationSource, Hashable, Sendable, Codable {
+    var id: SourceID
+    /// "owner/repo" — the account header title.
+    var title: String
+    var owner: String
+    var repository: String
+    /// From the remote (`GET /repos/owner/repo`), never guessed.
+    var defaultBranch: String
+    /// Working-copy folder, LocalSource-style security-scoped bookmark.
+    var bookmarkData: Data
+    var displayPath: String
+    /// What GitHub granted the token; display-only, never the token.
+    var grantedScopes: [String]
+    // Transient — resolved at load time, not persisted (LocalSource pattern).
+    var isAvailable: Bool = true
+    var branch: String? = nil
+    var isSyncing: Bool = false
+    var lastSyncError: String? = nil
+
+    var kind: SourceKind { .github }
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, owner, repository, defaultBranch, bookmarkData, displayPath, grantedScopes
+    }
+
+    /// Keychain account for this source's token: `github:<owner>/<repo>`.
+    var tokenAccount: String {
+        "github:\(owner)/\(repository)"
+    }
+
+    /// Repo page for "Open on GitHub".
+    var remoteURL: URL {
+        URL(string: "https://github.com/\(owner)/\(repository)")!
+    }
+
+    func resolve() throws -> (url: URL, stale: Bool) {
+        var stale = false
+        let url = try URL(
+            resolvingBookmarkData: bookmarkData,
+            options: [.withSecurityScope],
+            relativeTo: nil,
+            bookmarkDataIsStale: &stale
+        )
+        return (url, stale)
+    }
+
+    /// Folder the working-copy bookmark points at.
+    func workspaceRoot() throws -> URL {
+        try resolve().url.standardizedFileURL
+    }
+}

--- a/Sources/Workspace/Source.swift
+++ b/Sources/Workspace/Source.swift
@@ -42,22 +42,26 @@ protocol PublicationSource: Identifiable, Sendable {
 /// type lands; the sidebar still only reads `id` / `title` / `kind`.
 enum SourceItem: Identifiable, Hashable, Sendable {
     case local(LocalSource)
+    case github(GithubSource)
 
     var id: SourceID {
         switch self {
         case .local(let source): return source.id
+        case .github(let source): return source.id
         }
     }
 
     var title: String {
         switch self {
         case .local(let source): return source.title
+        case .github(let source): return source.title
         }
     }
 
     var kind: SourceKind {
         switch self {
         case .local: return .local
+        case .github: return .github
         }
     }
 
@@ -66,12 +70,14 @@ enum SourceItem: Identifiable, Hashable, Sendable {
     var isAvailable: Bool {
         switch self {
         case .local(let source): return source.isAvailable
+        case .github(let source): return source.isAvailable
         }
     }
 
     var detailLine: String? {
         switch self {
         case .local(let source): return source.displayPath
+        case .github(let source): return source.displayPath
         }
     }
 
@@ -79,6 +85,7 @@ enum SourceItem: Identifiable, Hashable, Sendable {
     var branch: String? {
         switch self {
         case .local(let source): return source.branch
+        case .github(let source): return source.branch
         }
     }
 }

--- a/Sources/Workspace/WorkspacePersistence.swift
+++ b/Sources/Workspace/WorkspacePersistence.swift
@@ -7,6 +7,31 @@ struct PersistedWorkspace: Codable, Equatable, Sendable {
     var selected: SourceID?
     /// Raw mailbox token. Missing key decodes as nil; do not canonicalize.
     var mailbox: String? = nil
+    /// GitHub sources (M15): remote identity + working-copy bookmark.
+    /// The token is never here — Keychain only.
+    var github: [GithubSource] = []
+
+    init(
+        sources: [LocalSource],
+        selected: SourceID?,
+        mailbox: String? = nil,
+        github: [GithubSource] = []
+    ) {
+        self.sources = sources
+        self.selected = selected
+        self.mailbox = mailbox
+        self.github = github
+    }
+
+    /// Synthesized encode; decode tolerates V1 payloads that predate
+    /// `github` (missing key → empty, never a decode failure).
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sources = try container.decode([LocalSource].self, forKey: .sources)
+        selected = try container.decodeIfPresent(SourceID.self, forKey: .selected)
+        mailbox = try container.decodeIfPresent(String.self, forKey: .mailbox)
+        github = try container.decodeIfPresent([GithubSource].self, forKey: .github) ?? []
+    }
 }
 
 enum WorkspacePersistence {

--- a/Tests/ContractTests/GithubOAuthTests.swift
+++ b/Tests/ContractTests/GithubOAuthTests.swift
@@ -1,0 +1,372 @@
+import XCTest
+
+final class GithubOAuthTests: XCTestCase {
+    // MARK: - Device code request
+
+    func testRequestDeviceCodeParsesSession() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["device_code": "dc-123", "user_code": "ABCD-EFGH",
+                  "verification_uri": "https://github.com/login/device", "expires_in": 900, "interval": 5]),
+            for: GithubOAuth.deviceCodeURL
+        )
+        let clock = StubClock()
+
+        let session = try await GithubOAuth.requestDeviceCode(
+            clientID: "client-1",
+            scope: "repo",
+            transport: transport,
+            clock: clock
+        )
+
+        XCTAssertEqual(session.deviceCode, "dc-123")
+        XCTAssertEqual(session.userCode, "ABCD-EFGH")
+        XCTAssertEqual(session.verificationURI, URL(string: "https://github.com/login/device"))
+        XCTAssertEqual(session.interval, 5)
+        let expectedExpiry = await clock.now.addingTimeInterval(900)
+        XCTAssertEqual(session.expiresAt, expectedExpiry)
+        let recorded = await transport.recorded
+        let call = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(call.url, GithubOAuth.deviceCodeURL)
+        XCTAssertEqual(call.form["client_id"], "client-1")
+        XCTAssertEqual(call.form["scope"], "repo")
+        XCTAssertEqual(call.form.count, 2, "only client_id + scope, never more")
+    }
+
+    func testRequestDeviceCodeSurfacesErrors() async {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["error": "incorrect_client_credentials", "error_description": "The client_id passed is incorrect"]),
+            for: GithubOAuth.deviceCodeURL
+        )
+        do {
+            _ = try await GithubOAuth.requestDeviceCode(
+                clientID: "bad",
+                scope: "repo",
+                transport: transport,
+                clock: StubClock()
+            )
+            XCTFail("expected deviceCodeFailed")
+        } catch let GithubOAuthError.deviceCodeFailed(code, message) {
+            XCTAssertEqual(code, "incorrect_client_credentials")
+            XCTAssertTrue(message.contains("client_id"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        let bad = StubTransport()
+        await bad.enqueue(json(["unexpected": true]), for: GithubOAuth.deviceCodeURL)
+        do {
+            _ = try await GithubOAuth.requestDeviceCode(
+                clientID: "client-1",
+                scope: "repo",
+                transport: bad,
+                clock: StubClock()
+            )
+            XCTFail("expected invalidResponse")
+        } catch GithubOAuthError.invalidResponse {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Single poll rounds
+
+    func testPollForTokenHandlesResponseShapes() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["access_token": "gho_abc123", "token_type": "bearer", "scope": "repo user"]),
+            for: GithubOAuth.accessTokenURL
+        )
+        let poll = try await GithubOAuth.pollForToken(
+            deviceCode: "dc-123",
+            clientID: "client-1",
+            transport: transport
+        )
+        guard case .success(let token) = poll else {
+            return XCTFail("expected success, got \(poll)")
+        }
+        XCTAssertEqual(token.token.copyBytes(), Array("gho_abc123".utf8))
+        XCTAssertEqual(token.scopes, ["repo", "user"])
+        XCTAssertEqual(token.tokenType, "bearer")
+
+        let bad = StubTransport()
+        await bad.enqueue(json(["token_type": "bearer"]), for: GithubOAuth.accessTokenURL)
+        do {
+            _ = try await GithubOAuth.pollForToken(deviceCode: "dc-123", clientID: "client-1", transport: bad)
+            XCTFail("expected invalidResponse")
+        } catch GithubOAuthError.invalidResponse {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testPollForTokenMapsErrorCodes() async throws {
+        let transport = StubTransport()
+        let cases: [(code: String, expected: GithubOAuth.TokenPoll)] = [
+            ("authorization_pending", .pending),
+            ("slow_down", .slowDown),
+            ("expired_token", .expired),
+            ("access_denied", .denied),
+            ("unexpected_code", .failed(code: "unexpected_code", message: "detail")),
+        ]
+        for item in cases {
+            await transport.enqueue(
+                json(["error": item.code, "error_description": "detail"]),
+                for: GithubOAuth.accessTokenURL
+            )
+        }
+        for item in cases {
+            let poll = try await GithubOAuth.pollForToken(
+                deviceCode: "dc-123",
+                clientID: "client-1",
+                transport: transport
+            )
+            assertPoll(poll, matches: item.expected)
+        }
+
+        let recorded = await transport.recorded
+        let call = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(call.url, GithubOAuth.accessTokenURL)
+        XCTAssertEqual(call.form["grant_type"], "urn:ietf:params:oauth:grant-type:device_code")
+        XCTAssertEqual(call.form["device_code"], "dc-123")
+        XCTAssertEqual(call.form["client_id"], "client-1")
+    }
+
+    // MARK: - Poll loop
+
+    func testPollUntilTokenLoopsPendingThenSucceeds() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(json(["error": "authorization_pending"]), for: GithubOAuth.accessTokenURL)
+        await transport.enqueue(json(["error": "authorization_pending"]), for: GithubOAuth.accessTokenURL)
+        await transport.enqueue(json(["access_token": "gho_final", "scope": "repo"]), for: GithubOAuth.accessTokenURL)
+        let clock = StubClock()
+
+        let poll = try await GithubOAuth.pollUntilToken(session: makeSession(interval: 5), clientID: "client-1", transport: transport, clock: clock)
+
+        guard case .success(let token) = poll else {
+            return XCTFail("expected success, got \(poll)")
+        }
+        XCTAssertEqual(token.token.copyBytes(), Array("gho_final".utf8))
+        let slept = await clock.sleptNanoseconds
+        XCTAssertEqual(slept, [5_000_000_000, 5_000_000_000])
+    }
+
+    func testPollUntilTokenSlowDownAndTerminalResults() async throws {
+        let slowTransport = StubTransport()
+        await slowTransport.enqueue(json(["error": "authorization_pending"]), for: GithubOAuth.accessTokenURL)
+        await slowTransport.enqueue(json(["error": "slow_down"]), for: GithubOAuth.accessTokenURL)
+        await slowTransport.enqueue(json(["access_token": "gho_final", "scope": "repo"]), for: GithubOAuth.accessTokenURL)
+        let slowClock = StubClock()
+
+        let slowPoll = try await GithubOAuth.pollUntilToken(session: makeSession(interval: 5), clientID: "client-1", transport: slowTransport, clock: slowClock)
+        guard case .success = slowPoll else {
+            return XCTFail("expected success, got \(slowPoll)")
+        }
+        let slowSlept = await slowClock.sleptNanoseconds
+        XCTAssertEqual(
+            slowSlept,
+            [5_000_000_000, 10_000_000_000],
+            "slow_down bumps the interval by \(GithubOAuth.slowDownStep)s"
+        )
+
+        let expiredTransport = StubTransport()
+        await expiredTransport.enqueue(json(["error": "authorization_pending"]), for: GithubOAuth.accessTokenURL)
+        await expiredTransport.enqueue(json(["error": "expired_token"]), for: GithubOAuth.accessTokenURL)
+        let expiredClock = StubClock()
+
+        let expiredPoll = try await GithubOAuth.pollUntilToken(session: makeSession(interval: 5), clientID: "client-1", transport: expiredTransport, clock: expiredClock)
+        guard case .expired = expiredPoll else {
+            return XCTFail("expected expired, got \(expiredPoll)")
+        }
+        let expiredSlept = await expiredClock.sleptNanoseconds
+        XCTAssertEqual(expiredSlept, [5_000_000_000], "no sleep after a terminal result")
+    }
+
+    func testPollUntilTokenCancellationStopsPoller() async throws {
+        let transport = StubTransport(defaultToPending: true)
+        let session = makeSession(interval: 5)
+
+        let task = Task {
+            try await GithubOAuth.pollUntilToken(session: session, clientID: "client-1", transport: transport, clock: StubClock())
+        }
+        try? await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("expected CancellationError")
+        } catch is CancellationError {
+            // expected — the sheet closed, the poller stopped.
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - SourceItem payload
+
+    func testSourceItemGithubExhaustiveness() {
+        let source = makeSource()
+        let item = SourceItem.github(source)
+
+        XCTAssertEqual(item.id, source.id)
+        XCTAssertEqual(item.title, "acme/blog")
+        XCTAssertEqual(item.kind, .github)
+        XCTAssertEqual(item.symbolName, "chevron.left.forwardslash.chevron.right")
+        XCTAssertEqual(item.detailLine, "/tmp/blog")
+        XCTAssertTrue(item.isAvailable)
+        XCTAssertNil(item.branch)
+        XCTAssertEqual(source.tokenAccount, "github:acme/blog")
+        XCTAssertEqual(source.remoteURL, URL(string: "https://github.com/acme/blog"))
+
+        var unavailable = source
+        unavailable.isAvailable = false
+        unavailable.branch = "main"
+        let badItem = SourceItem.github(unavailable)
+        XCTAssertFalse(badItem.isAvailable)
+        XCTAssertEqual(badItem.branch, "main")
+    }
+
+    func testGithubSourceRoundTripExcludesTransientFields() throws {
+        var source = makeSource()
+        source.isAvailable = false
+        source.branch = "main"
+        source.isSyncing = true
+        source.lastSyncError = "boom"
+
+        let data = try JSONEncoder().encode(source)
+        let decoded = try JSONDecoder().decode(GithubSource.self, from: data)
+
+        XCTAssertTrue(decoded.isAvailable, "transient fields reset on decode")
+        XCTAssertNil(decoded.branch)
+        XCTAssertFalse(decoded.isSyncing)
+        XCTAssertNil(decoded.lastSyncError)
+        XCTAssertEqual(decoded.owner, "acme")
+        XCTAssertEqual(decoded.repository, "blog")
+        XCTAssertEqual(decoded.defaultBranch, "main")
+        XCTAssertEqual(decoded.grantedScopes, ["repo"])
+
+        let raw = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertFalse(raw.contains("\"isAvailable\""))
+        XCTAssertFalse(raw.contains("\"branch\""))
+        XCTAssertFalse(raw.contains("\"lastSyncError\""))
+        XCTAssertFalse(raw.contains("\"isSyncing\""))
+    }
+
+    func testPersistedWorkspaceRoundTripsGithubSources() throws {
+        let github = makeSource()
+        let payload = PersistedWorkspace(sources: [], selected: nil, mailbox: nil, github: [github])
+
+        let decoded = try WorkspacePersistence.decode(try WorkspacePersistence.encode(payload))
+
+        XCTAssertEqual(decoded.github, [github])
+        XCTAssertTrue(decoded.sources.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func assertPoll(
+        _ poll: GithubOAuth.TokenPoll,
+        matches expected: GithubOAuth.TokenPoll,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        switch (poll, expected) {
+        case (.pending, .pending), (.slowDown, .slowDown), (.expired, .expired), (.denied, .denied):
+            break
+        case let (.failed(aCode, aMessage), .failed(bCode, bMessage)):
+            XCTAssertEqual(aCode, bCode, file: file, line: line)
+            XCTAssertEqual(aMessage, bMessage, file: file, line: line)
+        case (.success, .success):
+            break
+        default:
+            XCTFail("poll \(poll) != expected \(expected)", file: file, line: line)
+        }
+    }
+}
+
+private func json(_ object: [String: Any]) -> Data {
+    (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
+}
+
+private func makeSession(interval: TimeInterval) -> GithubOAuth.DeviceCodeSession {
+    GithubOAuth.DeviceCodeSession(
+        deviceCode: "dc-123",
+        userCode: "ABCD-EFGH",
+        verificationURI: URL(string: "https://github.com/login/device")!,
+        expiresAt: Date(timeIntervalSince1970: 1_700_000_900),
+        interval: interval
+    )
+}
+
+private func makeSource() -> GithubSource {
+    GithubSource(
+        id: SourceID(),
+        title: "acme/blog",
+        owner: "acme",
+        repository: "blog",
+        defaultBranch: "main",
+        bookmarkData: Data([1, 2, 3]),
+        displayPath: "/tmp/blog",
+        grantedScopes: ["repo"]
+    )
+}
+
+/// Records calls and returns queued responses per URL. An actor: the
+/// poll loop and the test both touch it across await points.
+private actor StubTransport: GithubOAuth.HTTPTransport {
+    struct RecordedCall: Equatable, Sendable {
+        let url: URL
+        let form: [String: String]
+    }
+
+    private var queues: [URL: [Result<Data, Error>]] = [:]
+    private(set) var calls: [RecordedCall] = []
+
+    /// When true, an exhausted queue answers `authorization_pending`
+    /// instead of throwing — for cancellation tests that must spin.
+    private let defaultToPending: Bool
+
+    init(defaultToPending: Bool = false) {
+        self.defaultToPending = defaultToPending
+    }
+
+    var recorded: [RecordedCall] {
+        calls
+    }
+
+    func enqueue(_ data: Data, for url: URL) {
+        queues[url, default: []].append(.success(data))
+    }
+
+    func post(_ url: URL, form: [String: String]) async throws -> Data {
+        calls.append(RecordedCall(url: url, form: form))
+        var queue = queues[url] ?? []
+        let next = queue.isEmpty ? nil : queue.removeFirst()
+        queues[url] = queue
+        guard let next else {
+            if defaultToPending {
+                return Self.pendingJSON
+            }
+            throw GithubOAuthError.invalidResponse
+        }
+        return try next.get()
+    }
+
+    private static let pendingJSON = (try? JSONSerialization.data(
+        withJSONObject: ["error": "authorization_pending"]
+    )) ?? Data()
+}
+
+/// Fast-forward clock: sleeps return immediately and record their
+/// requested durations so the poll loop is testable without real waits.
+private actor StubClock: GithubOAuth.Clock {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private(set) var sleptNanoseconds: [UInt64] = []
+
+    func sleep(nanoseconds: UInt64) async throws {
+        sleptNanoseconds.append(nanoseconds)
+    }
+}


### PR DESCRIPTION
## What

First slice of **M15 — GitHub source** (#179), the device-flow OAuth
seam per `docs/GITHUB-OAUTH-DESIGN.md`. No settings sheet, no token
store, no git verbs yet — those are the next slices. This lands the
payload and the state machine so the sheet slice has something to
drive.

- **`Sources/Workspace/GitHub/GithubSource.swift`** — the
  `SourceKind.github` payload: identity (`owner/repo`, default branch,
  display-only granted scopes) + working-copy security-scoped bookmark.
  `tokenAccount` names the Keychain slot; the token itself is never in
  the payload (zero-leak). Transient fields (`isAvailable`, `branch`,
  `isSyncing`, `lastSyncError`) excluded from Codable.
- **`Sources/Workspace/GitHub/GithubOAuth.swift`** — device-flow state
  machine with injectable `HTTPTransport` + `Clock` (tests stub both;
  CI never touches GitHub):
  - `requestDeviceCode(clientID:scope:)` → session with `user_code`,
    `verification_uri`, `expires_at`, poll `interval`.
  - `pollForToken(...)` — one round; maps `authorization_pending` /
    `slow_down` / `expired_token` / `access_denied` / unknown to typed
    results, nothing swallowed.
  - `pollUntilToken(...)` — the cancellable loop the settings sheet
    runs in a `Task`: pending sleeps the server's interval, `slow_down`
    bumps it by 5 s, `Task.checkCancellation()` stops it on sheet
    close. The token crosses the boundary in a `SecureBuffer`.
  - `URLSessionGithubTransport` + `SystemGithubClock` production impls.
- **`SourceItem.github`** case across every switch (`id`/`title`/`kind`/
  `isAvailable`/`detailLine`/`branch`); `PlayHost` / `PreviewWindow` /
  `EditorWindow` gain the exhaustive case with an honest seam
  placeholder/fail until the working-copy slice lands.
- **`PersistedWorkspace.github`** — sources persist; custom `init(from:)`
  with `decodeIfPresent` keeps V1 payloads (no `github` key) decoding
  — caught by the existing V1 test, which would have failed silently
  under the synthesized decoder.

## Tests (12 scenarios, no network)

Device-code parse + server-error + invalid-response; poll success
(scopes, token bytes) + error-code mapping + missing-token; poll loop
pending→token with exact sleep cadence, `slow_down` +5 s bump, expired
terminal, and cancellation stopping the poller; `SourceItem.github`
exhaustiveness; payload round-trip excluding transient fields (and the
token never serialized); `PersistedWorkspace` round trip.

## Notable bugs caught by the tests

- `.convertFromSnakeCase` maps `verification_uri` → `verificationUri`,
  not `verificationURI` — the acronym spelling silently decoded nil.
- Synthesized Codable ignores default values on missing keys: V1
  persisted payloads would have failed to decode without the custom
  `init(from:)`.
- `NSLock` is unavailable from async contexts on this SDK — the test
  stubs are actors.

## Gates

`SKIP_EMBED_BORIS=1 make build` ✅ · `make test` 295 tests, 0 failures
✅ · `make lint` 0 violations (SwiftFormat + SwiftLint --strict) ✅ ·
spike scheme builds ✅. Docs-only #178 design gate already merged; this
is the first Swift slice of #179.
