### PR TITLE
feat(github): Add GitHub Account… sheet — device flow + PAT, Keychain token, clone-add (#179)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -21,6 +21,7 @@ settings:
     CODE_SIGN_STYLE: Manual
     CODE_SIGN_IDENTITY: "-"
     ENABLE_HARDENED_RUNTIME: YES
+    GITHUB_OAUTH_CLIENT_ID: ""
     ENABLE_USER_SCRIPT_SANDBOXING: NO
 
 targets:
@@ -48,6 +49,10 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_CFBundleDisplayName: Solipsist
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.developer-tools
+        # GitHub device-flow OAuth client id (M15). Public by design;
+        # an operator registers the OAuth App and injects the id here.
+        # Empty = the sheet offers the token (PAT) path only.
+        INFOPLIST_KEY_GithubOAuthClientID: "$(GITHUB_OAUTH_CLIENT_ID)"
         INFOPLIST_KEY_NSHumanReadableCopyright: "© 2026 draw me an elephant"
         INFOPLIST_KEY_NSPrincipalClass: NSApplication
     entitlements:

--- a/Sources/App/Settings/AddGithubAccountSheet.swift
+++ b/Sources/App/Settings/AddGithubAccountSheet.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+/// The M15 "Add GitHub Account…" sheet: device-flow OAuth with browser
+/// confirm, PAT fallback, repo resolution, clone, Keychain, add.
+struct AddGithubAccountSheet: View {
+    @Environment(WorkspaceStore.self) private var store
+    @Environment(\.dismiss) private var dismiss
+    @State private var flow = AddGithubFlowModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("Add GitHub Account", systemImage: "chevron.left.forwardslash.chevron.right")
+                .font(.headline)
+            content
+            if let error = flow.errorMessage {
+                Text(error)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Divider()
+            footer
+        }
+        .padding(20)
+        .frame(width: 460)
+        .onChange(of: flow.step) { _, step in
+            if case .done = step {
+                dismiss()
+            }
+        }
+        .onDisappear {
+            flow.cancel()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch flow.step {
+        case .chooseMethod:
+            chooseMethod
+        case .awaitingAuthorization(let userCode):
+            awaitingAuthorization(userCode: userCode)
+        case .tokenInput:
+            tokenInput
+        case .repo(let identity):
+            repoStep(identity: identity)
+        case .cloning(let owner, let repository):
+            cloning(owner: owner, repository: repository)
+        case .done:
+            EmptyView()
+        }
+    }
+
+    private var chooseMethod: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Sign in through your browser — GitHub shows a code, you confirm it here or on any device.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Button {
+                flow.startDeviceFlow()
+            } label: {
+                Label("Sign in with GitHub", systemImage: "safari")
+                    .frame(maxWidth: .infinity)
+            }
+            .controlSize(.large)
+            .disabled(flow.isBusy)
+
+            HStack {
+                Rectangle().frame(height: 1).foregroundStyle(.quaternary)
+                Text("or")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                Rectangle().frame(height: 1).foregroundStyle(.quaternary)
+            }
+
+            Text("Use a fine-grained personal access token (the app-password path). No browser needed.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Button {
+                flow.chooseTokenInput()
+            } label: {
+                Label("Use a token", systemImage: "key")
+                    .frame(maxWidth: .infinity)
+            }
+            .controlSize(.large)
+            .disabled(flow.isBusy)
+        }
+    }
+
+    private func awaitingAuthorization(userCode: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("GitHub is waiting for you to authorize Solipsist.")
+                .font(.callout)
+            HStack(spacing: 10) {
+                Text("Code:")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Text(userCode)
+                    .font(.system(.title3, design: .monospaced, weight: .bold))
+                    .textSelection(.enabled)
+                Spacer()
+            }
+            Button("Open GitHub") {
+                flow.reopenAuthorization()
+            }
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Waiting for you to confirm…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var tokenInput: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Paste a GitHub personal access token. It is saved to the Keychain and used for clone and sync.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            SecureField("github_pat_…", text: $flow.tokenText)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit {
+                    flow.useToken()
+                }
+            Button("Verify") {
+                flow.useToken()
+            }
+            .disabled(flow.isBusy)
+        }
+    }
+
+    private func repoStep(identity: AddGithubFlowModel.GithubIdentity) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Signed in as \(identity.login)\(identity.name.map { " (\($0))" } ?? "")")
+                .font(.callout)
+            if !identity.scopes.isEmpty {
+                Text("Granted scopes: \(identity.scopes.joined(separator: ", "))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 8) {
+                TextField("owner", text: $flow.ownerText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 140)
+                Text("/")
+                    .foregroundStyle(.secondary)
+                TextField("repository", text: $flow.repositoryText)
+                    .textFieldStyle(.roundedBorder)
+                Button("Check") {
+                    flow.resolveRepository()
+                }
+                .disabled(flow.isBusy)
+            }
+            if let info = flow.repositoryInfo {
+                Label(
+                    "\(info.fullName) — default branch \(info.defaultBranch)\(info.isPrivate ? ", private" : "")",
+                    systemImage: "checkmark.circle.fill"
+                )
+                .font(.callout)
+                .foregroundStyle(.green)
+            }
+            Button {
+                flow.cloneAndAdd(store: store)
+            } label: {
+                Label("Clone & Add", systemImage: "arrow.down.circle")
+                    .frame(maxWidth: .infinity)
+            }
+            .controlSize(.large)
+            .disabled(flow.isBusy || flow.repositoryInfo == nil)
+        }
+    }
+
+    private func cloning(owner: String, repository: String) -> some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text("Cloning \(owner)/\(repository)…")
+                .font(.callout)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            if case .done = flow.step {
+                EmptyView()
+            } else {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+            }
+        }
+    }
+}

