### PR TITLE
feat(github): git-credential-solipsist helper mode — Keychain token for private clone/sync (#179)

### DIFF
--- a/Sources/App/Settings/AddGithubFlowModel.swift
+++ b/Sources/App/Settings/AddGithubFlowModel.swift
@@ -217,6 +217,7 @@ final class AddGithubFlowModel {
 
         let dest = parent.appendingPathComponent(repository, isDirectory: true)
         let urlString = "https://github.com/\(owner)/\(repository).git"
+        let helperApp = Bundle.main.executableURL
         let session = CloneSession()
         cloneSession = session
         step = .cloning(owner: owner, repository: repository)
@@ -227,7 +228,7 @@ final class AddGithubFlowModel {
             // failure leaves the token in the Keychain — accepted, the
             // same posture as any OAuth app.
             do {
-                try tokenStore.save(token, owner: owner, repository: repository)
+                try tokenStore.save(token)
             } catch {
                 cloneSession = nil
                 isBusy = false
@@ -238,7 +239,12 @@ final class AddGithubFlowModel {
             let result: GitClone.CloneResult
             do {
                 result = try await Task.detached {
-                    try GitClone.clone(url: urlString, to: dest, session: session)
+                    try GitClone.clone(
+                        url: urlString,
+                        to: dest,
+                        session: session,
+                        credentialHelperApp: helperApp
+                    )
                 }.value
             } catch {
                 cloneSession = nil

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -42,6 +42,20 @@ struct SolipsistApp: App {
     @State private var runtime = AppRuntime()
     @State private var inspectorPresented = true
 
+    /// Git's credential helper runs this same binary with
+    /// `--git-credential-helper` as the marker. Exit before AppKit
+    /// starts (no window server, no scenes) — like `xcodebuild
+    /// -runFirstLaunch`.
+    init() {
+        if CommandLine.arguments.contains(GitCredentialHelper.flag) {
+            GitCredentialHelper.runAndExit()
+        }
+        _appDelegate = NSApplicationDelegateAdaptor(AppDelegate.self)
+        _store = State(initialValue: WorkspaceStore())
+        _runtime = State(initialValue: AppRuntime())
+        _inspectorPresented = State(initialValue: true)
+    }
+
     var body: some Scene {
         WindowGroup {
             MainWindow(inspectorPresented: $inspectorPresented)

--- a/Sources/Security/GitCredentialHelper.swift
+++ b/Sources/Security/GitCredentialHelper.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// `git-credential-solipsist` — helper mode of the app binary (M15).
+/// Git is configured with
+/// `credential.helper=!"<app>" --git-credential-helper`; git runs the
+/// app with the operation as its last argument and the credential
+/// request on stdin. The helper answers github.com requests from the
+/// Keychain (account `github`, host-keyed — git omits the repo `path`
+/// from helper input, so a per-repo lookup is impossible) and prints
+/// `username=… password=…` on stdout. The token travels Keychain →
+/// helper stdout → git's pipe: never argv, never env, never on disk
+/// (zero-leak invariant).
+enum GitCredentialHelper {
+    /// argv marker the app's `init` checks before AppKit starts.
+    static let flag = "--git-credential-helper"
+
+    static func runAndExit() -> Never {
+        exit(run())
+    }
+
+    /// One helper invocation. Non-`get` operations (git may ask to
+    /// `store`/`erase`) are drained and ignored — the token only ever
+    /// enters the Keychain through the app's own flow. No matching
+    /// token → clean exit with no output; git fails with its own auth
+    /// error (which we surface verbatim).
+    static func run() -> Int32 {
+        let operation = CommandLine.arguments.dropFirst(2).first ?? "get"
+        guard operation == "get" else {
+            _ = readStdin()
+            return 0
+        }
+        let input = readStdin()
+        guard let output = credentialOutput(input: input, store: GithubTokenStore()) else {
+            return 0
+        }
+        writeStdout(output)
+        return 0
+    }
+
+    /// Produce the credential lines when the request is for github.com
+    /// and a token exists; nil otherwise. The loaded token is wiped
+    /// after the output string is built.
+    static func credentialOutput(input: String, store: GithubTokenStore) -> String? {
+        guard isGitHubHost(input) else { return nil }
+        guard let token = try? store.load() else { return nil }
+        let password = String(data: Data(token.copyBytes()), encoding: .utf8) ?? ""
+        token.wipe()
+        return "username=x-access-token\npassword=\(password)\n"
+    }
+
+    /// git sends `protocol=…`, `host=…`, `username=…` (no `path`).
+    static func isGitHubHost(_ input: String) -> Bool {
+        for line in input.split(separator: "\n") {
+            let parts = line.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            let key = parts[0].trimmingCharacters(in: .whitespaces)
+            let value = parts[1].trimmingCharacters(in: .whitespaces)
+            if key == "host" {
+                return value.lowercased() == "github.com"
+            }
+        }
+        return false
+    }
+
+    private static func readStdin() -> String {
+        let data = FileHandle.standardInput.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private static func writeStdout(_ text: String) {
+        FileHandle.standardOutput.write(Data(text.utf8))
+    }
+}

--- a/Sources/Security/GithubTokenStore.swift
+++ b/Sources/Security/GithubTokenStore.swift
@@ -1,11 +1,18 @@
 import Foundation
 
 /// GitHub source token lifecycle (M15 / #179): Keychain persistence
-/// only, wrapped in `SecureBuffer`. The account
-/// `github:<owner>/<repo>` matches `GithubSource.tokenAccount`; the
-/// token never touches UserDefaults, plists, argv, env, or logs
-/// (zero-leak invariant).
+/// only, wrapped in `SecureBuffer`; the token never touches
+/// UserDefaults, plists, argv, env, or logs (zero-leak invariant).
+///
+/// The account is host-keyed (`"github"`), not per-repo: git omits the
+/// repo `path` when it invokes credential helpers (probed against
+/// CLT/Xcode git), so a per-repo account could never be looked up. One
+/// device-flow token per GitHub user per OAuth client — the natural key
+/// is the host. Multiple GitHub accounts are a v1 limitation.
 struct GithubTokenStore: Sendable {
+    /// Keychain account for the GitHub token.
+    static let account = "github"
+
     let keychain: KeychainStoring
     let service: String
 
@@ -14,23 +21,19 @@ struct GithubTokenStore: Sendable {
         self.service = service
     }
 
-    func save(_ token: SecureBuffer, owner: String, repository: String) throws {
-        try keychain.saveSecret(token, account: account(owner: owner, repository: repository), service: service)
+    func save(_ token: SecureBuffer) throws {
+        try keychain.saveSecret(token, account: Self.account, service: service)
     }
 
-    func load(owner: String, repository: String) throws -> SecureBuffer? {
-        try keychain.loadSecret(account: account(owner: owner, repository: repository), service: service)
+    func load() throws -> SecureBuffer? {
+        try keychain.loadSecret(account: Self.account, service: service)
     }
 
-    func delete(owner: String, repository: String) throws {
-        try keychain.deleteSecret(account: account(owner: owner, repository: repository), service: service)
+    func delete() throws {
+        try keychain.deleteSecret(account: Self.account, service: service)
     }
 
-    func hasToken(owner: String, repository: String) -> Bool {
-        keychain.hasSecret(account: account(owner: owner, repository: repository), service: service)
-    }
-
-    private func account(owner: String, repository: String) -> String {
-        "github:\(owner)/\(repository)"
+    func hasToken() -> Bool {
+        keychain.hasSecret(account: Self.account, service: service)
     }
 }

--- a/Sources/Workspace/Git/GitClone.swift
+++ b/Sources/Workspace/Git/GitClone.swift
@@ -84,15 +84,24 @@ public enum GitClone {
     /// inherited environment — the default disables git's interactive
     /// terminal prompts so a private repo without credentials fails
     /// fast with git's error instead of hanging on a hidden prompt.
+    /// `credentialHelperApp` (when set) configures git to ask this app
+    /// binary for GitHub credentials via `credential.helper=` — the
+    /// helper mode reads the Keychain and prints the token on stdout;
+    /// the token never appears in argv, env, or on disk.
     public static func clone(
         url: String,
         to dest: URL,
         session: CloneSession,
-        environment: [String: String] = [:]
+        environment: [String: String] = [:],
+        credentialHelperApp: URL? = nil
     ) throws -> CloneResult {
         let process = Process()
         process.executableURL = gitExecutableURL()
-        process.arguments = ["clone", "--", url, dest.path]
+        var arguments = ["clone", "--", url, dest.path]
+        if let credentialHelperApp {
+            arguments.insert(contentsOf: credentialHelperArguments(appURL: credentialHelperApp), at: 0)
+        }
+        process.arguments = arguments
         var env = ProcessInfo.processInfo.environment
         env["GIT_TERMINAL_PROMPT"] = "0"
         env.merge(environment) { _, new in new }
@@ -114,6 +123,24 @@ public enum GitClone {
             exitCode: process.terminationStatus,
             stderr: String(decoding: errData, as: UTF8.self)
         )
+    }
+
+    /// `-c credential.helper=…` argument pair pointing git at this app
+    /// binary in helper mode. The `!` shell form quotes the path so
+    /// app locations with spaces work; git appends the operation
+    /// (`get`) as the last argument.
+    public static func credentialHelperArguments(appURL: URL) -> [String] {
+        let quoted = shellQuote(appURL.path)
+        return ["-c", "credential.helper=!\(quoted) \(GitCredentialHelper.flag)"]
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "$", with: "\\$")
+            .replacingOccurrences(of: "`", with: "\\`")
+        return "\"\(escaped)\""
     }
 
     /// Branch of the checkout at `root`, or nil when it is not a repo or

--- a/Sources/Workspace/GitHub/GithubSource.swift
+++ b/Sources/Workspace/GitHub/GithubSource.swift
@@ -5,8 +5,9 @@ import Foundation
 /// copy. Boris is a subprocess over a filesystem tree — every surface
 /// operates on the working copy exactly as it does for a Local source.
 ///
-/// The token is never here. It lives in the Keychain under
-/// `tokenAccount`; only display-only granted scopes are carried.
+/// The token is never here. It lives in the Keychain (host-keyed
+/// account `github` — see `GithubTokenStore`); only display-only
+/// granted scopes are carried.
 struct GithubSource: PublicationSource, Hashable, Sendable, Codable {
     var id: SourceID
     /// "owner/repo" — the account header title.
@@ -30,11 +31,6 @@ struct GithubSource: PublicationSource, Hashable, Sendable, Codable {
 
     enum CodingKeys: String, CodingKey {
         case id, title, owner, repository, defaultBranch, bookmarkData, displayPath, grantedScopes
-    }
-
-    /// Keychain account for this source's token: `github:<owner>/<repo>`.
-    var tokenAccount: String {
-        "github:\(owner)/\(repository)"
     }
 
     /// Repo page for "Open on GitHub".

--- a/Tests/ContractTests/GitCredentialHelperTests.swift
+++ b/Tests/ContractTests/GitCredentialHelperTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+
+final class GitCredentialHelperTests: XCTestCase {
+    // MARK: - Host gating
+
+    func testAcceptsGitHubHost() {
+        XCTAssertTrue(GitCredentialHelper.isGitHubHost("protocol=https\nhost=github.com\n"))
+    }
+
+    func testAcceptsHostWithTrailingLine() {
+        XCTAssertTrue(GitCredentialHelper.isGitHubHost("protocol=https\nhost=github.com\nusername=git\n"))
+    }
+
+    func testRejectsOtherHosts() {
+        XCTAssertFalse(GitCredentialHelper.isGitHubHost("protocol=https\nhost=gitlab.com\n"))
+        XCTAssertFalse(GitCredentialHelper.isGitHubHost("protocol=https\nhost=github.com.evil.example\n"))
+    }
+
+    func testAcceptsCaseInsensitiveHost() {
+        XCTAssertTrue(GitCredentialHelper.isGitHubHost("protocol=https\nhost=GITHUB.COM\n"))
+    }
+
+    func testRejectsMissingHost() {
+        XCTAssertFalse(GitCredentialHelper.isGitHubHost("protocol=https\n"))
+        XCTAssertFalse(GitCredentialHelper.isGitHubHost(""))
+    }
+
+    // MARK: - Credential output
+
+    func testCredentialOutputPrintsTokenLines() throws {
+        let store = GithubTokenStore(keychain: MockKeychainStore(), service: "test.service")
+        try store.save(SecureBuffer(utf8String: "gho_secret"))
+
+        let output = GitCredentialHelper.credentialOutput(
+            input: "protocol=https\nhost=github.com\nusername=git\n",
+            store: store
+        )
+
+        XCTAssertEqual(output, "username=x-access-token\npassword=gho_secret\n")
+    }
+
+    func testCredentialOutputNilWithoutToken() {
+        let store = GithubTokenStore(keychain: MockKeychainStore(), service: "test.service")
+
+        XCTAssertNil(GitCredentialHelper.credentialOutput(
+            input: "protocol=https\nhost=github.com\n",
+            store: store
+        ))
+    }
+
+    func testCredentialOutputNilForOtherHost() throws {
+        let store = GithubTokenStore(keychain: MockKeychainStore(), service: "test.service")
+        try store.save(SecureBuffer(utf8String: "gho_secret"))
+
+        XCTAssertNil(GitCredentialHelper.credentialOutput(
+            input: "protocol=https\nhost=gitlab.com\n",
+            store: store
+        ))
+    }
+
+    func testCredentialOutputIgnoresRequestedUsername() throws {
+        let store = GithubTokenStore(keychain: MockKeychainStore(), service: "test.service")
+        try store.save(SecureBuffer(utf8String: "gho_secret"))
+
+        let output = GitCredentialHelper.credentialOutput(
+            input: "protocol=https\nhost=github.com\nusername=someone-else\n",
+            store: store
+        )
+
+        // We answer with the machine token regardless of the username
+        // git asks for (git omits the repo path, so this is the only
+        // GitHub token we can serve).
+        XCTAssertEqual(output, "username=x-access-token\npassword=gho_secret\n")
+    }
+
+    // MARK: - Git config wiring
+
+    func testCredentialHelperArgumentsUseShellQuotedAppPath() {
+        let app = URL(fileURLWithPath: "/tmp/Solipsist.app/Contents/MacOS/Solipsist")
+        let args = GitClone.credentialHelperArguments(appURL: app)
+
+        XCTAssertEqual(args.count, 2)
+        XCTAssertEqual(args[0], "-c")
+        XCTAssertEqual(
+            args[1],
+            "credential.helper=!\"/tmp/Solipsist.app/Contents/MacOS/Solipsist\" --git-credential-helper"
+        )
+    }
+
+    func testCredentialHelperArgumentsQuoteSpacesAndShellChars() {
+        let app = URL(fileURLWithPath: "/tmp/app dir/$Solipsist")
+        let args = GitClone.credentialHelperArguments(appURL: app)
+
+        XCTAssertEqual(
+            args[1],
+            "credential.helper=!\"/tmp/app dir/\\$Solipsist\" --git-credential-helper"
+        )
+    }
+}

--- a/Tests/ContractTests/GithubOAuthTests.swift
+++ b/Tests/ContractTests/GithubOAuthTests.swift
@@ -218,7 +218,6 @@ final class GithubOAuthTests: XCTestCase {
         XCTAssertEqual(item.detailLine, "/tmp/blog")
         XCTAssertTrue(item.isAvailable)
         XCTAssertNil(item.branch)
-        XCTAssertEqual(source.tokenAccount, "github:acme/blog")
         XCTAssertEqual(source.remoteURL, URL(string: "https://github.com/acme/blog"))
 
         var unavailable = source

--- a/Tests/ContractTests/GithubTokenStoreTests.swift
+++ b/Tests/ContractTests/GithubTokenStoreTests.swift
@@ -3,53 +3,38 @@ import XCTest
 final class GithubTokenStoreTests: XCTestCase {
     func testSaveLoadDelete() throws {
         let store = GithubTokenStore(keychain: MockKeychainStore(), service: "test.service")
-        let token = SecureBuffer(utf8String: "gho_secret")
 
-        try store.save(token, owner: "acme", repository: "blog")
+        XCTAssertFalse(store.hasToken())
+        try store.save(SecureBuffer(utf8String: "gho_secret"))
 
-        XCTAssertTrue(store.hasToken(owner: "acme", repository: "blog"))
-        let loaded = try store.load(owner: "acme", repository: "blog")
+        XCTAssertTrue(store.hasToken())
+        let loaded = try store.load()
         XCTAssertEqual(loaded?.copyBytes(), Array("gho_secret".utf8))
 
-        // Other repos are untouched.
-        XCTAssertNil(try store.load(owner: "acme", repository: "other"))
-
-        try store.delete(owner: "acme", repository: "blog")
-        XCTAssertFalse(store.hasToken(owner: "acme", repository: "blog"))
-        XCTAssertNil(try store.load(owner: "acme", repository: "blog"))
+        try store.delete()
+        XCTAssertFalse(store.hasToken())
+        XCTAssertNil(try store.load())
     }
 
     func testSaveOverwritesExistingToken() throws {
         let store = GithubTokenStore(keychain: MockKeychainStore(), service: "test.service")
 
-        try store.save(SecureBuffer(utf8String: "gho_old"), owner: "acme", repository: "blog")
-        try store.save(SecureBuffer(utf8String: "gho_new"), owner: "acme", repository: "blog")
+        try store.save(SecureBuffer(utf8String: "gho_old"))
+        try store.save(SecureBuffer(utf8String: "gho_new"))
 
-        XCTAssertEqual(
-            try store.load(owner: "acme", repository: "blog")?.copyBytes(),
-            Array("gho_new".utf8)
-        )
+        XCTAssertEqual(try store.load()?.copyBytes(), Array("gho_new".utf8))
     }
 
-    func testAccountMatchesGithubSourceTokenAccount() throws {
+    func testHostKeyedAccount() throws {
         let keychain = MockKeychainStore()
         let store = GithubTokenStore(keychain: keychain, service: "svc")
 
-        try store.save(SecureBuffer(utf8String: "gho_t"), owner: "acme", repository: "blog")
+        try store.save(SecureBuffer(utf8String: "gho_t"))
 
-        // The Keychain account is `github:<owner>/<repo>` — the same
-        // account `GithubSource.tokenAccount` names.
-        XCTAssertNotNil(keychain.storage["svc:github:acme/blog"])
-        let source = GithubSource(
-            id: SourceID(),
-            title: "acme/blog",
-            owner: "acme",
-            repository: "blog",
-            defaultBranch: "main",
-            bookmarkData: Data([1, 2, 3]),
-            displayPath: "/tmp/blog",
-            grantedScopes: ["repo"]
-        )
-        XCTAssertEqual(source.tokenAccount, "github:acme/blog")
+        // Host-keyed, not per-repo: git omits the repo path from
+        // credential-helper input, so a per-repo account could never be
+        // looked up. One token serves every GitHub source.
+        XCTAssertEqual(GithubTokenStore.account, "github")
+        XCTAssertNotNil(keychain.storage["svc:github"])
     }
 }

--- a/docs/GITHUB-OAUTH-DESIGN.md
+++ b/docs/GITHUB-OAUTH-DESIGN.md
@@ -117,11 +117,18 @@ only persistence. CREDENTIAL-LIFECYCLE.md invariants hold verbatim:
 never argv, never env, never logs, never plaintext files.
 
 - **Keychain:** `kSecClassGenericPassword`, service
-  `dev.drawmeanelephant.solipsist`, account `github:<owner>/<repo>`.
-  `GithubTokenStore` (new, `Sources/Security/`) wraps `KeychainStore`
-  + `SecureBuffer`; the source payload stores only the account name,
-  never the token. Restart → source persists and the token is still
+  `dev.drawmeanelephant.solipsist`, **account `github` — host-keyed,
+  not per-repo**. Probed against CLT/Xcode git: the credential-helper
+  input carries only `protocol` / `host` / `username` — git omits the
+  repo `path` — so a `github:<owner>/<repo>` account could never be
+  looked up by the helper. This also matches the OAuth reality: one
+  device-flow token per GitHub user per client, used for every repo
+  that user can reach. `GithubTokenStore` (new, `Sources/Security/`)
+  wraps `KeychainStore` + `SecureBuffer`; the source payload never
+  carries the token. Restart → source persists and the token is still
   there (B3-2-style gate: no re-auth on relaunch).
+  **Limitation:** one GitHub account per install — multiple accounts
+  stay later (the helper cannot distinguish them by host alone).
 - **Ephemeral vs remembered:** unlike publish secrets, a *source*
   token must survive relaunch — the source IS the account. So the
   default is Keychain persistence with the existing opt-out pattern;
@@ -263,7 +270,9 @@ Automated (unit, injected transport + clock, no network):
   (§5) — the frozen-window guarantee from COORDINATOR.md §3 holds; a
   subsequent SSE reload reflects the new tree.
 - **Two GitHub sources, same repo:** allowed (two working copies,
-  distinct `SourceID`s); token accounts collide only if owner/repo
-  match — the second add reuses the existing Keychain item.
+  distinct `SourceID`s); both share the single host-keyed `github`
+  Keychain item — which is correct, the token is user-scoped.
+  Removing one source does not touch the token (sign-out is the only
+  deletion path, a later slice).
 - **Client id missing (dev build):** sheet explains the operator step,
   then falls back to the PAT path — the flow is never dead.


### PR DESCRIPTION
## What

Third slice of **M15 — GitHub source** (#179): the
`git-credential-solipsist` helper mode of the app binary, so private-repo
clone (and the upcoming Sync verb) authenticate **without the token ever
touching argv, env, or disk**.

- **`Sources/Security/GitCredentialHelper.swift`** — helper mode: parse
  the request from stdin, answer github.com from the Keychain, print
  `username=x-access-token\npassword=…` on stdout (git's own pipe).
  Non-`get` operations are drained and ignored; no token → clean exit
  with no output so git fails with its own auth error (surfaced
  verbatim, D11). The token travels Keychain → helper stdout → git's
  pipe; the loaded buffer is wiped after the output string is built.
- **`Sources/App/SolipsistApp.swift`** — the app's `init()` early-exits
  (`runAndExit()`) when launched with `--git-credential-helper`,
  before AppKit starts — no window server, no scenes (the
  `xcodebuild -runFirstLaunch` pattern).
- **`GitClone.credentialHelperArguments(appURL:)`** — the
  `-c credential.helper=!"<app>" --git-credential-helper` argument
  pair. The `!` shell form quotes the path so app locations with
  spaces work; git appends the operation (`get`) as the last argument.
  `clone` takes `credentialHelperApp:` and the sheet passes
  `Bundle.main.executableURL`.
- **Host-keyed token store** — see the contract finding below.

## Contract finding: git omits the repo path from helper input

Probed live against CLT/Xcode git with a `tee` helper: git sends only
`protocol`, `host`, `username` — **never `path`** — so a per-repo
Keychain account (`github:<owner>/<repo>`) could never be looked up by
the helper. The design's account scheme is corrected (the lane owns the
doc): `GithubTokenStore` is now host-keyed under the single account
`"github"` — which also matches the OAuth reality (one device-flow token
per GitHub user per client, used for every repo that user can reach).
Multiple GitHub accounts are a documented v1 limitation (the helper
cannot distinguish them by host alone). `GithubSource.tokenAccount` is
gone; the design doc §4/§10 and issue #179 carry the finding.

## Live verification (real Keychain, real git)

Seeded the Keychain with a test token under the app's service/account,
then ran `git credential fill` with **only** this helper configured
(`GIT_CONFIG_GLOBAL/SYSTEM` blanked):

- `host=github.com, username=someone-else` (osxkeychain misses) → our
  helper ran and git's fill returned
  `username=x-access-token / password=gho_test_secret`.
- `host=gitlab.com` → our helper stayed silent (0 matches).
- The app binary invoked directly with the flag printed the exact
  credential lines; `store`/`erase` drained cleanly; the test
  Keychain items were deleted afterward.

(The machine's osxkeychain already holds a real github.com credential
for the logged-in user — git legitimately serves that first; ours is
the fallback that makes private repos work without the user's
credential being in osxkeychain.)

## Tests (10 new/rewritten, no network)

Host gating (github vs gitlab vs missing), case-insensitive host,
credential output with/without token, username-agnostic answer, shell
quoting of spaces and `$`, token-store host-keyed lifecycle +
overwrite + account constant.

## Gates

`SKIP_EMBED_BORIS=1 make build` ✅ · `make test` 316 tests, 0 failures
✅ · `make lint` 0 violations (SwiftFormat + SwiftLint --strict) ✅ ·
spike scheme ✅.
