### PR TITLE
feat(github): Remote mailbox — working-copy play + fetch/pull sync (#179)

### DIFF
--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -93,16 +93,22 @@ final class Coordinator {
     func syncSaveWatch(store: WorkspaceStore, runtime: AppRuntime) {
         boundStore = store
         boundRuntime = runtime
-        guard case .local(let source) = store.selectedSource, source.isAvailable,
-              let root = try? source.contentRoot(),
+        let folder: (any PlayFolderSource)?
+        switch store.selectedSource {
+        case .local(let source): folder = source
+        case .github(let source): folder = source
+        case nil: folder = nil
+        }
+        guard let folder, folder.isAvailable,
+              let root = try? folder.contentRoot(),
               FileManager.default.fileExists(atPath: root.path)
         else {
             saveWatcher.stop()
             watchingSourceID = nil
             return
         }
-        guard watchingSourceID != source.id else { return }
-        watchingSourceID = source.id
+        guard watchingSourceID != folder.id else { return }
+        watchingSourceID = folder.id
         saveWatcher.handler = { [weak self] in
             Task { @MainActor in
                 self?.noteSave()

--- a/Sources/App/CoordinatorPolicy.swift
+++ b/Sources/App/CoordinatorPolicy.swift
@@ -86,7 +86,7 @@ enum CoordinatorPolicy {
 /// over the source, and `--out` must be a real path, which `~/Library/Caches`
 /// is and `/tmp` is not on macOS).
 enum ContentAuditOutput {
-    static func directory(for source: LocalSource) -> URL {
+    static func directory(for source: any PlayFolderSource) -> URL {
         let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
         return caches

--- a/Sources/Chrome/PlayHost.swift
+++ b/Sources/Chrome/PlayHost.swift
@@ -17,7 +17,9 @@ struct PlayHost: View {
                 case .local(let source):
                     LocalPlay(source: source)
                 case .github(let source):
-                    GithubPlayPlaceholder(source: source)
+                    // The working copy IS the tree: the same folder
+                    // surfaces as Local, plus the Remote mailbox.
+                    LocalPlay(source: source)
                 }
             } else if store.sources.isEmpty {
                 EmptyStateView(
@@ -43,11 +45,15 @@ struct PlayHost: View {
 
     private func syncPreviewSession() {
         let session = runtime.previewSession
-        guard
-            case .local(let local) = store.selectedSource,
-            local.isAvailable,
-            let content = try? local.contentRoot(),
-            let project = try? local.workspaceRoot()
+        let folder: (any PlayFolderSource)?
+        switch store.selectedSource {
+        case .local(let local): folder = local
+        case .github(let github): folder = github
+        case nil: folder = nil
+        }
+        guard let folder, folder.isAvailable,
+              let content = try? folder.contentRoot(),
+              let project = try? folder.workspaceRoot()
         else {
             if session.phase != .idle { session.stop() }
             return
@@ -68,16 +74,3 @@ struct PlayHost: View {
     }
 }
 
-/// M15 seam: the GitHub play surface (Pages/Outputs/Publish/Plan/
-/// Activity over the working copy) lands with the working-copy slice.
-private struct GithubPlayPlaceholder: View {
-    let source: GithubSource
-
-    var body: some View {
-        EmptyStateView(
-            title: source.title,
-            systemImage: "chevron.left.forwardslash.chevron.right",
-            message: "\(source.owner)/\(source.repository) is authenticated. The play surface lands with the working-copy slice."
-        )
-    }
-}

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -82,7 +82,7 @@ private struct SourceSection: View {
 
     var body: some View {
         Section(isExpanded: $isExpanded) {
-            ForEach(WorkspaceMailbox.all, id: \.self) { box in
+            ForEach(WorkspaceMailbox.all(for: item), id: \.self) { box in
                 if box == WorkspaceMailbox.pages {
                     // Pages grows trunk-folder children from the decoded
                     // graph (M13-1). No graph yet → no children, not an

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -57,23 +57,23 @@ struct EditorWindow: View {
     }
 
     private func startEditor(for source: SourceItem) {
+        let folder: (any PlayFolderSource)?
         switch source {
-        case .local(let local):
-            guard
-                let projectRoot = try? local.workspaceRoot(),
-                let contentRoot = try? local.contentRoot()
-            else {
-                session.fail("Could not resolve project folder for '\(source.title)'")
-                return
-            }
-            session.start(
-                contentRoot: contentRoot,
-                projectRoot: projectRoot,
-                engine: runtime.engine
-            )
-        case .github(let github):
-            session.fail("The editor for \(github.owner)/\(github.repository) lands with the working-copy slice.")
+        case .local(let local): folder = local
+        case .github(let github): folder = github
         }
+        guard let folder,
+              let projectRoot = try? folder.workspaceRoot(),
+              let contentRoot = try? folder.contentRoot()
+        else {
+            session.fail("Could not resolve project folder for '\(source.title)'")
+            return
+        }
+        session.start(
+            contentRoot: contentRoot,
+            projectRoot: projectRoot,
+            engine: runtime.engine
+        )
     }
 
     /// Single entry point for pointing the web view at an editor URL.

--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -56,26 +56,24 @@ struct PreviewWindow: View {
     /// Starts (or reuses) the watch server for the selected source's content
     /// root. Ran per source id; switching sources restarts the server.
     private func startPreview(for source: SourceItem) {
+        let folder: (any PlayFolderSource)?
         switch source {
-        case .local(let local):
-            guard
-                let projectRoot = try? local.workspaceRoot(),
-                let contentRoot = try? local.contentRoot()
-            else {
-                session.fail("could not resolve the project folder for '\(source.title)'")
-                return
-            }
-            session.start(
-                contentRoot: contentRoot,
-                projectRoot: projectRoot,
-                engine: runtime.engine,
-                coordinator: runtime.coordinator
-            )
-        case .github(let github):
-            // M15 seam: the working-copy slice resolves the bookmark and
-            // previews the GitHub source's working copy like a Local one.
-            session.fail("Preview for \(github.owner)/\(github.repository) lands with the working-copy slice.")
+        case .local(let local): folder = local
+        case .github(let github): folder = github
         }
+        guard let folder,
+              let projectRoot = try? folder.workspaceRoot(),
+              let contentRoot = try? folder.contentRoot()
+        else {
+            session.fail("could not resolve the project folder for '\(source.title)'")
+            return
+        }
+        session.start(
+            contentRoot: contentRoot,
+            projectRoot: projectRoot,
+            engine: runtime.engine,
+            coordinator: runtime.coordinator
+        )
     }
 
     /// Single entry point the grind lane uses to point the web view at a

--- a/Sources/Play/GitHub/RemoteMailboxView.swift
+++ b/Sources/Play/GitHub/RemoteMailboxView.swift
@@ -1,0 +1,140 @@
+import AppKit
+import SwiftUI
+
+/// Remote mailbox (M15 / #179): the read-only sync state of a GitHub
+/// working copy — branch, ahead/behind against the upstream, last sync
+/// time, the **Sync** verb (fetch + `pull --ff-only` through the
+/// credential helper), and **Open on GitHub**. Watch is suspended for
+/// the pull (the working copy is the tree watch serves) and resumed
+/// after, exactly like play's own IR builds.
+struct RemoteMailboxView: View {
+    let source: GithubSource
+
+    @Environment(WorkspaceStore.self) private var store
+    @Environment(AppRuntime.self) private var runtime
+
+    @State private var status: GitClone.GitBranchStatus?
+    @State private var statusError: String?
+
+    var body: some View {
+        List {
+            syncSection
+            statusSection
+            if let error = live.lastSyncError {
+                Section {
+                    Text(error)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                } header: {
+                    Text("Last Sync Failed")
+                }
+            }
+        }
+        .listStyle(.inset)
+        .navigationTitle(source.title)
+        .task(id: source.id) {
+            await refreshStatus()
+        }
+        .onChange(of: live.isSyncing) { _, syncing in
+            guard !syncing else { return }
+            Task { await refreshStatus() }
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: openOnGitHub) {
+                    Label("Open on GitHub", systemImage: "arrow.up.right.square")
+                }
+                .help("Open \\(source.owner)/\\(source.repository) in your browser")
+            }
+        }
+    }
+
+    /// The store's live copy — reflects isSyncing / lastSyncError as the
+    /// store mutates it, so the button spins and errors surface.
+    private var live: GithubSource {
+        if case .github(let github) = store.selectedSource, github.id == source.id {
+            return github
+        }
+        return source
+    }
+
+    private var syncSection: some View {
+        Section {
+            HStack {
+                if live.isSyncing {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Syncing…")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Cancel") { store.cancelSyncGithub(source.id) }
+                } else {
+                    Label("Sync", systemImage: "arrow.triangle.2.circlepath")
+                    Spacer()
+                    Button("Sync") {
+                        sync()
+                    }
+                    .keyboardShortcut("r", modifiers: .command)
+                }
+            }
+        }
+    }
+
+    private var statusSection: some View {
+        Section {
+            LabeledContent("Branch") {
+                Text(status?.branch ?? "—")
+                    .monospaced()
+            }
+            LabeledContent("Ahead") {
+                Text("\\(status?.ahead ?? 0) commit\\(status?.ahead == 1 ? \"\" : \"s\")")
+            }
+            LabeledContent("Behind") {
+                Text("\\(status?.behind ?? 0) commit\\(status?.behind == 1 ? \"\" : \"s\")")
+            }
+            LabeledContent("Default Branch") {
+                Text(source.defaultBranch)
+                    .monospaced()
+            }
+            if let lastSyncedAt = live.lastSyncedAt {
+                LabeledContent("Last Synced") {
+                    Text(lastSyncedAt, style: .relative)
+                }
+            }
+            if let statusError {
+                Text(statusError)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private func sync() {
+        guard !live.isSyncing else { return }
+        Task {
+            // The pull rewrites the tree watch serves: freeze it for the
+            // sync, thaw after (COORDINATOR.md §3 primitives).
+            runtime.coordinator.beginTreeWrite()
+            defer { runtime.coordinator.endTreeWrite() }
+            await store.syncGithub(source.id)
+        }
+    }
+
+    private func openOnGitHub() {
+        NSWorkspace.shared.open(source.remoteURL)
+    }
+
+    @MainActor
+    private func refreshStatus() async {
+        status = nil
+        statusError = nil
+        guard let root = try? source.workspaceRoot() else {
+            statusError = "Working copy is unavailable."
+            return
+        }
+        let result = await Task.detached {
+            GitClone.branchStatus(at: root)
+        }.value
+        status = result
+    }
+}

--- a/Sources/Play/Local/ContentAuditPane.swift
+++ b/Sources/Play/Local/ContentAuditPane.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// single process slot (`runTool`). Report lands in the app container
 /// (`ContentAuditOutput`), never the user's content tree.
 struct ContentAuditPane: View {
-    let source: LocalSource
+    let source: any PlayFolderSource
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -1,15 +1,18 @@
 import AppKit
 import SwiftUI
 
-/// Play surface for a local folder: mailbox contents plus, for Pages, a
-/// reading pane for the selected letter.
+/// Play surface for a folder-backed source (Local, or a GitHub working
+/// copy — M15): mailbox contents plus, for Pages, a reading pane for the
+/// selected letter. The surfaces are identical for both kinds; the GitHub
+/// source resolves to its working copy and additionally offers the
+/// Remote mailbox (branch, ahead/behind, Sync).
 ///
 /// Reads `<source>/.boris/graph.json` when present; otherwise asks
 /// `BorisEngine.buildIR` to produce it. Selection is written to
 /// `WorkspaceStore` as `noun.kind == "page"` with `sourcePath` — the
 /// drawer and companions only read it.
 struct LocalPlay: PlaySurface {
-    let source: LocalSource
+    let source: any PlayFolderSource
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
@@ -37,6 +40,14 @@ struct LocalPlay: PlaySurface {
                 ActivityPane()
             case WorkspaceMailbox.contentAudit:
                 ContentAuditPane(source: source)
+            case WorkspaceMailbox.remote:
+                if let github = source as? GithubSource {
+                    RemoteMailboxView(source: github)
+                } else {
+                    // Unreachable: the Remote row only exists for github
+                    // sources. Honest fallback rather than a crash.
+                    trunkMailbox
+                }
             default:
                 // Unknown mailbox is a trunk id (M13): Pages means all;
                 // a trunk id means that folder and its descendants.

--- a/Sources/Play/Local/OutputsPane.swift
+++ b/Sources/Play/Local/OutputsPane.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// "Build this". Selection is written to `WorkspaceStore` as `noun.kind == "target"`
 /// or `noun.kind == "edition"`.
 struct OutputsPane: View {
-    let source: LocalSource
+    let source: any PlayFolderSource
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime

--- a/Sources/Play/Local/PlanPane.swift
+++ b/Sources/Play/Local/PlanPane.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Read-only document view for a decoded PublicationPlan (M8 / #89).
 /// Shows declared targets, projections, inputs, site metadata, and editions.
 struct PlanPane: View {
-    let source: LocalSource
+    let source: any PlayFolderSource
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime

--- a/Sources/Play/Local/ProblemResolver.swift
+++ b/Sources/Play/Local/ProblemResolver.swift
@@ -8,7 +8,7 @@ enum ProblemResolution: Equatable, Sendable {
 enum ProblemResolver {
     static func resolve(
         path: String,
-        source: LocalSource?,
+        source: (any PlayFolderSource)?,
         graph: Graph?
     ) -> ProblemResolution? {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -44,7 +44,7 @@ enum ProblemResolver {
         }
     }
 
-    static func resolveFileURL(path: String, source: LocalSource?) -> URL? {
+    static func resolveFileURL(path: String, source: (any PlayFolderSource)?) -> URL? {
         if path.hasPrefix("/") {
             return URL(fileURLWithPath: path)
         }

--- a/Sources/Play/Local/ProblemsPane.swift
+++ b/Sources/Play/Local/ProblemsPane.swift
@@ -53,15 +53,15 @@ struct ProblemsPane: View {
                     let item = runtime.coordinator.problems.first(where: { $0.id == id }),
                     let path = item.path
                 else { return }
-                let localSource: LocalSource?
-                if case .local(let src) = store.selectedSource {
-                    localSource = src
-                } else {
-                    localSource = nil
+                let folderSource: (any PlayFolderSource)?
+                switch store.selectedSource {
+                case .local(let src): folderSource = src
+                case .github(let src): folderSource = src
+                case nil: folderSource = nil
                 }
 
                 var graph: Graph?
-                if let localSource, let root = try? localSource.resolve().url {
+                if let folderSource, let root = try? folderSource.resolve().url {
                     let graphURL = root
                         .appendingPathComponent(".boris", isDirectory: true)
                         .appendingPathComponent("graph.json")
@@ -70,7 +70,7 @@ struct ProblemsPane: View {
                     }
                 }
 
-                guard let resolution = ProblemResolver.resolve(path: path, source: localSource, graph: graph) else {
+                guard let resolution = ProblemResolver.resolve(path: path, source: folderSource, graph: graph) else {
                     return
                 }
 

--- a/Sources/Play/Local/PublishPane.swift
+++ b/Sources/Play/Local/PublishPane.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// evidence chain (`_boris/proof/`), Proof Pack claims & checks, Nostr relay verdicts,
 /// package checksums, and publish actions.
 struct PublishPane: View {
-    let source: LocalSource
+    let source: any PlayFolderSource
 
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime

--- a/Sources/Play/Local/ReadingPane.swift
+++ b/Sources/Play/Local/ReadingPane.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// contract-backed summary. Never `file://`, never a Markdown renderer.
 struct ReadingPane: View {
     let page: PlayPage?
-    let source: LocalSource
+    let source: any PlayFolderSource
     let loadGeneration: Int
 
     @Environment(AppRuntime.self) private var runtime
@@ -359,7 +359,7 @@ struct ReadingPane: View {
 
     /// Decode `.boris/completion.json` the same way Play reads `graph.json`.
     /// Failure omits relations (D8). Does not import Inspector.
-    private static func loadRelations(source: LocalSource, pageID: String?) -> [CompletionRelation] {
+    private static func loadRelations(source: any PlayFolderSource, pageID: String?) -> [CompletionRelation] {
         guard
             let pageID,
             source.isAvailable,

--- a/Sources/Workspace/Git/GitClone.swift
+++ b/Sources/Workspace/Git/GitClone.swift
@@ -146,8 +146,16 @@ public enum GitClone {
     /// Branch of the checkout at `root`, or nil when it is not a repo or
     /// git is unavailable. Missing git / not-a-repo is not an error.
     public static func currentBranch(at root: URL) -> String? {
+        branchStatus(at: root).branch
+    }
+
+    /// Branch + ahead/behind of the checkout at `root` (Remote mailbox,
+    /// M15). `ahead`/`behind` count commits against the upstream
+    /// (`origin/<branch>`). Missing git / not-a-repo yields an empty
+    /// status with a nil branch — never an error.
+    public static func branchStatus(at root: URL) -> GitBranchStatus {
         guard FileManager.default.fileExists(atPath: root.appendingPathComponent(".git").path) else {
-            return nil
+            return GitBranchStatus(branch: nil, ahead: 0, behind: 0)
         }
         let process = Process()
         process.executableURL = gitExecutableURL()
@@ -159,17 +167,48 @@ public enum GitClone {
             try process.run()
             process.waitUntilExit()
         } catch {
-            return nil
+            return GitBranchStatus(branch: nil, ahead: 0, behind: 0)
         }
-        guard process.terminationStatus == 0 else { return nil }
+        guard process.terminationStatus == 0 else {
+            return GitBranchStatus(branch: nil, ahead: 0, behind: 0)
+        }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let text = String(decoding: data, as: UTF8.self)
+        var branch: String?
+        var ahead = 0
+        var behind = 0
         for line in text.split(separator: "\n") {
-            if let branch = parseBranch(from: String(line)) {
-                return branch
+            let line = String(line)
+            if let parsed = parseBranch(from: line) {
+                branch = parsed
+            }
+            if let ab = parseAheadBehind(from: line) {
+                ahead = ab.ahead
+                behind = ab.behind
             }
         }
-        return nil
+        return GitBranchStatus(branch: branch, ahead: ahead, behind: behind)
+    }
+
+    /// Branch + ahead/behind parsed from `status --porcelain=v2 --branch`.
+    public struct GitBranchStatus: Sendable, Equatable {
+        public let branch: String?
+        public let ahead: Int
+        public let behind: Int
+    }
+
+    /// Parse the ahead/behind counts out of one porcelain v2 line:
+    /// `# branch.ab +1 -2` → (1, 2). Anything else returns nil.
+    public static func parseAheadBehind(from line: String) -> (ahead: Int, behind: Int)? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("# branch.ab ") else { return nil }
+        let rest = trimmed.dropFirst("# branch.ab ".count)
+        let parts = rest.split(separator: " ")
+        guard parts.count == 2 else { return nil }
+        let aheadPart = parts[0].hasPrefix("+") ? parts[0].dropFirst() : parts[0]
+        let behindPart = parts[1].hasPrefix("-") ? parts[1].dropFirst() : parts[1]
+        guard let ahead = Int(aheadPart), let behind = Int(behindPart) else { return nil }
+        return (ahead, behind)
     }
 
     /// Parse the branch out of one porcelain line:

--- a/Sources/Workspace/GitHub/GithubSource.swift
+++ b/Sources/Workspace/GitHub/GithubSource.swift
@@ -8,7 +8,7 @@ import Foundation
 /// The token is never here. It lives in the Keychain (host-keyed
 /// account `github` — see `GithubTokenStore`); only display-only
 /// granted scopes are carried.
-struct GithubSource: PublicationSource, Hashable, Sendable, Codable {
+struct GithubSource: PublicationSource, PlayFolderSource, Hashable, Sendable, Codable {
     var id: SourceID
     /// "owner/repo" — the account header title.
     var title: String
@@ -26,6 +26,8 @@ struct GithubSource: PublicationSource, Hashable, Sendable, Codable {
     var branch: String? = nil
     var isSyncing: Bool = false
     var lastSyncError: String? = nil
+    /// Set when the last Sync succeeded; shown in the Remote mailbox.
+    var lastSyncedAt: Date? = nil
 
     var kind: SourceKind { .github }
 

--- a/Sources/Workspace/GitHub/GithubSync.swift
+++ b/Sources/Workspace/GitHub/GithubSync.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Remote mailbox sync verb (M15 / #179): `fetch` then `pull --ff-only`
+/// against a GitHub working copy, one-shot `/usr/bin/git` processes (not
+/// the engine slot) authenticated through the app binary's
+/// `--git-credential-helper` mode — the token never appears in argv,
+/// env, or on disk.
+public enum GithubSync {
+    public struct SyncResult: Sendable {
+        public let exitCode: Int32
+        public let stderr: String
+
+        public var isSuccess: Bool { exitCode == 0 }
+    }
+
+    /// Fetch then fast-forward pull. Runs two sequential git processes
+    /// sharing one `SyncSession` (SIGTERM cancels the in-flight one).
+    /// The pull is skipped when the fetch fails — the fetch result is
+    /// returned so the failure surfaces with git's own stderr.
+    public static func sync(
+        workingCopy: URL,
+        credentialHelperApp: URL?,
+        session: SyncSession
+    ) -> SyncResult {
+        let fetch = run(["fetch"], workingCopy: workingCopy, credentialHelperApp: credentialHelperApp, session: session)
+        guard fetch.isSuccess else { return fetch }
+        return run(["pull", "--ff-only"], workingCopy: workingCopy, credentialHelperApp: credentialHelperApp, session: session)
+    }
+
+    private static func run(
+        _ verb: [String],
+        workingCopy: URL,
+        credentialHelperApp: URL?,
+        session: SyncSession
+    ) -> SyncResult {
+        let process = Process()
+        process.executableURL = GitClone.gitExecutableURL()
+        var arguments = ["-C", workingCopy.path]
+        if let credentialHelperApp {
+            arguments.append(contentsOf: GitClone.credentialHelperArguments(appURL: credentialHelperApp))
+        }
+        arguments.append(contentsOf: verb)
+        process.arguments = arguments
+        var env = ProcessInfo.processInfo.environment
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        process.environment = env
+        let errPipe = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errPipe
+        session.attach(process)
+        do {
+            try process.run()
+        } catch {
+            session.detach()
+            return SyncResult(exitCode: 1, stderr: String(describing: error))
+        }
+        process.waitUntilExit()
+        session.detach()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        return SyncResult(
+            exitCode: process.terminationStatus,
+            stderr: String(decoding: errData, as: UTF8.self)
+        )
+    }
+}
+
+/// Owns the running git sync child so the store can SIGTERM it on cancel.
+/// Same shape as `CloneSession` — thread-safe, not the engine's one slot.
+public final class SyncSession: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+
+    public init() {}
+
+    func attach(_ process: Process) {
+        lock.lock()
+        self.process = process
+        lock.unlock()
+    }
+
+    func detach() {
+        lock.lock()
+        process = nil
+        lock.unlock()
+    }
+
+    public func terminate() {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        guard let process, process.isRunning else { return }
+        process.terminate()
+    }
+}

--- a/Sources/Workspace/Local/LocalSource.swift
+++ b/Sources/Workspace/Local/LocalSource.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A folder on disk, remembered via an app-scoped security-scoped bookmark.
 /// Local play owns the work surface for this source; this type is only the
 /// sidebar identity plus the bookmark that keeps sandbox access alive.
-struct LocalSource: PublicationSource, Hashable, Sendable, Codable {
+struct LocalSource: PublicationSource, PlayFolderSource, Hashable, Sendable, Codable {
     var id: SourceID
     var title: String
     var bookmarkData: Data

--- a/Sources/Workspace/Source.swift
+++ b/Sources/Workspace/Source.swift
@@ -38,6 +38,55 @@ protocol PublicationSource: Identifiable, Sendable {
     var kind: SourceKind { get }
 }
 
+/// The folder contract every play surface operates on (M15): both Local
+/// and GitHub sources resolve to a folder boris can read, so the panes
+/// (Pages/Outputs/Publish/Plan/Activity) are identical for both — the
+/// working copy IS the tree. The github payload only adds identity on
+/// top of this.
+protocol PlayFolderSource: PublicationSource {
+    var displayPath: String { get }
+    var isAvailable: Bool { get }
+    /// Current checkout branch when the folder has `.git`; nil otherwise.
+    var branch: String? { get }
+    func resolve() throws -> (url: URL, stale: Bool)
+    func workspaceRoot() throws -> URL
+    /// `content/` when this looks like a project root (`content/` + `boris.json`).
+    func contentRoot() throws -> URL
+    func profileURL() -> URL?
+    func artifactDirectory(named name: String) throws -> URL
+}
+
+extension PlayFolderSource {
+    /// True when `root` looks like a project root (`content/` + `boris.json`).
+    static func isProjectRoot(_ root: URL) -> Bool {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        let content = root.appendingPathComponent("content", isDirectory: true)
+        let profile = root.appendingPathComponent("boris.json")
+        let hasContent = fm.fileExists(atPath: content.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+        return hasContent && fm.fileExists(atPath: profile.path)
+    }
+
+    /// `content/` when this looks like a project root (`content/` + `boris.json`).
+    func contentRoot() throws -> URL {
+        let root = try workspaceRoot()
+        return Self.isProjectRoot(root)
+            ? root.appendingPathComponent("content", isDirectory: true)
+            : root
+    }
+
+    func profileURL() -> URL? {
+        guard let root = try? workspaceRoot() else { return nil }
+        let url = root.appendingPathComponent("boris.json")
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    func artifactDirectory(named name: String) throws -> URL {
+        try workspaceRoot().appendingPathComponent(name, isDirectory: true)
+    }
+}
+
 /// Inventory item in the workspace store. Add a case when a new source
 /// type lands; the sidebar still only reads `id` / `title` / `kind`.
 enum SourceItem: Identifiable, Hashable, Sendable {

--- a/Sources/Workspace/WorkspaceSelection.swift
+++ b/Sources/Workspace/WorkspaceSelection.swift
@@ -44,6 +44,9 @@ enum WorkspaceMailbox {
     static let plan = "plan"
     static let activity = "activity"
     static let contentAudit = "content-audit"
+    /// GitHub-source-only mailbox (M15): branch, ahead/behind, Sync.
+    /// Deliberately not in `all` — Local sources never see a Remote row.
+    static let remote = "remote"
 
     static let all: [String] = [pages, outputs, publish, plan, activity, contentAudit]
     static let defaultMailbox = pages
@@ -70,6 +73,7 @@ enum WorkspaceMailbox {
         case plan: return "Plan"
         case activity: return "Activity"
         case contentAudit: return "Content Audit"
+        case remote: return "Remote"
         default: return raw
         }
     }
@@ -82,7 +86,17 @@ enum WorkspaceMailbox {
         case plan: return "doc.plaintext"
         case activity: return "clock"
         case contentAudit: return "checkmark.shield"
+        case remote: return "arrow.triangle.2.circlepath"
         default: return "folder"
+        }
+    }
+
+    /// Sidebar row list for one source. Local sources get the M10 set;
+    /// GitHub sources additionally get the Remote mailbox.
+    static func all(for item: SourceItem) -> [String] {
+        switch item.kind {
+        case .github: return all + [remote]
+        case .local: return all
         }
     }
 }

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -187,6 +187,59 @@ final class WorkspaceStore {
         activeCloneSession?.terminate()
     }
 
+    // MARK: - GitHub sync (M15 Remote mailbox)
+
+    /// In-flight syncs by source id (one per source; the engine slot is
+    /// untouched — git is a settings-adjacent one-shot like clone).
+    private var activeSyncSessions: [SourceID: SyncSession] = [:]
+
+    /// Remote mailbox Sync verb: `fetch` + `pull --ff-only` through the
+    /// credential helper, off the main actor. Marks the source syncing,
+    /// updates branch / lastSyncError / lastSyncedAt on completion. The
+    /// caller (RemoteMailboxView) suspends watch around the call — the
+    /// working copy is the tree watch serves.
+    func syncGithub(_ id: SourceID) async {
+        guard let index = sources.firstIndex(where: { $0.id == id }),
+              case .github(let github) = sources[index],
+              github.isAvailable,
+              let url = try? github.workspaceRoot()
+        else { return }
+
+        var syncing = github
+        syncing.isSyncing = true
+        syncing.lastSyncError = nil
+        sources[index] = .github(syncing)
+
+        let helperApp = Bundle.main.executableURL
+        let session = SyncSession()
+        activeSyncSessions[id] = session
+        defer { activeSyncSessions[id] = nil }
+
+        let result = await Task.detached {
+            GithubSync.sync(workingCopy: url, credentialHelperApp: helperApp, session: session)
+        }.value
+
+        guard let index = sources.firstIndex(where: { $0.id == id }),
+              case .github(let current) = sources[index]
+        else { return }
+        var updated = current
+        updated.isSyncing = false
+        if result.isSuccess {
+            updated.lastSyncError = nil
+            updated.lastSyncedAt = Date()
+        } else {
+            updated.lastSyncError = "git sync failed (exit \(result.exitCode)): \(result.stderr)"
+        }
+        updated.branch = GitClone.branchStatus(at: url).branch
+        sources[index] = .github(updated)
+    }
+
+    /// SIGTERM the in-flight sync for a source. The working copy is left
+    /// in place mid-pull; the next Sync retries.
+    func cancelSyncGithub(_ id: SourceID) {
+        activeSyncSessions[id]?.terminate()
+    }
+
     // MARK: - Graph mirror (M13-1)
 
     /// Sidebar read path for trunk folders. Cached value wins; otherwise

--- a/Tests/ContractTests/GitCloneTests.swift
+++ b/Tests/ContractTests/GitCloneTests.swift
@@ -63,6 +63,13 @@ final class GitCloneTests: XCTestCase {
         XCTAssertNil(GitClone.parseBranch(from: "##"))
     }
 
+    func testBranchStatusParsesAheadBehind() {
+        let status = GitClone.branchStatus(at: URL(fileURLWithPath: "/nonexistent/repo"))
+        XCTAssertNil(status.branch)
+        XCTAssertEqual(status.ahead, 0)
+        XCTAssertEqual(status.behind, 0)
+    }
+
     // MARK: - Live branch read (local repo only, no network)
 
     func testCurrentBranchReadsLocalCheckout() throws {

--- a/Tests/ContractTests/GithubSyncTests.swift
+++ b/Tests/ContractTests/GithubSyncTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+
+final class GithubSyncTests: XCTestCase {
+    // MARK: - Ahead/behind porcelain parsing (pure)
+
+    func testParseAheadBehindV2() {
+        XCTAssertEqual(GitClone.parseAheadBehind(from: "# branch.ab +1 -2")?.ahead, 1)
+        XCTAssertEqual(GitClone.parseAheadBehind(from: "# branch.ab +1 -2")?.behind, 2)
+        XCTAssertEqual(GitClone.parseAheadBehind(from: "# branch.ab +0 -0")?.ahead, 0)
+        XCTAssertEqual(GitClone.parseAheadBehind(from: "# branch.ab +0 -0")?.behind, 0)
+        XCTAssertEqual(GitClone.parseAheadBehind(from: "# branch.ab +3 -0")?.ahead, 3)
+        XCTAssertEqual(GitClone.parseAheadBehind(from: "# branch.ab +0 -7")?.behind, 7)
+        XCTAssertNil(GitClone.parseAheadBehind(from: "# branch.head main"))
+        XCTAssertNil(GitClone.parseAheadBehind(from: "1 .M N..."))
+        XCTAssertNil(GitClone.parseAheadBehind(from: "# branch.ab +1")) // malformed
+        XCTAssertNil(GitClone.parseAheadBehind(from: "# branch.ab +x -y")) // non-numeric
+    }
+
+    // MARK: - Live sync (local remotes only, no network)
+
+    func testSyncFastForwardsWorkingCopy() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("githubsync-\\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let origin = dir.appendingPathComponent("origin.git", isDirectory: true)
+        let work = dir.appendingPathComponent("work", isDirectory: true)
+
+        try runGit(["init", "--bare", "-b", "main", origin.path], in: dir)
+        // Seed the origin with one commit (a bare repo has no checkout).
+        let seed = dir.appendingPathComponent("seed", isDirectory: true)
+        try FileManager.default.createDirectory(at: seed, withIntermediateDirectories: true)
+        try runGit(["init", "-b", "main"], in: seed)
+        try "one".write(to: seed.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: seed)
+        try runGit(["-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-m", "one"], in: seed)
+        try runGit(["remote", "add", "origin", origin.path], in: seed)
+        try runGit(["push", "-u", "origin", "main"], in: seed)
+
+        // Clone the working copy, then advance origin.
+        try runGit(["clone", origin.path, work.path], in: dir)
+        XCTAssertEqual(GitClone.currentBranch(at: work), "main")
+
+        try "two".write(to: seed.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: seed)
+        try runGit(["-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-m", "two"], in: seed)
+        try runGit(["push", "origin", "main"], in: seed)
+
+        // Fetch so the remote-tracking ref sees the new commit, then the
+        // working copy is behind 1 (ahead/behind is against the local
+        // tracking ref, which only advances on fetch/sync).
+        try runGit(["fetch", "origin"], in: work)
+        let before = GitClone.branchStatus(at: work)
+        XCTAssertEqual(before.branch, "main")
+        XCTAssertEqual(before.behind, 1)
+        XCTAssertEqual(before.ahead, 0)
+
+        let session = SyncSession()
+        let result = GithubSync.sync(workingCopy: work, credentialHelperApp: nil, session: session)
+        XCTAssertTrue(result.isSuccess, "sync failed: \\(result.stderr)")
+
+        let after = GitClone.branchStatus(at: work)
+        XCTAssertEqual(after.branch, "main")
+        XCTAssertEqual(after.ahead, 0)
+        XCTAssertEqual(after.behind, 0)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: work.appendingPathComponent("b.txt").path),
+            "pulled file should exist"
+        )
+    }
+
+    func testSyncFailsFastOnNonRepo() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("githubsync-\\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let session = SyncSession()
+        let result = GithubSync.sync(workingCopy: dir, credentialHelperApp: nil, session: session)
+        XCTAssertFalse(result.isSuccess)
+        XCTAssertFalse(result.stderr.isEmpty, "git's stderr must surface, never be swallowed")
+    }
+
+    func testSyncWithCredentialHelperAppOnLocalRemote() throws {
+        // The helper app is only invoked for https remotes; passing one
+        // must not disturb a local-remote sync (proves the `-c` argument
+        // shape is accepted by git).
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("githubsync-\\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let origin = dir.appendingPathComponent("origin.git", isDirectory: true)
+        let work = dir.appendingPathComponent("work", isDirectory: true)
+        try runGit(["init", "--bare", "-b", "main", origin.path], in: dir)
+        let seed = dir.appendingPathComponent("seed", isDirectory: true)
+        try FileManager.default.createDirectory(at: seed, withIntermediateDirectories: true)
+        try runGit(["init", "-b", "main"], in: seed)
+        try "one".write(to: seed.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: seed)
+        try runGit(["-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-m", "one"], in: seed)
+        try runGit(["remote", "add", "origin", origin.path], in: seed)
+        try runGit(["push", "-u", "origin", "main"], in: seed)
+        try runGit(["clone", origin.path, work.path], in: dir)
+
+        let helper = URL(fileURLWithPath: "/nonexistent/solipsist-helper")
+        let session = SyncSession()
+        let result = GithubSync.sync(workingCopy: work, credentialHelperApp: helper, session: session)
+        XCTAssertTrue(result.isSuccess, "sync failed: \\(result.stderr)")
+    }
+
+    // MARK: - Helpers
+
+    private func runGit(_ arguments: [String], in dir: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.currentDirectoryURL = dir
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(bytes: data, encoding: .utf8) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, "git \\(arguments) failed: \\(output)")
+    }
+}


### PR DESCRIPTION
## M15 Remote mailbox — the working copy opens as a source-backed mailbox

Closes the working-copy slice of #179: a GitHub source now behaves like
any other account — Pages/Outputs/Publish/Plan/Activity over the working
copy — plus a new **Remote** mailbox with branch, ahead/behind, the
**Sync** verb, and Open on GitHub.

### The folder generalization

The panes took `LocalSource`; now they take a `PlayFolderSource`
protocol (`Sources/Workspace/Source.swift`) that both `LocalSource` and
`GithubSource` conform to, with the folder helpers
(`contentRoot`/`profileURL`/`artifactDirectory`) as default
implementations. The GitHub payload is identity on top of a folder — the
design's "no new code path" promise, honored literally. `PlayHost`,
`PreviewWindow`, `EditorWindow`, `ProblemsPane`, and the coordinator's
save-watcher all resolve github working copies like local folders; the
"lands with the working-copy slice" seam placeholders are deleted.

### Sync

- `GithubSync` (`Sources/Workspace/GitHub/GithubSync.swift`): `fetch`
  then `pull --ff-only`, one-shot git processes (never the engine slot),
  `GIT_TERMINAL_PROMPT=0`, authenticated via the app binary's
  `--git-credential-helper` mode — the token never touches argv/env/disk.
  `SyncSession` mirrors `CloneSession` (SIGTERM cancel path).
- `GitClone.branchStatus(at:)` — branch + ahead/behind parsed from
  `status --porcelain=v2 --branch` (`# branch.ab +N -M`), `currentBranch`
  now delegates to it.
- `WorkspaceStore.syncGithub(_:)` — marks the source syncing, runs the
  sync off the main actor, writes `lastSyncError`/`lastSyncedAt`/branch.
  The mailbox suspends watch for the pull (COORDINATOR.md §3) and
  resumes after, same as play's IR builds.

### UI

`RemoteMailboxView` (`Sources/Play/GitHub/`): branch, ahead/behind,
default branch, last-synced, Sync button (+cancel), Open on GitHub.
The sidebar appends the Remote row **only** for github sources
(`WorkspaceMailbox.all(for:)`); the mailbox token is deliberately not in
`all`, so Local sources never see it.

### Tests (no network)

- `GithubSyncTests`: ahead/behind porcelain parsing; live fast-forward
  sync against a local bare remote (clone → advance origin → fetch →
  behind 1 → sync → 0/0, pulled file present); sync fails fast on a
  non-repo with git's stderr surfaced; credential-helper `-c` argument
  shape accepted by git on a local-remote sync.
- `GitCloneTests`: branchStatus on a non-repo → nil branch, 0/0.

Gates: `SKIP_EMBED_BORIS=1 make build` ✅ · 321 tests, 0 failures ✅ ·
`make lint` 0 violations ✅ · spike ✅.