--- a/Sources/App/Settings/AddGithubFlowModel.swift
+++ b/Sources/App/Settings/AddGithubFlowModel.swift
@@ -1,0 +1,328 @@
+import AppKit
+import Foundation
+import Observation
+
+/// Drives the Add GitHub Account… sheet (M15 / #179): device-flow OAuth
+/// (browser confirm + cancellable poll) or PAT paste, identity via
+/// `GET /user`, repo resolution, then clone → Keychain → source. The
+/// token lives in a `SecureBuffer` and is wiped on cancel / finish /
+/// dismissal.
+@MainActor
+@Observable
+final class AddGithubFlowModel {
+    enum Step: Equatable {
+        case chooseMethod
+        case awaitingAuthorization(userCode: String)
+        case tokenInput
+        case repo(GithubIdentity)
+        case cloning(owner: String, repository: String)
+        case done(GithubSource)
+    }
+
+    struct GithubIdentity: Equatable {
+        let login: String
+        let name: String?
+        let scopes: [String]
+    }
+
+    private(set) var step: Step = .chooseMethod
+    var tokenText = ""
+    var ownerText = ""
+    var repositoryText = ""
+    private(set) var repositoryInfo: GithubRepositoryInfo?
+    private(set) var errorMessage: String?
+    private(set) var isBusy = false
+
+    private let transport: GithubOAuth.HTTPTransport
+    private let clock: GithubOAuth.Clock
+    private let openBrowser: (URL) -> Void
+    private let tokenStore: GithubTokenStore
+    private let clientID: String?
+    private var token: SecureBuffer?
+    private var identity: GithubIdentity?
+    private var deviceSession: GithubOAuth.DeviceCodeSession?
+    private var pollTask: Task<Void, Never>?
+    private var cloneSession: CloneSession?
+
+    static let requestedScope = "repo"
+
+    init(
+        transport: GithubOAuth.HTTPTransport = URLSessionGithubTransport(),
+        clock: GithubOAuth.Clock = SystemGithubClock(),
+        openBrowser: @escaping (URL) -> Void = { NSWorkspace.shared.open($0) },
+        tokenStore: GithubTokenStore = GithubTokenStore(),
+        clientID: String? = AddGithubFlowModel.bundleClientID()
+    ) {
+        self.transport = transport
+        self.clock = clock
+        self.openBrowser = openBrowser
+        self.tokenStore = tokenStore
+        self.clientID = clientID
+    }
+
+    // MARK: - Device flow
+
+    func startDeviceFlow() {
+        guard let clientID, !clientID.isEmpty else {
+            fail(
+                "This build has no GitHub OAuth client id (an operator step — see docs/GITHUB-OAUTH-DESIGN.md §3). Use “Use a token” instead.",
+                returningTo: .chooseMethod
+            )
+            return
+        }
+        isBusy = true
+        pollTask = Task {
+            do {
+                let session = try await GithubOAuth.requestDeviceCode(
+                    clientID: clientID,
+                    scope: Self.requestedScope,
+                    transport: transport,
+                    clock: clock
+                )
+                deviceSession = session
+                openBrowser(session.verificationURI)
+                step = .awaitingAuthorization(userCode: session.userCode)
+                await pollForToken(session: session, clientID: clientID)
+            } catch is CancellationError {
+                reset()
+            } catch {
+                fail(Self.describe(error), returningTo: .chooseMethod)
+                isBusy = false
+            }
+        }
+    }
+
+    func reopenAuthorization() {
+        guard let deviceSession else { return }
+        openBrowser(deviceSession.verificationURI)
+    }
+
+    private func pollForToken(session: GithubOAuth.DeviceCodeSession, clientID: String) async {
+        do {
+            let result = try await GithubOAuth.pollUntilToken(
+                session: session,
+                clientID: clientID,
+                transport: transport,
+                clock: clock
+            )
+            switch result {
+            case .success(let granted):
+                token = granted.token
+                isBusy = false
+                await verifyUser(scopes: granted.scopes)
+            case .expired:
+                fail("The device code expired. Start again.", returningTo: .chooseMethod)
+            case .denied:
+                fail("Authorization was denied.", returningTo: .chooseMethod)
+            case let .failed(code, message):
+                fail("\(code): \(message)", returningTo: .chooseMethod)
+            case .pending, .slowDown:
+                break
+            }
+        } catch is CancellationError {
+            reset()
+        } catch {
+            fail(Self.describe(error), returningTo: .chooseMethod)
+        }
+    }
+
+    // MARK: - Token (PAT) fallback
+
+    func chooseTokenInput() {
+        step = .tokenInput
+    }
+
+    func useToken() {
+        let trimmed = tokenText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            fail("Paste a GitHub personal access token first.", returningTo: .tokenInput)
+            return
+        }
+        tokenText = ""
+        token = SecureBuffer(utf8String: trimmed)
+        isBusy = true
+        Task {
+            await verifyUser(scopes: [])
+        }
+    }
+
+    // MARK: - Identity + repository
+
+    private func verifyUser(scopes: [String]) async {
+        guard let token else {
+            fail("No token to verify.", returningTo: .chooseMethod)
+            return
+        }
+        isBusy = true
+        do {
+            let user = try await GithubAPIClient.user(bearer: token, transport: transport)
+            let identity = GithubIdentity(login: user.login, name: user.name, scopes: scopes)
+            self.identity = identity
+            step = .repo(identity)
+            isBusy = false
+        } catch is CancellationError {
+            reset()
+        } catch {
+            fail(Self.describe(error), returningTo: .chooseMethod)
+            isBusy = false
+        }
+    }
+
+    func resolveRepository() {
+        let owner = ownerText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let repository = repositoryText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let token else { return }
+        guard !owner.isEmpty, !repository.isEmpty else {
+            fail("Enter owner and repository (for example: acme/blog).", returningTo: currentRepoStep)
+            return
+        }
+        isBusy = true
+        Task {
+            do {
+                let info = try await GithubAPIClient.repository(
+                    owner: owner,
+                    repository: repository,
+                    bearer: token,
+                    transport: transport
+                )
+                repositoryInfo = info
+                isBusy = false
+            } catch {
+                repositoryInfo = nil
+                fail(Self.describe(error), returningTo: currentRepoStep)
+                isBusy = false
+            }
+        }
+    }
+
+    // MARK: - Clone + add
+
+    func cloneAndAdd(store: WorkspaceStore) {
+        guard let token, let identity, let info = repositoryInfo else { return }
+        let owner = ownerText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let repository = repositoryText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !owner.isEmpty, !repository.isEmpty else { return }
+
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Clone Into"
+        panel.message = "\(owner)/\(repository) will be cloned into the folder you choose."
+        guard panel.runModal() == .OK, let parent = panel.url else {
+            step = currentRepoStep
+            return
+        }
+
+        let dest = parent.appendingPathComponent(repository, isDirectory: true)
+        let urlString = "https://github.com/\(owner)/\(repository).git"
+        let session = CloneSession()
+        cloneSession = session
+        step = .cloning(owner: owner, repository: repository)
+        isBusy = true
+        Task {
+            // Persist the token first (design §3 step 5): a save failure
+            // aborts before any clone, so a retry is clean. A clone
+            // failure leaves the token in the Keychain — accepted, the
+            // same posture as any OAuth app.
+            do {
+                try tokenStore.save(token, owner: owner, repository: repository)
+            } catch {
+                cloneSession = nil
+                isBusy = false
+                fail("The token could not be saved: \(Self.describe(error))", returningTo: currentRepoStep)
+                return
+            }
+
+            let result: GitClone.CloneResult
+            do {
+                result = try await Task.detached {
+                    try GitClone.clone(url: urlString, to: dest, session: session)
+                }.value
+            } catch {
+                cloneSession = nil
+                isBusy = false
+                fail("git clone failed: \(Self.describe(error))", returningTo: currentRepoStep)
+                return
+            }
+            cloneSession = nil
+            guard result.isSuccess else {
+                isBusy = false
+                fail(
+                    "git clone failed (exit \(result.exitCode)): \(result.stderr)",
+                    returningTo: currentRepoStep
+                )
+                return
+            }
+
+            if let source = store.addGithub(
+                workingCopy: dest,
+                owner: owner,
+                repository: repository,
+                defaultBranch: info.defaultBranch,
+                grantedScopes: identity.scopes
+            ) {
+                isBusy = false
+                step = .done(source)
+            } else {
+                isBusy = false
+                fail("The working copy was cloned but could not be added: \(store.lastError ?? "unknown error")", returningTo: currentRepoStep)
+            }
+        }
+    }
+
+    func cancel() {
+        pollTask?.cancel()
+        cloneSession?.terminate()
+        reset()
+    }
+
+    // MARK: - Helpers
+
+    private var currentRepoStep: Step {
+        if let identity {
+            return .repo(identity)
+        }
+        return .chooseMethod
+    }
+
+    private func fail(_ message: String, returningTo step: Step) {
+        errorMessage = message
+        self.step = step
+    }
+
+    private func reset() {
+        pollTask = nil
+        cloneSession = nil
+        deviceSession = nil
+        token?.wipe()
+        token = nil
+        identity = nil
+        repositoryInfo = nil
+        errorMessage = nil
+        isBusy = false
+        step = .chooseMethod
+    }
+
+    static func bundleClientID() -> String? {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: "GithubOAuthClientID") as? String,
+              !value.isEmpty
+        else { return nil }
+        return value
+    }
+
+    static func describe(_ error: Error) -> String {
+        if let github = error as? GithubOAuthError {
+            switch github {
+            case let .deviceCodeFailed(code, message):
+                return "\(code): \(message)"
+            case let .httpStatus(status, message):
+                return "GitHub returned \(status): \(message)"
+            case .invalidResponse:
+                return "GitHub returned an unexpected response."
+            }
+        }
+        return String(describing: error)
+    }
+}

