### PR TITLE
docs: M16 write-remote design gate + four slice cards (#185)

### DIFF
--- a/docs/M16-WRITE-REMOTE-DESIGN.md
+++ b/docs/M16-WRITE-REMOTE-DESIGN.md
@@ -1,0 +1,216 @@
+# M16 — Write the remote: commit / push / PR authoring / issues mailbox
+
+**Status:** design gate for
+[#185](https://github.com/drawmeanelephant/solipsist/issues/185) (cards
+`cards/M16-commit.md` · `M16-push.md` · `M16-pr.md` · `M16-issues.md`).
+Drafted by the dispatcher after M15 fully shipped (PRs #180–#184). The
+lane owns this file and the implementation. This is the ROADMAP §3
+"Later" remainder of the GitHub-source deferral — *"Fetch / pull /
+commit / push on a checkout"* — with fetch + `pull --ff-only` already
+moved up as M15's Remote mailbox Sync. What remains is everything that
+**writes** the remote, kept deliberately out of M15: commit, push, PR
+authoring, and the issues mailbox.
+
+## 1. What exists today (do not redo)
+
+| Piece | Current behavior |
+|-------|------------------|
+| `GithubSource` (`Sources/Workspace/GitHub/`) | Identity (`owner/repo`, default branch) + working-copy security-scoped bookmark. Transient: `branch`, `isSyncing`, `lastSyncError`, `lastSyncedAt`. `PlayFolderSource` conformance — every play surface runs on the working copy. |
+| `GithubSync` + `SyncSession` | fetch + `pull --ff-only`, one-shot git processes (never the engine slot), `GIT_TERMINAL_PROMPT=0`, credential helper args from `GitClone.credentialHelperArguments`. Reuse the runner shape for every new git verb. |
+| `GitClone` | `gitExecutableURL()` (CLT/Xcode resolution), `currentBranch`, `branchStatus(at:)` (ahead/behind via `status --porcelain=v2 --branch`), `CloneSession`. Reuse, do not re-derive. |
+| `git-credential-solipsist` helper mode | App-binary early exit, Keychain host-keyed account `github`, token on stdout only. Every https git verb authenticates through it — **push included, no new auth surface.** |
+| `GithubTokenStore` | Keychain-only token lifecycle; `delete()` is sign-out's only path (M15 #184). |
+| `GithubAPIClient` + `GithubOAuth.HTTPTransport` | `GET /user`, `GET /repos/{owner}/{repo}`. Transport has form-`post` (device flow) and bearer-`get`. **No JSON POST yet** — PR creation and issue creation need a new `post(json:bearer:)` seam. |
+| `WorkspaceMailbox` | Open vocabulary; M15 added `remote` for github-only rows via `WorkspaceMailbox.all(for:)`. A `issues` token follows the same pattern — never in `all`. |
+| `RemoteMailboxView` | Branch, ahead/behind, last-synced, Sync verb (watch suspended for the pull), Open on GitHub. The natural home for the Commit / Push verbs. |
+| Proof chain (M8) | Evidence commits are **Boris's** job (its own publish flow), not an app verb. The app's commit verb is for the user's own commits; it does not reach into `_boris/proof/` any more than any other surface. |
+
+## 2. What M16 is
+
+The Remote mailbox already reads the remote (branch, ahead/behind,
+Sync). M16 adds the **write** side of that same loop, all through the
+seams M15 built:
+
+- **Commit** — the user's own commits on the working copy: a
+  changed-files picker, a message, `git add <picked>` + `git commit`
+  as one-shots (never `git add -A` — the repo's own git discipline,
+  and the app never mutates the content tree except on an explicit
+  save).
+- **Push** — `git push` through the credential helper (no new auth
+  surface), branch upstream tracking, ahead → 0 on success.
+- **PR authoring** — push the current branch, then
+  `POST /repos/{owner}/{repo}/pulls` with the Keychain bearer (new
+  JSON-post seam), title + body from a sheet, base = the source's
+  `defaultBranch` (from the remote, never guessed).
+- **Issues mailbox** — a github-only mailbox token listing the repo's
+  issues (`GET /repos/{owner}/{repo}/issues`), each row opening in the
+  browser, plus a create-issue sheet (`POST`).
+
+Four slices, one worktree / one PR each (the #167 slice pattern), all
+behind this design gate. **Watch arbitration:** `git add`/`commit`/
+`push` do not rewrite the content tree watch serves (only `.git` and
+the index), so — unlike pull — none of them suspend watch. That is an
+explicit decision, not an accident: the only tree-writing git verb is
+`pull --ff-only`, which M15 already freezes watch for.
+
+## 3. Commit (M16-1)
+
+- **Changed-files picker, not `add -A`.** `git status --porcelain`
+  parsed (extend `GitClone` with a `statusEntries(at:)` — same runner
+  shape as `branchStatus`), listed in the sheet with checkboxes, the
+  user picks, `git add -- <paths>` stages exactly those, `git commit`
+  runs with the message. Nothing is staged that the user did not pick;
+  untracked files appear so a new page can be committed deliberately.
+- **Identity is never invented.** `git commit` with no
+  `user.name`/`user.email` fails with git's own error — surfaced
+  **verbatim** (D11), with a hint pointing at the repo config or a
+  Settings identity row. The app never writes global config and never
+  synthesizes an identity. M16-1 may add a Settings row that writes
+  **repo-local** `user.name`/`user.email` only on the user's explicit
+  save (the working copy's `.git/config`, never `--global`).
+- **One-shots.** `GithubCommit`-style enum (or extend `GithubSync`)
+  with the same `Session` cancel path as `SyncSession`. Watch keeps
+  running (decision above); after the commit, `branchStatus` refreshes
+  (ahead grows by 1), last-synced untouched.
+- **What commits are for:** the user's work in the working copy —
+  content edits, new pages, profile changes. Not the proof chain, not
+  the app's own state, not `.boris/` artifacts unless the user picks
+  them (they show in the picker like anything else).
+
+## 4. Push (M16-2)
+
+- `git push -u origin <branch>` (one-shot, credential helper,
+  `GIT_TERMINAL_PROMPT=0`). `-u` sets upstream tracking when the
+  branch is new — `branchStatus` then reports real ahead/behind
+  against `origin/<branch>` instead of nil upstream.
+- 401 / auth failure → git's stderr surfaced verbatim; the mailbox
+  keeps the M15 §10 posture (`lastSyncError`, non-blocking; re-auth
+  = the existing settings flow, since sign-out is the only token
+  deletion path).
+- Success → ahead → 0, `lastPushedAt` on the source (transient, like
+  `lastSyncedAt`), Remote mailbox reflects it.
+- **No force-push, ever.** The verb is a plain `git push`; any
+  non-fast-forward rejection is git's own error, surfaced.
+
+## 5. PR authoring (M16-3)
+
+- **Seam first:** `GithubOAuth.HTTPTransport` gains
+  `post(_ url: URL, json: Data, bearer: SecureBuffer) async throws ->
+  Data` (stub in tests; the URLSession impl is a clone of `get` with
+  a JSON body). `GithubAPIClient` gains `createPullRequest(owner:
+  repository: title: body: head: base: bearer: transport:)` →
+  `POST /repos/{owner}/{repo}/pulls`; the response carries `html_url`
+  + `number`; non-2xx bodies surface as `httpStatus(status, message)`
+  (D11 — never swallow).
+- **Flow:** from the Remote mailbox, "New Pull Request…" → if the
+  branch has no upstream, push it first (M16-2) → sheet with title +
+  body (prefilled: branch name as title suggestion, never required) →
+  `POST` → success opens the PR in the browser and offers "Open on
+  GitHub". Base = `source.defaultBranch`, head = current branch. The
+  user picks the base explicitly if they want a different one — never
+  guessed beyond the stored default.
+- **Do not:** fetch repo/branch lists without the user's pick;
+  fabricate a title; merge anything; touch review/merge endpoints.
+
+## 6. Issues mailbox (M16-4)
+
+- New github-only mailbox token `issues` (pattern: M15 `remote` —
+  `WorkspaceMailbox.all(for:)` appends it, never in `all`, `display`
+  passes it through).
+- `GithubAPIClient.listIssues(owner:repository:bearer:transport:)` →
+  `GET /repos/{owner}/{repo}/issues?state=open` (REST returns PRs in
+  the same list — filter `pull_request == nil`). Rows: number, title,
+  labels; click → Open on GitHub (`NSWorkspace`, existing pattern).
+- Create-issue sheet → `POST /repos/{owner}/{repo}/issues` (title +
+  body) → row appears on refresh. This is the one M16 surface that is
+  a *mailbox* rather than a Remote-mailbox verb.
+- PRs stay out of this mailbox (the REST list mixes them; we filter).
+  A Pull Requests mailbox is named in "Later", not built here.
+
+## 7. Files and lanes
+
+| File | Lane | Owns |
+|------|------|------|
+| `Sources/Workspace/GitHub/GithubCommit.swift` (or extend `GithubSync`) | workspace | commit + push one-shots, `Session` cancel, status-entries picker data |
+| `Sources/Workspace/Git/GitClone.swift` | workspace | `statusEntries(at:)` porcelain parse (extend, do not re-derive) |
+| `Sources/Workspace/GitHub/GithubAPIClient.swift` | workspace | `createPullRequest`, `listIssues`, `createIssue` |
+| `Sources/Workspace/GitHub/GithubOAuth.swift` | workspace | transport gains `post(json:bearer:)` |
+| `Sources/Play/GitHub/RemoteMailboxView.swift` | play | Commit + Push verbs, New Pull Request… sheet |
+| `Sources/Play/GitHub/IssuesMailboxView.swift` (new) | play | issues mailbox rows + create sheet |
+| `Sources/Workspace/WorkspaceSelection.swift` | workspace | `issues` mailbox token (github-only rows) |
+| `Sources/Workspace/WorkspaceStore.swift` | workspace | `commitGithub` / `pushGithub` (one-shot, off main), transient `lastPushedAt` |
+| `Sources/App/Settings/` | settings | repo-local identity row (M16-1, optional) |
+
+**Untouched:** `Sources/Engine/**` (boris never talks to GitHub; the
+working copy is the tree), `Sources/Compose/**`,
+`Sources/Chrome/MainWindow.swift`, entitlements (`network.client` +
+keychain-access already exist). Watch is **not** suspended for any M16
+verb (decision §2).
+
+## 8. Do not
+
+- Reimplement git in Swift; re-derive `gitExecutableURL`; invent a
+  second credential seam (reuse `SecureBuffer` / `KeychainStore` /
+  helper mode).
+- `git add -A` or stage files the user did not pick.
+- Invent commit identity, force-push, or touch global git config.
+- Fetch repo/branch lists without the user's pick; guess the base
+  branch beyond `defaultBranch`; merge or review PRs.
+- Put the token in argv/env/logs/plists (zero-leak invariant holds —
+  every write verb authenticates via the helper or the Keychain
+  bearer over the transport).
+- Treat issues as a PR mailbox (filter `pull_request`); grow
+  `Sources/Chrome/MainWindow.swift`; touch `Sources/Engine/**`.
+
+## 9. Gate (how the lane proves it)
+
+Manual, against the real app (`make build`; a GitHub source with a
+working copy):
+
+1. Edit a file in the working copy → Remote mailbox → **Commit** shows
+   the changed file in the picker; commit with a message → ahead 1,
+   working copy unchanged otherwise.
+2. **Push** → ahead 0; the change is on the remote (verified via
+   GitHub or a second clone).
+3. **New Pull Request…** → title/body sheet → PR opens in the browser;
+   the PR exists on `owner/repo`.
+4. Issues mailbox lists the repo's open issues (no PRs in the list);
+   create-issue sheet posts a new issue that appears on refresh.
+5. Watch was never suspended across any of the above (preview keeps
+   serving; the frozen-window guarantee is untouched).
+6. `SKIP_EMBED_BORIS=1 make build` + `make test` green — **no live
+   GitHub in CI**.
+
+Automated (unit, injected transport + clock, no network):
+
+- Transport `post(json:bearer:)` stub round trip; API client decodes
+  PR/issue responses and surfaces non-2xx bodies.
+- `statusEntries` porcelain parsing (v1 + v2 lines, untracked files).
+- Commit/push invocation against a local bare remote (clone precedent,
+  live but local — no network): add → commit → ahead 1 → push → 0;
+  commit with no identity fails with git's error surfaced.
+- `WorkspaceMailbox.all(for:)` github-only `issues` row.
+
+## 10. Edge cases
+
+- **No commit identity configured:** git's own "Please tell me who you
+  are" surfaces verbatim with a repo-config hint; the commit is not
+  attempted with a fake identity.
+- **Non-fast-forward push:** git's rejection surfaced verbatim; the
+  user pulls (existing Sync verb), never a force-push.
+- **PR from a branch with no upstream:** M16-3 pushes it first
+  (`-u`), then creates the PR — one user-visible action, two git
+  verbs.
+- **Token revoked while composing:** the API write fails with 401 →
+  `httpStatus(401, …)` surfaced, the M15 §10 `needsAuth` posture
+  (non-blocking, re-auth via the existing flow).
+- **Issues list empty:** honest empty state, never a fake row.
+- **Working copy deleted:** the picker shows an unavailable state
+  (existing badge); Commit/Push disabled until Relocate or re-clone.
+
+## 11. Sequencing
+
+M16-1 (commit) first — it unblocks M16-2 (push), and M16-3 needs
+push. M16-4 (issues) is independent of the git verbs and can run
+parallel with M16-1. Cards below; one worktree, one PR each, all
+against `main`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -112,20 +112,21 @@ No scraped prose. No homegrown graph. No third settings store.
 - **GitHub as its own `SourceKind`** (OAuth / app password, not
   just a clone). The clone slice landed as M12:
   [#131](https://github.com/drawmeanelephant/solipsist/issues/131)
-  → PRs #152/#153 (URL → folder → Local source). OAuth / app
-  password remains. Pages as a *target* does not require either.
-  **M15:** device-flow OAuth + PAT fallback, Keychain token, working
-  copy, Remote mailbox Sync (fetch + `pull --ff-only`;
-  commit/push/PR stay later). Design gate:
-  [`docs/GITHUB-OAUTH-DESIGN.md`](GITHUB-OAUTH-DESIGN.md) —
-  [#179](https://github.com/drawmeanelephant/solipsist/issues/179).
+  → PRs #152/#153 (URL → folder → Local source). **M15** landed:
+  device-flow OAuth + PAT fallback, Keychain token, working copy,
+  Remote mailbox Sync, sign-out (PRs #180–#184;
+  [`GITHUB-OAUTH-DESIGN.md`](GITHUB-OAUTH-DESIGN.md)). The remote
+  *write* verbs (commit / push / PR authoring / issues mailbox) are
+  **M16** — design gate
+  [`M16-WRITE-REMOTE-DESIGN.md`](M16-WRITE-REMOTE-DESIGN.md),
+  [#185](https://github.com/drawmeanelephant/solipsist/issues/185).
 - Content-audit mailbox (`boris-content-audit`)
 - Source-RAG export for AI assist
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)
 - Cooklang recipe-scale as a first-class mailbox (v1: available from
   the page inspector when the corpus has recipes)
-- Fetch / pull / commit / push on a checkout (clone is M12; remotes
-  stay later)
+- A Pull Requests mailbox (the issues mailbox filters PRs out of the
+  REST list; a dedicated PR mailbox stays later)
 - Width-adaptive list-left-of-letter split (M10 default is stacked)
 - The fart app (CI job reserved, `make fart` refuses; do not build it)
 
@@ -151,7 +152,8 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M12** Clone | ✅ Add Git Repository… → Local source ([#131](https://github.com/drawmeanelephant/solipsist/issues/131); PRs #152/#153) |
 | **M13** Graph folders | ✅ trunk mailboxes from `graph.parent` ([#142](https://github.com/drawmeanelephant/solipsist/issues/142); #144–#146 → PRs #154/#155/#156) |
 | **M14** Watch contract | ✅ A1 `--watch-json` + letter SSE ([#143](https://github.com/drawmeanelephant/solipsist/issues/143); #147/#148 → PRs #157/#158) |
-| **M15** GitHub source | filed — OAuth device flow + `SourceKind.github` payload ([#179](https://github.com/drawmeanelephant/solipsist/issues/179); design [`GITHUB-OAUTH-DESIGN.md`](GITHUB-OAUTH-DESIGN.md)) |
+| **M15** GitHub source | ✅ OAuth device flow + `SourceKind.github` payload, working copy, Remote mailbox Sync, sign-out ([#179](https://github.com/drawmeanelephant/solipsist/issues/179); PRs #180–#184) |
+| **M16** Write the remote | filed — commit / push / PR authoring / issues mailbox ([#185](https://github.com/drawmeanelephant/solipsist/issues/185); design [`M16-WRITE-REMOTE-DESIGN.md`](M16-WRITE-REMOTE-DESIGN.md)) |
 
 **Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
 batch then landed: first-run and problem→page (#88/#94), graph filter /
@@ -604,20 +606,20 @@ here, it is not a v1 promise.
 
 ## 8. Pickup (what to do next)
 
-M10–M14 and the post-ship batch (#165/#166/#167 — content-audit,
-source-rag, compose depth) landed. Remaining **ship** is Apple-account
-only. Next **product** slice is M15, the GitHub source (the deferred
-ROADMAP §3 item) — design gate
-[`docs/GITHUB-OAUTH-DESIGN.md`](GITHUB-OAUTH-DESIGN.md).
+M10–M14, the post-ship batch (#165/#166/#167), and **M15** (the
+GitHub source, PRs #180–#184) landed. Remaining **ship** is
+Apple-account only. Next **product** slice is M16, the remote *write*
+verbs — design gate
+[`docs/M16-WRITE-REMOTE-DESIGN.md`](M16-WRITE-REMOTE-DESIGN.md).
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
-| 1 | M15 GitHub source | [#179](https://github.com/drawmeanelephant/solipsist/issues/179) | Board is empty; the deferred OAuth/`SourceKind.github` payload is the only named product item left. Device flow → Keychain → working copy → Remote mailbox. |
-| 2 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. Parallel with #179. |
-| 3 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
-
-#179 is OAuth + `SourceKind.github` payload, not the M12 clone
-(clone-as-local stays landed and untouched).
+| 1 | M16-1 Commit | [#185](https://github.com/drawmeanelephant/solipsist/issues/185) | M15 shipped the full read side (Sync + Remote mailbox); commit is the first write verb and unblocks push + PR. |
+| 2 | M16-2 Push | #185 | after M16-1 — pushes its commits through the credential helper. |
+| 3 | M16-3 PR | #185 | after M16-2 — push branch → `POST /pulls`. |
+| 4 | M16-4 Issues | #185 | parallel with M16-1 — the mailbox is independent of the git verbs. |
+| 5 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. Parallel with the M16 slices. |
+| 6 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
 
 ### Landed depth (do not redo)
 
@@ -642,9 +644,10 @@ Named in this file and **not** a product surface yet: browser OAuth,
 `github-pages-audit`, A1 `--watch-json` (M14), trunk mailbox
 folders (M13).
 
-Out of v1 (unchanged): GitHub OAuth / `SourceKind.github` payload,
-content-audit, source-rag, migration labs, Wasm in the app,
+Out of v1 (unchanged): migration labs, Wasm in the app,
 `validate --watch` until A5 + pin. Clone-as-local is M12 / #131.
+GitHub source is M15 (landed); its remote *write* verbs are M16
+(commit / push / PR authoring / issues mailbox).
 Compose **depth** (diagnostics, bundle `oliver`) stays Later; the
 M10 compose window is #106 / #108.
 

--- a/docs/cards/M16-commit.md
+++ b/docs/cards/M16-commit.md
@@ -1,0 +1,53 @@
+# Card M16-1 — Commit verb (changed-files picker + git commit)
+
+**Milestone:** M16 (write the remote) · **Issue:**
+[#185](https://github.com/drawmeanelephant/solipsist/issues/185)
+**Lane:** workspace / play / settings. One worktree, one PR against
+`main`; branch suggestion `feat/github-commit`.
+
+Design gate: [`docs/M16-WRITE-REMOTE-DESIGN.md`](../M16-WRITE-REMOTE-DESIGN.md)
+— the lane owns that file and the implementation.
+
+## Owns
+
+- `Sources/Workspace/Git/GitClone.swift` — extend with
+  `statusEntries(at:)` (parse `status --porcelain` v1/v2 + untracked;
+  same runner shape as `branchStatus`). Do not re-derive the runner.
+- `Sources/Workspace/GitHub/GithubCommit.swift` (new) — `git add --`
+  + `git commit` one-shots with a `Session` cancel path (SyncSession
+  shape); identity is never invented — git's missing-identity error
+  surfaces verbatim.
+- `Sources/Play/GitHub/RemoteMailboxView.swift` — Commit verb +
+  changed-files picker sheet (checkboxes → `git add -- <picked>` →
+  commit → `branchStatus` refresh).
+- `Sources/App/Settings/` — optional repo-local identity row (writes
+  `user.name`/`user.email` to the working copy's `.git/config` only
+  on explicit save; never `--global`).
+
+## Do not touch
+
+- `Sources/Engine/**`, `Sources/Compose/**`, `Sources/Chrome/MainWindow.swift`
+- `git add -A`; staging anything the user did not pick
+- Global git config; invented identity; force-push
+- The `GithubSync` fetch/pull path (read-only, keep)
+
+## Do
+
+1. `statusEntries(at:)` porcelain parse + tests (v1/v2, untracked,
+   deleted, renamed).
+2. Picker sheet in the Remote mailbox: changed files with checkboxes,
+   commit-message field, Commit button. Runs one-shots off the main
+   actor; cancel = SIGTERM.
+3. After commit: `branchStatus` refresh (ahead grows by 1), surface
+   git's exit + stderr verbatim on failure (D11).
+4. Missing `user.name`/`user.email` → git's error surfaced with a
+   repo-config hint (and the Settings row if shipped).
+5. Watch is **not** suspended for commit (design §2) — nothing in
+   this slice calls `beginTreeWrite`.
+
+## Gate
+
+Edit a file in the working copy → Commit picker shows it → commit with
+a message → ahead 1, working copy otherwise untouched; no identity →
+git's own error, no fake commit. `make build` + `make test` green, no
+live GitHub in CI.

--- a/docs/cards/M16-issues.md
+++ b/docs/cards/M16-issues.md
@@ -1,0 +1,42 @@
+# Card M16-4 — Issues mailbox (`GET/POST /repos/{owner}/{repo}/issues`)
+
+**Milestone:** M16 (write the remote) · **Issue:**
+[#185](https://github.com/drawmeanelephant/solipsist/issues/185)
+**Lane:** workspace / play. One worktree, one PR against `main`;
+branch suggestion `feat/github-issues`.
+
+Design gate: [`docs/M16-WRITE-REMOTE-DESIGN.md`](../M16-WRITE-REMOTE-DESIGN.md)
+— the lane owns that file and the implementation.
+
+## Owns
+
+- `Sources/Workspace/WorkspaceSelection.swift` — `issues` mailbox
+  token, github-only via `WorkspaceMailbox.all(for:)` (M15 `remote`
+  pattern: never in `all`, `display` passes through).
+- `Sources/Workspace/GitHub/GithubAPIClient.swift` — `listIssues`
+  (`?state=open`, filter `pull_request == nil` — REST mixes PRs into
+  issues) + `createIssue` (title/body).
+- `Sources/Workspace/GitHub/GithubOAuth.swift` — transport JSON-post
+  seam shared with M16-3 (merge order: after or with that card).
+- `Sources/Play/GitHub/IssuesMailboxView.swift` (new) — rows (number,
+  title, labels) → Open on GitHub; create-issue sheet.
+
+## Do not touch
+
+- `Sources/Engine/**`, `Sources/Compose/**`, `Sources/Chrome/MainWindow.swift`
+- A Pull Requests mailbox (named "Later", not built here)
+- Token in argv/env/logs; repo/branch list fetches without the user's pick
+
+## Do
+
+1. `issues` mailbox token + sidebar row for github sources only;
+   `LocalPlay` switch case → `IssuesMailboxView`.
+2. List issues (open, PRs filtered), honest empty state.
+3. Create-issue sheet → row appears on refresh; API errors surfaced
+   (D11).
+
+## Gate
+
+Issues mailbox lists the repo's open issues with no PRs in the list;
+create-issue posts a new issue that appears on refresh. API unit tests
+green; `make build` + `make test` green.

--- a/docs/cards/M16-pr.md
+++ b/docs/cards/M16-pr.md
@@ -1,0 +1,43 @@
+# Card M16-3 — PR authoring (`POST /repos/{owner}/{repo}/pulls`)
+
+**Milestone:** M16 (write the remote) · **Issue:**
+[#185](https://github.com/drawmeanelephant/solipsist/issues/185)
+**Lane:** workspace / play. One worktree, one PR against `main`;
+branch suggestion `feat/github-pr`.
+
+Design gate: [`docs/M16-WRITE-REMOTE-DESIGN.md`](../M16-WRITE-REMOTE-DESIGN.md)
+— the lane owns that file and the implementation.
+
+## Owns
+
+- `Sources/Workspace/GitHub/GithubOAuth.swift` — `HTTPTransport` gains
+  `post(_ url: JSON, bearer: SecureBuffer)` (URLSession impl clones
+  `get`; test stubs updated in `GithubTestSupport.swift`).
+- `Sources/Workspace/GitHub/GithubAPIClient.swift` —
+  `createPullRequest(owner:repository:title:body:head:base:bearer:
+  transport:)`; response carries `html_url` + `number`; non-2xx
+  bodies → `httpStatus(status, message)` (D11).
+- `Sources/Play/GitHub/RemoteMailboxView.swift` — New Pull Request…
+  sheet (title + body; branch-name title suggestion, never required;
+  base = `source.defaultBranch`, user may override).
+
+## Do not touch
+
+- `Sources/Engine/**`, `Sources/Compose/**`, `Sources/Chrome/MainWindow.swift`
+- Fetching repo/branch lists without the user's pick
+- Merge / review endpoints; force-push; token in argv/env/logs
+
+## Do
+
+1. Transport JSON-post seam + stub in tests (CI never touches GitHub).
+2. API client: create-PR decode + error surfacing; tests for 2xx and
+   non-2xx bodies.
+3. Sheet flow: no upstream → push first (`-u`, M16-2's one-shot) →
+   `POST` → success opens the PR in the browser (existing
+   `NSWorkspace` pattern).
+
+## Gate
+
+Remote mailbox → New Pull Request… → title/body → PR opens in the
+browser and exists on `owner/repo`. Transport/API unit tests green;
+`make build` + `make test` green.

--- a/docs/cards/M16-push.md
+++ b/docs/cards/M16-push.md
@@ -1,0 +1,42 @@
+# Card M16-2 — Push verb (`git push` through the credential helper)
+
+**Milestone:** M16 (write the remote) · **Issue:**
+[#185](https://github.com/drawmeanelephant/solipsist/issues/185)
+**Lane:** workspace / play. One worktree, one PR against `main`;
+branch suggestion `feat/github-push`.
+
+Design gate: [`docs/M16-WRITE-REMOTE-DESIGN.md`](../M16-WRITE-REMOTE-DESIGN.md)
+— the lane owns that file and the implementation.
+
+## Owns
+
+- `Sources/Workspace/GitHub/GithubCommit.swift` (or the commit slice's
+  file — this lane may extend it) — `git push -u origin <branch>`
+  one-shot, credential helper, `GIT_TERMINAL_PROMPT=0`, `Session`
+  cancel.
+- `Sources/Workspace/GitHub/GithubSource.swift` — transient
+  `lastPushedAt: Date?` (not persisted, like `lastSyncedAt`).
+- `Sources/Play/GitHub/RemoteMailboxView.swift` — Push verb next to
+  Sync/Commit; success → ahead 0 + last-pushed shown.
+
+## Do not touch
+
+- `Sources/Engine/**`, `Sources/Compose/**`, `Sources/Chrome/MainWindow.swift`
+- Force-push, ever; the credential helper seam (reuse, do not re-derive)
+- The token in argv/env/logs
+
+## Do
+
+1. Push one-shot with `-u` (sets upstream tracking for a new branch).
+2. Surface git's stderr verbatim on failure — 401 → the M15 §10
+   `needsAuth` posture (non-blocking; re-auth via the existing
+   settings flow).
+3. On success: ahead → 0, `lastPushedAt` set, Remote mailbox reflects
+   it.
+4. Watch is **not** suspended (design §2).
+
+## Gate
+
+After an M16-1 commit, Push → ahead 0; the change is on the remote
+(verified via GitHub or a second clone). Non-fast-forward rejection =
+git's error, no force-push. `make build` + `make test` green.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -126,21 +126,35 @@ The two tool cards run through the coordinator's single `Process?` slot;
 | [3.4 Cooklang autocomplete](LATER-compose-cooklang.md) | #167 | compose | after 3.3 | `@` suggests corpus ingredients from completion.json |
 | [3.5 Bundle oliver](LATER-compose-bundle-oliver.md) | #167 | ship | parallel | Resources/oliver next to boris; preview without env override |
 
-## M15 — GitHub source (pickable)
+## M15 — GitHub source ✅
 
-The deferred ROADMAP §3 "Later" item — GitHub as its own
-`SourceKind` (OAuth device flow + PAT fallback, not just a clone).
-Design gate: [`docs/GITHUB-OAUTH-DESIGN.md`](../GITHUB-OAUTH-DESIGN.md).
+Landed — PRs #180 (seam) · #181 (settings sheet) · #182 (credential
+helper) · #183 (Remote mailbox) · #184 (sign-out). Do not pick.
+
+| Card | Issue | Fate |
+|------|-------|------|
+| [GitHub source](GITHUB-OAUTH.md) | [#179](https://github.com/drawmeanelephant/solipsist/issues/179) | ✅ |
+
+## M16 — Write the remote (pickable)
+
+The ROADMAP §3 "Later" remainder of the GitHub-source deferral —
+commit / push / PR authoring / issues mailbox (fetch + `pull --ff-only`
+moved up with M15). Design gate:
+[`docs/M16-WRITE-REMOTE-DESIGN.md`](../M16-WRITE-REMOTE-DESIGN.md).
+One slice per worktree/PR.
 
 | Card | Issue | Lane | Parallel with | Gate |
 |------|-------|------|----------------|------|
-| [GitHub source](GITHUB-OAUTH.md) | [#179](https://github.com/drawmeanelephant/solipsist/issues/179) | workspace / settings / play | — | device flow → Keychain → working copy; Remote mailbox Sync; restart keeps the source |
+| [M16-1 Commit](M16-commit.md) | [#185](https://github.com/drawmeanelephant/solipsist/issues/185) | workspace / play / settings | M16-4 | changed-files picker → `git add <picked>` + commit; identity never invented |
+| [M16-2 Push](M16-push.md) | #185 | workspace / play | after M16-1 | `git push -u` through the helper; ahead → 0 |
+| [M16-3 PR](M16-pr.md) | #185 | workspace / play | after M16-2 | push branch → `POST /pulls` → PR in browser |
+| [M16-4 Issues](M16-issues.md) | #185 | workspace / play | M16-1 | issues mailbox; create sheet; PRs filtered out |
 
 ## Do not start yet
 
-Wasm in the app. The fart app. Commit / push / PR authoring / issues
-mailboxes (fetch + `pull --ff-only` moved up with the GitHub source;
-remote *writes* stay later).
+Wasm in the app. The fart app. A Pull Requests mailbox (REST mixes PRs
+into issues; the issues mailbox filters them — a PR mailbox stays
+later).
 
 ## Shared noun kinds (play writes, inspector reads)
 


### PR DESCRIPTION
## M16 design gate — write the remote (commit / push / PR / issues)

Closes the deferred remote-*write* half of the GitHub-source deferral,
now that M15 fully shipped (PRs #180–#184). Issue
[#185](https://github.com/drawmeanelephant/solipsist/issues/185) is
the lane tracker; this PR is the docs batch that makes it pickable.

**`docs/M16-WRITE-REMOTE-DESIGN.md`** — the spec, in COORDINATOR /
GITHUB-OAUTH house style:

- **M16-1 Commit** — changed-files picker from `git status --porcelain`
  (new `GitClone.statusEntries`), `git add -- <picked>` + commit
  one-shots, **never `git add -A`**. Identity is never invented: git's
  own missing-identity error surfaces verbatim, with a repo-local
  Settings row as the only write.
- **M16-2 Push** — `git push -u origin <branch>` through the existing
  credential helper (no new auth surface), no force-push, 401 → the
  M15 §10 needsAuth posture.
- **M16-3 PR authoring** — the transport gains `post(json:bearer:)`;
  `POST /repos/{owner}/{repo}/pulls` with base = `defaultBranch`
  (never guessed), push-first when the branch has no upstream, success
  opens the PR in the browser.
- **M16-4 Issues mailbox** — `issues` token on the M15 `remote`
  pattern (github-only rows), `GET …/issues?state=open` with PRs
  filtered out of the REST mix, rows → Open on GitHub, create sheet.

**The one deliberate decision worth flagging:** none of the M16 verbs
suspend watch — commit/push touch only `.git`/the index, never the
content tree watch serves (the single tree-writing git verb, pull,
already freezes watch under M15). If a lane disagrees, say why on #185.

**Also:** four slice cards (`docs/cards/M16-{commit,push,pr,issues}.md`),
the board section, and the roadmap (Later bullet, M15 → ✅, M16 filed,
§8 pickup re-ordered, stale "GitHub OAuth out of v1" line fixed).

Docs only — no code, no CI implications beyond lint.
