### PR TITLE
feat(github): Sign Out verb — Keychain token delete + working-copy Trash (#179)

### DIFF
--- a/Sources/App/Settings/SourcesSettingsPane.swift
+++ b/Sources/App/Settings/SourcesSettingsPane.swift
@@ -6,6 +6,8 @@ struct SourcesSettingsPane: View {
     @Environment(WorkspaceStore.self) private var store
     @State private var confirmRemove = false
     @State private var showAddGithub = false
+    /// The github source awaiting a sign-out confirmation, when any.
+    @State private var signOutItem: SourceItem?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -36,6 +38,25 @@ struct SourcesSettingsPane: View {
         } message: {
             Text("The folder on disk is not deleted.")
         }
+        .confirmationDialog(
+            signOutPrompt,
+            isPresented: Binding(
+                get: { signOutItem != nil },
+                set: { if !$0 { signOutItem = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: signOutItem
+        ) { item in
+            Button("Sign Out") {
+                store.signOutGithub(item.id, deleteWorkingCopy: false)
+            }
+            Button("Sign Out & Move Working Copy to Trash", role: .destructive) {
+                store.signOutGithub(item.id, deleteWorkingCopy: true)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { item in
+            Text("The GitHub token will be removed from the Keychain. The working copy stays on disk unless you move it to the Trash.")
+        }
         .sheet(isPresented: $showAddGithub) {
             AddGithubAccountSheet()
         }
@@ -46,6 +67,13 @@ struct SourcesSettingsPane: View {
             ForEach(store.sources) { item in
                 SourceAccountRow(item: item)
                     .tag(item.id)
+                    .contextMenu {
+                        if case .github = item {
+                            Button("Sign Out…", role: .destructive) {
+                                signOutItem = item
+                            }
+                        }
+                    }
             }
         }
         .listStyle(.inset)
@@ -125,6 +153,11 @@ struct SourcesSettingsPane: View {
     private var removePrompt: String {
         let name = store.selectedSource?.title ?? "this source"
         return "Remove “\(name)” from Solipsist?"
+    }
+
+    private var signOutPrompt: String {
+        let name = signOutItem?.title ?? "this GitHub account"
+        return "Sign Out of “\(name)”?"
     }
 }
 

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -79,6 +79,8 @@ private struct SourceSection: View {
     let item: SourceItem
     @Binding var isExpanded: Bool
     let store: WorkspaceStore
+    /// The github source awaiting a sign-out confirmation, when any.
+    @State private var signOutItem: SourceItem?
 
     var body: some View {
         Section(isExpanded: $isExpanded) {
@@ -96,8 +98,40 @@ private struct SourceSection: View {
             }
         } header: {
             SourceAccountHeader(item: item)
-                .contextMenu { sourceMenu(item, store: store) }
+                .contextMenu {
+                    sourceMenu(item, store: store)
+                    if case .github = item {
+                        Divider()
+                        Button("Sign Out…", role: .destructive) {
+                            signOutItem = item
+                        }
+                    }
+                }
         }
+        .confirmationDialog(
+            signOutPrompt,
+            isPresented: Binding(
+                get: { signOutItem != nil },
+                set: { if !$0 { signOutItem = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: signOutItem
+        ) { item in
+            Button("Sign Out") {
+                store.signOutGithub(item.id, deleteWorkingCopy: false)
+            }
+            Button("Sign Out & Move Working Copy to Trash", role: .destructive) {
+                store.signOutGithub(item.id, deleteWorkingCopy: true)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { item in
+            Text("The GitHub token will be removed from the Keychain. The working copy stays on disk unless you move it to the Trash.")
+        }
+    }
+
+    private var signOutPrompt: String {
+        let name = signOutItem?.title ?? "this GitHub account"
+        return "Sign Out of “\(name)”?"
     }
 }
 

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -240,6 +240,37 @@ final class WorkspaceStore {
         activeSyncSessions[id]?.terminate()
     }
 
+    // MARK: - GitHub sign-out (M15)
+
+    /// Sign out of a GitHub source (design §4): delete the Keychain
+    /// token — the only deletion path for it, plain `remove` never
+    /// touches the token — then drop the source from the sidebar.
+    /// `deleteWorkingCopy` additionally moves the user-owned working
+    /// copy folder to the Trash; it is never deleted without the
+    /// caller's explicit choice. A token-delete failure aborts the
+    /// sign-out (the source stays); a Trash failure surfaces on
+    /// `lastError` after the sign-out completes.
+    func signOutGithub(_ id: SourceID, deleteWorkingCopy: Bool) {
+        lastError = nil
+        guard let index = sources.firstIndex(where: { $0.id == id }),
+              case .github = sources[index]
+        else { return }
+        do {
+            try GithubTokenStore().delete()
+        } catch {
+            lastError = "Sign out failed — the GitHub token could not be removed: \(String(describing: error))"
+            return
+        }
+        if deleteWorkingCopy, let url = scopedURLs[id] {
+            do {
+                try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+            } catch {
+                lastError = "Signed out, but the working copy could not be moved to the Trash: \(String(describing: error))"
+            }
+        }
+        remove(id)
+    }
+
     // MARK: - Graph mirror (M13-1)
 
     /// Sidebar read path for trunk folders. Cached value wins; otherwise

--- a/docs/GITHUB-OAUTH-DESIGN.md
+++ b/docs/GITHUB-OAUTH-DESIGN.md
@@ -272,7 +272,9 @@ Automated (unit, injected transport + clock, no network):
 - **Two GitHub sources, same repo:** allowed (two working copies,
   distinct `SourceID`s); both share the single host-keyed `github`
   Keychain item — which is correct, the token is user-scoped.
-  Removing one source does not touch the token (sign-out is the only
-  deletion path, a later slice).
+  Removing one source does not touch the token — **Sign Out**
+  (context menu / Settings row) is the only deletion path: it removes
+  the Keychain item, drops the source, and only with an explicit
+  choice moves the user-owned working copy to the Trash.
 - **Client id missing (dev build):** sheet explains the operator step,
   then falls back to the PAT path — the flow is never dead.


### PR DESCRIPTION
## M15 Sign Out — the token's only deletion path (#179)

Closes the last named verb on the M15 card. **Sign Out** appears on a
GitHub source's account-header context menu (sidebar) and in the
Sources Settings row's context menu.

### What it does

- `WorkspaceStore.signOutGithub(_:deleteWorkingCopy:)` deletes the
  Keychain token via `GithubTokenStore().delete()` — plain `remove`
  never touches the token, so sign-out is the **only** deletion path
  (design §10). Then the source drops from the sidebar; no re-auth
  state lingers, adding the account again runs the full flow fresh.
- The confirmation dialog makes the working-copy choice explicit
  (design §4 / gate 5): **Sign Out** keeps the user-owned folder on
  disk; **Sign Out & Move Working Copy to Trash** moves it to the
  Trash. The folder is never deleted without that explicit prompt.
- Failure posture: a token-delete failure **aborts** the sign-out
  (source stays, error on `lastError` — never a half-signed-out
  source); a Trash failure surfaces after the sign-out completes.
- The design doc's "sign-out is a later slice" edge case is updated —
  the lane owns that file.

### Gates

`SKIP_EMBED_BORIS=1 make build` ✅ · 321 tests, 0 failures ✅ ·
`make lint` 0 violations ✅ · spike ✅.