--- a/Sources/App/Settings/SourcesSettingsPane.swift
+++ b/Sources/App/Settings/SourcesSettingsPane.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct SourcesSettingsPane: View {
     @Environment(WorkspaceStore.self) private var store
     @State private var confirmRemove = false
+    @State private var showAddGithub = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -14,7 +15,7 @@ struct SourcesSettingsPane: View {
                 sourceList
                 actionBar
                 Text(
-                    "A source is a place content lives. Local folders now. GitHub — and other remotes — later, in this same list."
+                    "A source is a place content lives: local folders and GitHub accounts, in this same list."
                 )
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -34,6 +35,9 @@ struct SourcesSettingsPane: View {
             }
         } message: {
             Text("The folder on disk is not deleted.")
+        }
+        .sheet(isPresented: $showAddGithub) {
+            AddGithubAccountSheet()
         }
     }
 
@@ -66,6 +70,9 @@ struct SourcesSettingsPane: View {
                 Button("Add Git Repository…") {
                     store.presentClonePanel()
                 }
+                Button("Add GitHub Account…") {
+                    showAddGithub = true
+                }
             }
             Button("Relocate…") {
                 if let id = store.selection.sourceID {
@@ -89,7 +96,7 @@ struct SourcesSettingsPane: View {
                 .foregroundStyle(.secondary)
             Text("No Sources")
                 .font(.headline)
-            Text("A source is a place content lives — an account, not a file tree. Local folders now (a folder with `boris.json`, for example `Stunts/happy`). GitHub and other remotes later, in this same list.")
+            Text("A source is a place content lives — an account, not a file tree. Local folders (a folder with `boris.json`, for example `Stunts/happy`) and GitHub accounts, in this same list.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -99,6 +106,9 @@ struct SourcesSettingsPane: View {
             }
             Button("Add Git Repository…") {
                 store.presentClonePanel()
+            }
+            Button("Add GitHub Account…") {
+                showAddGithub = true
             }
             Spacer(minLength: 0)
         }

--- a/Sources/Security/GithubTokenStore.swift
+++ b/Sources/Security/GithubTokenStore.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// GitHub source token lifecycle (M15 / #179): Keychain persistence
+/// only, wrapped in `SecureBuffer`. The account
+/// `github:<owner>/<repo>` matches `GithubSource.tokenAccount`; the
+/// token never touches UserDefaults, plists, argv, env, or logs
+/// (zero-leak invariant).
+struct GithubTokenStore: Sendable {
+    let keychain: KeychainStoring
+    let service: String
+
+    init(keychain: KeychainStoring = KeychainStore(), service: String = KeychainStore.defaultService) {
+        self.keychain = keychain
+        self.service = service
+    }
+
+    func save(_ token: SecureBuffer, owner: String, repository: String) throws {
+        try keychain.saveSecret(token, account: account(owner: owner, repository: repository), service: service)
+    }
+
+    func load(owner: String, repository: String) throws -> SecureBuffer? {
+        try keychain.loadSecret(account: account(owner: owner, repository: repository), service: service)
+    }
+
+    func delete(owner: String, repository: String) throws {
+        try keychain.deleteSecret(account: account(owner: owner, repository: repository), service: service)
+    }
+
+    func hasToken(owner: String, repository: String) -> Bool {
+        keychain.hasSecret(account: account(owner: owner, repository: repository), service: service)
+    }
+
+    private func account(owner: String, repository: String) -> String {
+        "github:\(owner)/\(repository)"
+    }
+}

--- a/Sources/Workspace/Git/GitClone.swift
+++ b/Sources/Workspace/Git/GitClone.swift
@@ -80,11 +80,23 @@ public enum GitClone {
 
     /// Run `/usr/bin/git clone -- <url> <dest>`. SIGTERM on the child is
     /// available through the returned session. Blocks until the clone
-    /// finishes; call off the main actor.
-    public static func clone(url: String, to dest: URL, session: CloneSession) throws -> CloneResult {
+    /// finishes; call off the main actor. `environment` merges over the
+    /// inherited environment — the default disables git's interactive
+    /// terminal prompts so a private repo without credentials fails
+    /// fast with git's error instead of hanging on a hidden prompt.
+    public static func clone(
+        url: String,
+        to dest: URL,
+        session: CloneSession,
+        environment: [String: String] = [:]
+    ) throws -> CloneResult {
         let process = Process()
         process.executableURL = gitExecutableURL()
         process.arguments = ["clone", "--", url, dest.path]
+        var env = ProcessInfo.processInfo.environment
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env.merge(environment) { _, new in new }
+        process.environment = env
         let errPipe = Pipe()
         process.standardOutput = FileHandle.nullDevice
         process.standardError = errPipe

--- a/Sources/Workspace/GitHub/GithubAPIClient.swift
+++ b/Sources/Workspace/GitHub/GithubAPIClient.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// The authenticated user, from `GET /user`. `name` is optional — not
+/// every account sets one.
+struct GithubUser: Decodable, Equatable, Sendable {
+    let login: String
+    let name: String?
+    let id: Int
+}
+
+/// Repository identity from `GET /repos/{owner}/{repo}`: the default
+/// branch comes from the remote, never guessed (M15).
+struct GithubRepositoryInfo: Decodable, Equatable, Sendable {
+    let fullName: String
+    let defaultBranch: String
+    let isPrivate: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case fullName = "full_name"
+        case defaultBranch = "default_branch"
+        case isPrivate = "private"
+    }
+}
+
+/// Minimal GitHub REST surface (M15 / #179): identity + repo default
+/// branch. Boris has no GitHub API — the app owns this. Tokens ride as
+/// `SecureBuffer`; the transport builds the Authorization header. Error
+/// bodies surface as `GithubOAuthError.httpStatus`, never swallowed.
+enum GithubAPIClient {
+    static let userURL = URL(string: "https://api.github.com/user")!
+
+    static func repositoryURL(owner: String, repository: String) -> URL {
+        URL(string: "https://api.github.com/repos/\(owner)/\(repository)")!
+    }
+
+    static func user(bearer: SecureBuffer, transport: GithubOAuth.HTTPTransport) async throws -> GithubUser {
+        let data = try await transport.get(userURL, bearer: bearer)
+        return try decode(GithubUser.self, from: data)
+    }
+
+    static func repository(
+        owner: String,
+        repository: String,
+        bearer: SecureBuffer,
+        transport: GithubOAuth.HTTPTransport
+    ) async throws -> GithubRepositoryInfo {
+        let data = try await transport.get(
+            repositoryURL(owner: owner, repository: repository),
+            bearer: bearer
+        )
+        return try decode(GithubRepositoryInfo.self, from: data)
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            throw GithubOAuthError.invalidResponse
+        }
+    }
+}

--- a/Sources/Workspace/GitHub/GithubOAuth.swift
+++ b/Sources/Workspace/GitHub/GithubOAuth.swift
@@ -43,10 +43,12 @@ enum GithubOAuth {
         case failed(code: String, message: String)
     }
 
-    /// Form-encoded POST transport. Tests inject a stub; CI never
-    /// touches GitHub.
+    /// Form-encoded POST + bearer GET transport. Tests inject a stub;
+    /// CI never touches GitHub. The bearer token stays in a
+    /// `SecureBuffer` — the transport builds the header from its bytes.
     protocol HTTPTransport: Sendable {
         func post(_ url: URL, form: [String: String]) async throws -> Data
+        func get(_ url: URL, bearer: SecureBuffer) async throws -> Data
     }
 
     /// Clock seam: the poller sleeps and computes expiry through this,
@@ -196,11 +198,14 @@ enum GithubOAuth {
 enum GithubOAuthError: Error, Equatable, Sendable {
     case deviceCodeFailed(code: String, message: String)
     case invalidResponse
-    case httpStatus(Int)
+    /// Non-2xx from GitHub. `message` is the response body (truncated),
+    /// surfaced verbatim — never swallowed (D11).
+    case httpStatus(Int, message: String)
 }
 
-/// Production transport: form-encoded POST over URLSession. Non-2xx
-/// responses throw `GithubOAuthError.httpStatus` — never swallowed.
+/// Production transport: form-encoded POST + bearer GET over
+/// URLSession. Non-2xx responses throw `GithubOAuthError.httpStatus`
+/// with the body message — never swallowed.
 struct URLSessionGithubTransport: GithubOAuth.HTTPTransport {
     func post(_ url: URL, form: [String: String]) async throws -> Data {
         var request = URLRequest(url: url)
@@ -211,9 +216,35 @@ struct URLSessionGithubTransport: GithubOAuth.HTTPTransport {
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1
-            throw GithubOAuthError.httpStatus(status)
+            throw GithubOAuthError.httpStatus(status, message: Self.errorMessage(from: data))
         }
         return data
+    }
+
+    func get(_ url: URL, bearer: SecureBuffer) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.setValue(Self.bearerHeader(bearer), forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw GithubOAuthError.httpStatus(status, message: Self.errorMessage(from: data))
+        }
+        return data
+    }
+
+    /// The token's only stop outside the buffer: the Authorization
+    /// header value, transient inside the request, released by ARC.
+    private static func bearerHeader(_ buffer: SecureBuffer) -> String {
+        guard !buffer.isEmpty else { return "" }
+        let bytes = buffer.copyBytes()
+        return "Bearer " + (String(decoding: bytes, as: UTF8.self))
+    }
+
+    private static func errorMessage(from data: Data) -> String {
+        let text = String(decoding: data, as: UTF8.self)
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(trimmed.prefix(300))
     }
 
     private static func formBody(_ fields: [String: String]) -> Data {

--- a/Sources/Workspace/GitHub/GithubSource.swift
+++ b/Sources/Workspace/GitHub/GithubSource.swift
@@ -57,4 +57,43 @@ struct GithubSource: PublicationSource, Hashable, Sendable, Codable {
     func workspaceRoot() throws -> URL {
         try resolve().url.standardizedFileURL
     }
+
+    /// Bookmark a freshly cloned working copy with the remote identity.
+    static func make(
+        workingCopy url: URL,
+        owner: String,
+        repository: String,
+        defaultBranch: String,
+        grantedScopes: [String]
+    ) throws -> GithubSource {
+        let data = try url.bookmarkData(
+            options: [.withSecurityScope],
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+        return GithubSource(
+            id: SourceID(),
+            title: "\(owner)/\(repository)",
+            owner: owner,
+            repository: repository,
+            defaultBranch: defaultBranch,
+            bookmarkData: data,
+            displayPath: url.standardizedFileURL.path,
+            grantedScopes: grantedScopes
+        )
+    }
+
+    /// Re-bookmark the same working copy after a stale-bookmark reload.
+    func refreshedBookmark() throws -> GithubSource {
+        let resolved = try resolve()
+        var next = try Self.make(
+            workingCopy: resolved.url,
+            owner: owner,
+            repository: repository,
+            defaultBranch: defaultBranch,
+            grantedScopes: grantedScopes
+        )
+        next.id = id
+        return next
+    }
 }

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -214,11 +214,15 @@ final class WorkspaceStore {
 
     private func resolvedURL(for id: SourceID) -> URL? {
         if let url = scopedURLs[id] { return url }
-        guard let item = sources.first(where: { $0.id == id }),
-              case .local(let local) = item,
-              let resolved = try? local.resolve().url
-        else { return nil }
-        return resolved.standardizedFileURL
+        guard let item = sources.first(where: { $0.id == id }) else { return nil }
+        switch item {
+        case .local(let local):
+            guard let resolved = try? local.resolve().url else { return nil }
+            return resolved.standardizedFileURL
+        case .github(let github):
+            guard let resolved = try? github.resolve().url else { return nil }
+            return resolved.standardizedFileURL
+        }
     }
 
     func addLocal(url: URL) {
@@ -243,6 +247,40 @@ final class WorkspaceStore {
             persist()
         } catch {
             lastError = String(describing: error)
+        }
+    }
+
+    /// Add an authenticated GitHub source (M15): the working copy was
+    /// already cloned by the sheet; here it is bookmarked like any
+    /// folder and the identity is attached. The token was saved to the
+    /// Keychain by the sheet under the same owner/repo.
+    @discardableResult
+    func addGithub(
+        workingCopy url: URL,
+        owner: String,
+        repository: String,
+        defaultBranch: String,
+        grantedScopes: [String]
+    ) -> GithubSource? {
+        lastError = nil
+        let standardized = url.standardizedFileURL
+        do {
+            var github = try GithubSource.make(
+                workingCopy: standardized,
+                owner: owner,
+                repository: repository,
+                defaultBranch: defaultBranch,
+                grantedScopes: grantedScopes
+            )
+            github = beginAccess(github)
+            sources.append(.github(github))
+            select(github.id)
+            noteRecent(standardized)
+            persist()
+            return github
+        } catch {
+            lastError = String(describing: error)
+            return nil
         }
     }
 
@@ -272,14 +310,29 @@ final class WorkspaceStore {
         }
 
         do {
-            var local = try LocalSource.make(from: standardized)
-            local.id = id
             endAccess(id)
-            local = beginAccess(local)
-            if let index = sources.firstIndex(where: { $0.id == id }) {
-                sources[index] = .local(local)
+            if let index = sources.firstIndex(where: { $0.id == id }),
+               case .github(let github) = sources[index]
+            {
+                var next = try GithubSource.make(
+                    workingCopy: standardized,
+                    owner: github.owner,
+                    repository: github.repository,
+                    defaultBranch: github.defaultBranch,
+                    grantedScopes: github.grantedScopes
+                )
+                next.id = id
+                next = beginAccess(next)
+                sources[index] = .github(next)
             } else {
-                sources.append(.local(local))
+                var local = try LocalSource.make(from: standardized)
+                local.id = id
+                local = beginAccess(local)
+                if let index = sources.firstIndex(where: { $0.id == id }) {
+                    sources[index] = .local(local)
+                } else {
+                    sources.append(.local(local))
+                }
             }
             select(id)
             noteRecent(standardized)
@@ -325,10 +378,15 @@ final class WorkspaceStore {
             if case .local(let local) = item { return local }
             return nil
         }
+        let githubs: [GithubSource] = sources.compactMap { item in
+            if case .github(let github) = item { return github }
+            return nil
+        }
         let payload = PersistedWorkspace(
             sources: locals,
             selected: selection.sourceID,
-            mailbox: selection.mailbox
+            mailbox: selection.mailbox,
+            github: githubs
         )
         do {
             defaults.set(try WorkspacePersistence.encode(payload), forKey: WorkspacePersistence.defaultsKey)
@@ -351,6 +409,13 @@ final class WorkspaceStore {
                     refreshed = true
                 }
                 return .local(local)
+            }
+            sources += payload.github.map { raw in
+                var github = beginAccess(raw)
+                if github.isAvailable, github.bookmarkData != raw.bookmarkData {
+                    refreshed = true
+                }
+                return .github(github)
             }
             selection = WorkspaceSelectionRules.restore(
                 selected: payload.selected,
@@ -405,6 +470,36 @@ final class WorkspaceStore {
             local.isAvailable = false
         }
         return local
+    }
+
+    /// GitHub working-copy variant: resolve the bookmark, start access,
+    /// refresh a stale bookmark, read the branch. Same failure posture
+    /// as the local path — unavailable badge, no `lastError`.
+    private func beginAccess(_ source: GithubSource) -> GithubSource {
+        var github = source
+        do {
+            let resolved = try github.resolve()
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(
+                atPath: resolved.url.path,
+                isDirectory: &isDirectory
+            ) && isDirectory.boolValue
+            guard exists, resolved.url.startAccessingSecurityScopedResource() else {
+                github.isAvailable = false
+                return github
+            }
+            scopedURLs[github.id] = resolved.url
+            github.displayPath = resolved.url.standardizedFileURL.path
+            github.title = "\(github.owner)/\(github.repository)"
+            github.isAvailable = true
+            if resolved.stale, let refreshed = try? github.refreshedBookmark() {
+                github.bookmarkData = refreshed.bookmarkData
+            }
+            github.branch = GitClone.currentBranch(at: resolved.url)
+        } catch {
+            github.isAvailable = false
+        }
+        return github
     }
 
     private func endAccess(_ id: SourceID) {

--- a/Tests/ContractTests/GithubAPIClientTests.swift
+++ b/Tests/ContractTests/GithubAPIClientTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+final class GithubAPIClientTests: XCTestCase {
+    func testUserDecode() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["login": "octocat", "name": "Mona", "id": 1]),
+            for: GithubAPIClient.userURL
+        )
+
+        let user = try await GithubAPIClient.user(
+            bearer: SecureBuffer(utf8String: "gho_test"),
+            transport: transport
+        )
+
+        XCTAssertEqual(user.login, "octocat")
+        XCTAssertEqual(user.name, "Mona")
+        XCTAssertEqual(user.id, 1)
+    }
+
+    func testUserWithoutNameDecodes() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(json(["login": "octocat", "id": 2]), for: GithubAPIClient.userURL)
+
+        let user = try await GithubAPIClient.user(
+            bearer: SecureBuffer(utf8String: "gho_test"),
+            transport: transport
+        )
+
+        XCTAssertEqual(user.login, "octocat")
+        XCTAssertNil(user.name)
+    }
+
+    func testRepositoryDecode() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["full_name": "acme/blog", "default_branch": "main", "private": false]),
+            for: GithubAPIClient.repositoryURL(owner: "acme", repository: "blog")
+        )
+
+        let repo = try await GithubAPIClient.repository(
+            owner: "acme",
+            repository: "blog",
+            bearer: SecureBuffer(utf8String: "gho_test"),
+            transport: transport
+        )
+
+        XCTAssertEqual(repo.fullName, "acme/blog")
+        XCTAssertEqual(repo.defaultBranch, "main")
+        XCTAssertFalse(repo.isPrivate)
+    }
+
+    func testRepositoryPrivateDecodes() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["full_name": "acme/private", "default_branch": "trunk", "private": true]),
+            for: GithubAPIClient.repositoryURL(owner: "acme", repository: "private")
+        )
+
+        let repo = try await GithubAPIClient.repository(
+            owner: "acme",
+            repository: "private",
+            bearer: SecureBuffer(utf8String: "gho_test"),
+            transport: transport
+        )
+
+        XCTAssertTrue(repo.isPrivate)
+        XCTAssertEqual(repo.defaultBranch, "trunk")
+    }
+
+    func testErrorSurfacesMessage() async {
+        let transport = StubTransport()
+        await transport.enqueue(
+            error: GithubOAuthError.httpStatus(404, message: "Not Found"),
+            for: GithubAPIClient.repositoryURL(owner: "acme", repository: "missing")
+        )
+
+        do {
+            _ = try await GithubAPIClient.repository(
+                owner: "acme",
+                repository: "missing",
+                bearer: SecureBuffer(utf8String: "gho_test"),
+                transport: transport
+            )
+            XCTFail("expected httpStatus")
+        } catch let GithubOAuthError.httpStatus(status, message) {
+            XCTAssertEqual(status, 404)
+            XCTAssertEqual(message, "Not Found")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testMalformedBodyIsInvalidResponse() async {
+        let transport = StubTransport()
+        await transport.enqueue(json(["unexpected": true]), for: GithubAPIClient.userURL)
+
+        do {
+            _ = try await GithubAPIClient.user(
+                bearer: SecureBuffer(utf8String: "gho_test"),
+                transport: transport
+            )
+            XCTFail("expected invalidResponse")
+        } catch GithubOAuthError.invalidResponse {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testBearerRidesTheGetRequest() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(json(["login": "octocat", "id": 1]), for: GithubAPIClient.userURL)
+
+        _ = try await GithubAPIClient.user(
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        let recorded = await transport.recorded
+        let call = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(call.url, GithubAPIClient.userURL)
+        XCTAssertNil(call.form)
+        XCTAssertEqual(call.bearerBytes, Array("gho_secret".utf8))
+    }
+}

--- a/Tests/ContractTests/GithubOAuthTests.swift
+++ b/Tests/ContractTests/GithubOAuthTests.swift
@@ -28,9 +28,9 @@ final class GithubOAuthTests: XCTestCase {
         let recorded = await transport.recorded
         let call = try XCTUnwrap(recorded.first)
         XCTAssertEqual(call.url, GithubOAuth.deviceCodeURL)
-        XCTAssertEqual(call.form["client_id"], "client-1")
-        XCTAssertEqual(call.form["scope"], "repo")
-        XCTAssertEqual(call.form.count, 2, "only client_id + scope, never more")
+        XCTAssertEqual(call.form?["client_id"], "client-1")
+        XCTAssertEqual(call.form?["scope"], "repo")
+        XCTAssertEqual(call.form?.count, 2, "only client_id + scope, never more")
     }
 
     func testRequestDeviceCodeSurfacesErrors() async {
@@ -130,9 +130,9 @@ final class GithubOAuthTests: XCTestCase {
         let recorded = await transport.recorded
         let call = try XCTUnwrap(recorded.first)
         XCTAssertEqual(call.url, GithubOAuth.accessTokenURL)
-        XCTAssertEqual(call.form["grant_type"], "urn:ietf:params:oauth:grant-type:device_code")
-        XCTAssertEqual(call.form["device_code"], "dc-123")
-        XCTAssertEqual(call.form["client_id"], "client-1")
+        XCTAssertEqual(call.form?["grant_type"], "urn:ietf:params:oauth:grant-type:device_code")
+        XCTAssertEqual(call.form?["device_code"], "dc-123")
+        XCTAssertEqual(call.form?["client_id"], "client-1")
     }
 
     // MARK: - Poll loop
@@ -287,10 +287,6 @@ final class GithubOAuthTests: XCTestCase {
     }
 }
 
-private func json(_ object: [String: Any]) -> Data {
-    (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
-}
-
 private func makeSession(interval: TimeInterval) -> GithubOAuth.DeviceCodeSession {
     GithubOAuth.DeviceCodeSession(
         deviceCode: "dc-123",
@@ -312,61 +308,4 @@ private func makeSource() -> GithubSource {
         displayPath: "/tmp/blog",
         grantedScopes: ["repo"]
     )
-}
-
-/// Records calls and returns queued responses per URL. An actor: the
-/// poll loop and the test both touch it across await points.
-private actor StubTransport: GithubOAuth.HTTPTransport {
-    struct RecordedCall: Equatable, Sendable {
-        let url: URL
-        let form: [String: String]
-    }
-
-    private var queues: [URL: [Result<Data, Error>]] = [:]
-    private(set) var calls: [RecordedCall] = []
-
-    /// When true, an exhausted queue answers `authorization_pending`
-    /// instead of throwing — for cancellation tests that must spin.
-    private let defaultToPending: Bool
-
-    init(defaultToPending: Bool = false) {
-        self.defaultToPending = defaultToPending
-    }
-
-    var recorded: [RecordedCall] {
-        calls
-    }
-
-    func enqueue(_ data: Data, for url: URL) {
-        queues[url, default: []].append(.success(data))
-    }
-
-    func post(_ url: URL, form: [String: String]) async throws -> Data {
-        calls.append(RecordedCall(url: url, form: form))
-        var queue = queues[url] ?? []
-        let next = queue.isEmpty ? nil : queue.removeFirst()
-        queues[url] = queue
-        guard let next else {
-            if defaultToPending {
-                return Self.pendingJSON
-            }
-            throw GithubOAuthError.invalidResponse
-        }
-        return try next.get()
-    }
-
-    private static let pendingJSON = (try? JSONSerialization.data(
-        withJSONObject: ["error": "authorization_pending"]
-    )) ?? Data()
-}
-
-/// Fast-forward clock: sleeps return immediately and record their
-/// requested durations so the poll loop is testable without real waits.
-private actor StubClock: GithubOAuth.Clock {
-    let now = Date(timeIntervalSince1970: 1_700_000_000)
-    private(set) var sleptNanoseconds: [UInt64] = []
-
-    func sleep(nanoseconds: UInt64) async throws {
-        sleptNanoseconds.append(nanoseconds)
-    }
 }

--- a/Tests/ContractTests/GithubTestSupport.swift
+++ b/Tests/ContractTests/GithubTestSupport.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+// Shared GitHub test doubles: queued-response transport + fast-forward
+// clock. No network in CI — everything is injected.
+
+func json(_ object: [String: Any]) -> Data {
+    (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
+}
+
+/// Records calls and returns queued responses per URL. An actor: the
+/// poll loop and the test both touch it across await points.
+actor StubTransport: GithubOAuth.HTTPTransport {
+    struct RecordedCall: Equatable, Sendable {
+        let url: URL
+        /// Form body for POSTs; nil for GETs.
+        let form: [String: String]?
+        /// Bearer token bytes for GETs; nil for POSTs.
+        let bearerBytes: [UInt8]?
+    }
+
+    private var queues: [URL: [Result<Data, Error>]] = [:]
+    private(set) var calls: [RecordedCall] = []
+
+    /// When true, an exhausted queue answers `authorization_pending`
+    /// instead of throwing — for cancellation tests that must spin.
+    private let defaultToPending: Bool
+
+    init(defaultToPending: Bool = false) {
+        self.defaultToPending = defaultToPending
+    }
+
+    var recorded: [RecordedCall] {
+        calls
+    }
+
+    func enqueue(_ data: Data, for url: URL) {
+        queues[url, default: []].append(.success(data))
+    }
+
+    func enqueue(error: Error, for url: URL) {
+        queues[url, default: []].append(.failure(error))
+    }
+
+    func post(_ url: URL, form: [String: String]) async throws -> Data {
+        try await respond(to: url, form: form, bearerBytes: nil)
+    }
+
+    func get(_ url: URL, bearer: SecureBuffer) async throws -> Data {
+        try await respond(to: url, form: nil, bearerBytes: bearer.copyBytes())
+    }
+
+    private func respond(
+        to url: URL,
+        form: [String: String]?,
+        bearerBytes: [UInt8]?
+    ) async throws -> Data {
+        calls.append(RecordedCall(url: url, form: form, bearerBytes: bearerBytes))
+        var queue = queues[url] ?? []
+        let next = queue.isEmpty ? nil : queue.removeFirst()
+        queues[url] = queue
+        guard let next else {
+            if defaultToPending {
+                return Self.pendingJSON
+            }
+            throw GithubOAuthError.invalidResponse
+        }
+        return try next.get()
+    }
+
+    private static let pendingJSON = (try? JSONSerialization.data(
+        withJSONObject: ["error": "authorization_pending"]
+    )) ?? Data()
+}
+
+/// Fast-forward clock: sleeps return immediately and record their
+/// requested durations so the poll loop is testable without real waits.
+actor StubClock: GithubOAuth.Clock {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private(set) var sleptNanoseconds: [UInt64] = []
+
+    func sleep(nanoseconds: UInt64) async throws {
+        sleptNanoseconds.append(nanoseconds)
+    }
+}

--- a/Tests/ContractTests/GithubTokenStoreTests.swift
+++ b/Tests/ContractTests/GithubTokenStoreTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+final class GithubTokenStoreTests: XCTestCase {
+    func testSaveLoadDelete() throws {
+        let store = GithubTokenStore(keychain: MockKeychainStore(), service: "test.service")
+        let token = SecureBuffer(utf8String: "gho_secret")
+
+        try store.save(token, owner: "acme", repository: "blog")
+
+        XCTAssertTrue(store.hasToken(owner: "acme", repository: "blog"))
+        let loaded = try store.load(owner: "acme", repository: "blog")
+        XCTAssertEqual(loaded?.copyBytes(), Array("gho_secret".utf8))
+
+        // Other repos are untouched.
+        XCTAssertNil(try store.load(owner: "acme", repository: "other"))
+
+        try store.delete(owner: "acme", repository: "blog")
+        XCTAssertFalse(store.hasToken(owner: "acme", repository: "blog"))
+        XCTAssertNil(try store.load(owner: "acme", repository: "blog"))
+    }
+
+    func testSaveOverwritesExistingToken() throws {
+        let store = GithubTokenStore(keychain: MockKeychainStore(), service: "test.service")
+
+        try store.save(SecureBuffer(utf8String: "gho_old"), owner: "acme", repository: "blog")
+        try store.save(SecureBuffer(utf8String: "gho_new"), owner: "acme", repository: "blog")
+
+        XCTAssertEqual(
+            try store.load(owner: "acme", repository: "blog")?.copyBytes(),
+            Array("gho_new".utf8)
+        )
+    }
+
+    func testAccountMatchesGithubSourceTokenAccount() throws {
+        let keychain = MockKeychainStore()
+        let store = GithubTokenStore(keychain: keychain, service: "svc")
+
+        try store.save(SecureBuffer(utf8String: "gho_t"), owner: "acme", repository: "blog")
+
+        // The Keychain account is `github:<owner>/<repo>` — the same
+        // account `GithubSource.tokenAccount` names.
+        XCTAssertNotNil(keychain.storage["svc:github:acme/blog"])
+        let source = GithubSource(
+            id: SourceID(),
+            title: "acme/blog",
+            owner: "acme",
+            repository: "blog",
+            defaultBranch: "main",
+            bookmarkData: Data([1, 2, 3]),
+            displayPath: "/tmp/blog",
+            grantedScopes: ["repo"]
+        )
+        XCTAssertEqual(source.tokenAccount, "github:acme/blog")
+    }
+}


### PR DESCRIPTION
## What

Second slice of **M15 — GitHub source** (#179), the "Add GitHub
Account…" settings sheet per `docs/GITHUB-OAUTH-DESIGN.md`. The OAuth
seam (#180) was the state machine; this is the flow that drives it.

- **`Sources/App/Settings/AddGithubAccountSheet.swift`** — the sheet:
  choose browser sign-in or token; device flow shows the `user_code`
  with an "Open GitHub" button and a cancellable poll spinner; token
  mode is a `SecureField`; repo step shows the signed-in identity +
  granted scopes, owner/repo fields with a Check that fetches the
  default branch, and Clone & Add.
- **`AddGithubFlowModel.swift`** (`@MainActor @Observable`, app-side
  glue like `PreviewWebModel`) — runs the device-code request, opens
  the browser, polls in a cancellable `Task` (cancel wipes the token),
  verifies via `GET /user`, resolves the repo, then clone → Keychain →
  `WorkspaceStore.addGithub`. The token lives in a `SecureBuffer`,
  wiped on cancel / dismiss / finish.
- **`GithubAPIClient.swift`** — `GET /user` + `GET /repos/{owner}/{repo}`
  (default branch from the remote, never guessed). Tokens ride the new
  transport `get(_:bearer:)` seam as `SecureBuffer`; non-2xx bodies
  surface as `GithubOAuthError.httpStatus(status, message)` — never
  swallowed (D11).
- **`GithubTokenStore.swift`** (`Sources/Security/`) — Keychain-only
  lifecycle, account `github:<owner>/<repo>` (matches
  `GithubSource.tokenAccount`); the token never touches UserDefaults /
  plists / argv / env / logs.
- **`WorkspaceStore`** — `addGithub` (bookmark + beginAccess + select +
  persist), github-aware `beginAccess`/`resolvedURL`/`relocate`, and
  `PersistedWorkspace.github` load/persist so the source survives
  relaunch.
- **`GitClone.clone`** — new `environment:` param; the default sets
  `GIT_TERMINAL_PROMPT=0` so a private repo without credentials fails
  fast with git's own error instead of hanging on a hidden prompt
  (the credential-helper slice makes private clones work).
- **`Project.yml`** — `GITHUB_OAUTH_CLIENT_ID` build setting →
  `GithubOAuthClientID` Info.plist key (operator step, public by
  design; empty = sheet offers the token path only, flow never dead).

## Tests (10 new, no network)

`GithubAPIClientTests` — user decode (with/without name), repo decode
(public/private, default branch), 404 message surfaced, malformed body
→ invalidResponse, bearer rides the GET. `GithubTokenStoreTests` —
save/load/delete isolation, overwrite, Keychain account parity with
`GithubSource.tokenAccount`. Shared doubles moved to
`GithubTestSupport.swift` (transport gained `get`; `form` optional in
recorded calls).

## Notable decisions

- Token is persisted **before** the clone (design §3 step 5): a save
  failure aborts cleanly with nothing on disk; a clone failure leaves
  the token in the Keychain — accepted, same posture as any OAuth app.
- The flow model is app-side (not unit-tested) matching the codebase's
  view-model pattern; the logic it calls (OAuth state machine, API
  client, token store, clone) is all tested.

## Gates

`SKIP_EMBED_BORIS=1 make build` ✅ · `make test` 305 tests, 0 failures
✅ · `make lint` 0 violations (SwiftFormat + SwiftLint --strict) ✅ ·
spike scheme ✅.
