### PR TITLE
feat(github): M16-1 Commit verb — changed-files picker + git commit (#185)

### DIFF
--- a/Sources/Play/GitHub/RemoteMailboxView.swift
+++ b/Sources/Play/GitHub/RemoteMailboxView.swift
@@ -15,10 +15,12 @@ struct RemoteMailboxView: View {
 
     @State private var status: GitClone.GitBranchStatus?
     @State private var statusError: String?
+    @State private var showCommitSheet = false
 
     var body: some View {
         List {
             syncSection
+            commitSection
             statusSection
             if let error = live.lastSyncError {
                 Section {
@@ -45,6 +47,24 @@ struct RemoteMailboxView: View {
                     Label("Open on GitHub", systemImage: "arrow.up.right.square")
                 }
                 .help("Open \\(source.owner)/\\(source.repository) in your browser")
+            }
+        }
+        .sheet(isPresented: $showCommitSheet) {
+            CommitSheet(source: source) {
+                Task { await refreshStatus() }
+            }
+        }
+    }
+
+    private var commitSection: some View {
+        Section {
+            HStack {
+                Label("Commit", systemImage: "square.and.pencil")
+                Spacer()
+                Button("Commit…") {
+                    showCommitSheet = true
+                }
+                .disabled(!live.isAvailable || live.isSyncing)
             }
         }
     }
@@ -136,5 +156,143 @@ struct RemoteMailboxView: View {
             GitClone.branchStatus(at: root)
         }.value
         status = result
+    }
+}
+
+/// Commit picker (M16-1): changed files with checkboxes, a message, and
+/// a Commit button. Exactly the picked paths are staged — never
+/// `git add -A`. Identity is never invented: git's missing-identity
+/// error surfaces verbatim with a repo-config hint.
+private struct CommitSheet: View {
+    let source: GithubSource
+    /// Runs after a successful commit (branchStatus refresh).
+    let onCommitted: () -> Void
+
+    @Environment(WorkspaceStore.self) private var store
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var entries: [GitClone.GitStatusEntry] = []
+    @State private var selectedPaths: Set<String> = []
+    @State private var message = ""
+    @State private var isCommitting = false
+    @State private var commitError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Commit Changes")
+                .font(.headline)
+
+            if let commitError {
+                Text(commitError)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+            }
+
+            if entries.isEmpty {
+                Text("No changed files in the working copy.")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(entries, id: \.path, selection: $selectedPaths) { entry in
+                    HStack {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Color.accentColor)
+                            .frame(width: 14)
+                            .opacity(selectedPaths.contains(entry.path) ? 1 : 0)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(entry.path)
+                                .font(.system(size: 12.5, weight: .regular))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            if let sourcePath = entry.sourcePath {
+                                Text("from \\(sourcePath)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                        }
+                        Spacer()
+                        Text(entry.statusLabel)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        if selectedPaths.contains(entry.path) {
+                            selectedPaths.remove(entry.path)
+                        } else {
+                            selectedPaths.insert(entry.path)
+                        }
+                    }
+                }
+                .listStyle(.inset)
+                .frame(minHeight: 160)
+            }
+
+            TextField("Commit message", text: $message, axis: .vertical)
+                .lineLimit(2...5)
+                .textFieldStyle(.roundedBorder)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Commit") { commit() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(
+                        selectedPaths.isEmpty
+                            || message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || isCommitting
+                    )
+            }
+        }
+        .padding(20)
+        .frame(width: 460, height: 380)
+        .task {
+            await load()
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        guard let root = try? source.workspaceRoot() else {
+            commitError = "Working copy is unavailable."
+            return
+        }
+        let result = await Task.detached {
+            GitClone.statusEntries(at: root)
+        }.value
+        entries = result
+        // Nothing pre-selected: the user decides exactly what to stage.
+        selectedPaths = []
+    }
+
+    private func commit() {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !selectedPaths.isEmpty, !trimmed.isEmpty, !isCommitting else { return }
+        isCommitting = true
+        commitError = nil
+        let paths = Array(selectedPaths).sorted()
+        Task {
+            let result = await store.commitGithub(source.id, paths: paths, message: trimmed)
+            isCommitting = false
+            if result.isSuccess {
+                onCommitted()
+                dismiss()
+            } else {
+                commitError = Self.describe(result)
+            }
+        }
+    }
+
+    /// Git's exit + stderr verbatim; a repo-config hint when the failure
+    /// is a missing identity — never a synthesized one.
+    static func describe(_ result: GithubCommit.CommitResult) -> String {
+        var text = "git commit failed (exit \(result.exitCode)): \(result.stderr)"
+        if result.stderr.contains("user.email") || result.stderr.contains("user.name") {
+            text += "\n\nSet user.name and user.email for this repository (git config user.name \"…\"; git config user.email …) — Solipsist never invents an identity."
+        }
+        return text
     }
 }

--- a/Sources/Workspace/Git/GitClone.swift
+++ b/Sources/Workspace/Git/GitClone.swift
@@ -197,6 +197,97 @@ public enum GitClone {
         public let behind: Int
     }
 
+    /// One changed file from `status --porcelain=v1 -z` (M16-1).
+    /// `path` is the working-copy-relative path `git add -- <path>`
+    /// accepts — for renames that is the **destination** (git -z emits
+    /// `XY <to>\0<from>`; staging the destination stages the rename).
+    public struct GitStatusEntry: Sendable, Equatable {
+        public let path: String
+        /// The porcelain XY pair, e.g. `" M"`, `"??"`, `"R "`.
+        public let status: String
+        /// Rename/copy source path (display only); nil otherwise.
+        public let sourcePath: String?
+
+        /// Human label for the picker row.
+        public var statusLabel: String {
+            switch status {
+            case "??": return "untracked"
+            case "M ", " M": return "modified"
+            case "A ", " A": return "added"
+            case "D ", " D": return "deleted"
+            case "R ", " R": return "renamed"
+            case "C ", " C": return "copied"
+            case "MM", "AM", "MD", "AD", "RM", "RD": return status
+            default:
+                let trimmed = status.trimmingCharacters(in: .whitespaces)
+                return trimmed.isEmpty ? status : trimmed
+            }
+        }
+    }
+
+    /// Changed files of the checkout at `root` (Commit picker, M16-1):
+    /// `git status --porcelain=v1 -z`, same runner shape as
+    /// `branchStatus`. Missing git / not-a-repo → empty, never an error.
+    public static func statusEntries(at root: URL) -> [GitStatusEntry] {
+        guard FileManager.default.fileExists(atPath: root.appendingPathComponent(".git").path) else {
+            return []
+        }
+        let process = Process()
+        process.executableURL = gitExecutableURL()
+        process.arguments = ["-C", root.path, "status", "--porcelain=v1", "-z"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return []
+        }
+        guard process.terminationStatus == 0 else { return [] }
+        return parseStatusEntries(pipe.fileHandleForReading.readDataToEndOfFile())
+    }
+
+    /// Parse `--porcelain=v1 -z` bytes. Each NUL record is `XY <path>`;
+    /// rename/copy entries emit a second bare record with the source
+    /// path (`XY <to>\0<from>`), consumed here. Pure — tests feed bytes.
+    public static func parseStatusEntries(_ data: Data) -> [GitStatusEntry] {
+        let records = data.split(separator: 0)
+        var entries: [GitStatusEntry] = []
+        var index = 0
+        while index < records.count {
+            let record = records[index]
+            guard let text = String(data: record, encoding: .utf8), text.count >= 3 else {
+                index += 1
+                continue
+            }
+            // Records are `XY <path>`; the second character must be the
+            // status, the third a space. A bare record (no `XY ` prefix)
+            // is a rename/copy source — it belongs to the prior entry,
+            // which is handled below, so skip it here.
+            guard text[text.index(text.startIndex, offsetBy: 2)] == " " else {
+                index += 1
+                continue
+            }
+            let status = String(text.prefix(2))
+            let path = String(text.dropFirst(3))
+            var entry = GitStatusEntry(path: path, status: status, sourcePath: nil)
+            if status.contains("R") || status.contains("C") {
+                if index + 1 < records.count,
+                   let source = String(data: records[index + 1], encoding: .utf8),
+                   !source.isEmpty
+                {
+                    entry = GitStatusEntry(path: path, status: status, sourcePath: source)
+                }
+                index += 2
+            } else {
+                index += 1
+            }
+            entries.append(entry)
+        }
+        return entries
+    }
+
     /// Parse the ahead/behind counts out of one porcelain v2 line:
     /// `# branch.ab +1 -2` → (1, 2). Anything else returns nil.
     public static func parseAheadBehind(from line: String) -> (ahead: Int, behind: Int)? {

--- a/Sources/Workspace/GitHub/GithubCommit.swift
+++ b/Sources/Workspace/GitHub/GithubCommit.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Commit verb (M16-1 / #185): `git add -- <picked>` then
+/// `git commit`, one-shot processes (never the engine slot) on the
+/// working copy. The picker decides exactly which paths are staged —
+/// never `git add -A`. Identity is never invented: git's own
+/// missing-identity error surfaces verbatim.
+public enum GithubCommit {
+    public struct CommitResult: Sendable {
+        public let exitCode: Int32
+        public let stderr: String
+
+        public var isSuccess: Bool { exitCode == 0 }
+    }
+
+    /// Stage exactly the picked paths, then commit with the message.
+    /// Runs two sequential git processes sharing one `SyncSession`
+    /// (SIGTERM cancels the in-flight one). The commit is skipped when
+    /// staging fails — its result is returned so the failure surfaces
+    /// with git's own stderr. Identity failures come back in `stderr`
+    /// verbatim (git's "Please tell me who you are").
+    public static func commit(
+        paths: [String],
+        message: String,
+        workingCopy: URL,
+        session: SyncSession,
+        environment: [String: String] = [:]
+    ) -> CommitResult {
+        let stage = run(["add", "--"] + paths, workingCopy: workingCopy, session: session, environment: environment)
+        guard stage.isSuccess else { return stage }
+        return run(["commit", "-m", message], workingCopy: workingCopy, session: session, environment: environment)
+    }
+
+    private static func run(
+        _ arguments: [String],
+        workingCopy: URL,
+        session: SyncSession,
+        environment: [String: String]
+    ) -> CommitResult {
+        let process = Process()
+        process.executableURL = GitClone.gitExecutableURL()
+        process.arguments = ["-C", workingCopy.path] + arguments
+        var env = ProcessInfo.processInfo.environment
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env.merge(environment) { _, new in new }
+        process.environment = env
+        let errPipe = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errPipe
+        session.attach(process)
+        do {
+            try process.run()
+        } catch {
+            session.detach()
+            return CommitResult(exitCode: 1, stderr: String(describing: error))
+        }
+        process.waitUntilExit()
+        session.detach()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        return CommitResult(
+            exitCode: process.terminationStatus,
+            stderr: String(decoding: errData, as: UTF8.self)
+        )
+    }
+}

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -240,6 +240,62 @@ final class WorkspaceStore {
         activeSyncSessions[id]?.terminate()
     }
 
+    // MARK: - GitHub commit (M16-1)
+
+    /// In-flight commits by source id (same one-shot shape as sync).
+    private var activeCommitSessions: [SourceID: SyncSession] = [:]
+
+    /// Commit verb (M16-1): stage exactly the picked paths + commit, off
+    /// the main actor, one-shots sharing a `SyncSession`. Watch is NOT
+    /// suspended — commit touches only `.git`/the index, never the
+    /// content tree watch serves (design §2). On success the branch
+    /// refreshes (ahead grows by 1). Git's exit + stderr surface
+    /// verbatim on failure (D11) — including the missing-identity error,
+    /// which is never papered over.
+    func commitGithub(
+        _ id: SourceID,
+        paths: [String],
+        message: String
+    ) async -> GithubCommit.CommitResult {
+        guard let index = sources.firstIndex(where: { $0.id == id }),
+              case .github(let github) = sources[index],
+              github.isAvailable,
+              let url = try? github.workspaceRoot()
+        else {
+            return GithubCommit.CommitResult(exitCode: 1, stderr: "Working copy is unavailable.")
+        }
+
+        let session = SyncSession()
+        activeCommitSessions[id] = session
+        defer { activeCommitSessions[id] = nil }
+
+        let result = await Task.detached {
+            GithubCommit.commit(
+                paths: paths,
+                message: message,
+                workingCopy: url,
+                session: session
+            )
+        }.value
+
+        // Refresh the branch regardless of outcome — a failed commit can
+        // still leave the index moved; the picker re-reads status anyway.
+        if let index = sources.firstIndex(where: { $0.id == id }),
+           case .github(let current) = sources[index]
+        {
+            var updated = current
+            updated.branch = GitClone.branchStatus(at: url).branch
+            sources[index] = .github(updated)
+        }
+        return result
+    }
+
+    /// SIGTERM the in-flight commit for a source. The index is left as
+    /// the interrupted `git` left it; the next picker run re-reads it.
+    func cancelCommitGithub(_ id: SourceID) {
+        activeCommitSessions[id]?.terminate()
+    }
+
     // MARK: - GitHub sign-out (M15)
 
     /// Sign out of a GitHub source (design §4): delete the Keychain

--- a/Tests/ContractTests/GithubCommitTests.swift
+++ b/Tests/ContractTests/GithubCommitTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+
+final class GithubCommitTests: XCTestCase {
+    // MARK: - Porcelain -z parsing (pure)
+
+    func testParseStatusEntriesUntrackedModifiedDeleted() {
+        let data = Data(" M a.txt\0 D b.txt\0?? c.txt\0".utf8)
+        let entries = GitClone.parseStatusEntries(data)
+        XCTAssertEqual(entries.count, 3)
+        XCTAssertEqual(entries[0].path, "a.txt")
+        XCTAssertEqual(entries[0].status, " M")
+        XCTAssertEqual(entries[0].statusLabel, "modified")
+        XCTAssertNil(entries[0].sourcePath)
+        XCTAssertEqual(entries[1].path, "b.txt")
+        XCTAssertEqual(entries[1].status, " D")
+        XCTAssertEqual(entries[1].statusLabel, "deleted")
+        XCTAssertEqual(entries[2].path, "c.txt")
+        XCTAssertEqual(entries[2].status, "??")
+        XCTAssertEqual(entries[2].statusLabel, "untracked")
+    }
+
+    func testParseStatusEntriesRenameEmitsDestinationFirst() {
+        // git -z emits `XY <to>\0<from>` for renames.
+        let data = Data("R  moved.txt\0renamed.txt\0 M keep.txt\0".utf8)
+        let entries = GitClone.parseStatusEntries(data)
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].path, "moved.txt")
+        XCTAssertEqual(entries[0].status, "R ")
+        XCTAssertEqual(entries[0].statusLabel, "renamed")
+        XCTAssertEqual(entries[0].sourcePath, "renamed.txt")
+        XCTAssertEqual(entries[1].path, "keep.txt")
+        XCTAssertNil(entries[1].sourcePath)
+    }
+
+    func testParseStatusEntriesEmpty() {
+        XCTAssertEqual(GitClone.parseStatusEntries(Data()), [])
+    }
+
+    func testStatusEntriesLiveLocalRepo() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gitcommit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try runGit(["init", "-b", "main"], in: dir)
+        try "one".write(to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: dir)
+        try runGit(["-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-m", "init"], in: dir)
+
+        // Modified + untracked appear; untouched files do not.
+        try "changed".write(to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "new".write(to: dir.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let entries = GitClone.statusEntries(at: dir)
+        let paths = entries.map(\.path)
+        XCTAssertTrue(paths.contains("a.txt"), "modified file must appear: \(paths)")
+        XCTAssertTrue(paths.contains("b.txt"), "untracked file must appear: \(paths)")
+    }
+
+    // MARK: - Commit one-shots (live, local remotes only, no network)
+
+    func testCommitStagesOnlyPickedPaths() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gitcommit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try runGit(["init", "-b", "main"], in: dir)
+        try runGit(["-c", "user.email=t@example.com", "-c", "user.name=t", "config", "user.email", "t@example.com"], in: dir)
+        try runGit(["config", "user.name", "t"], in: dir)
+        try "one".write(to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "two".write(to: dir.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: dir)
+        try runGit(["commit", "-m", "init"], in: dir)
+
+        // Modify both; commit only a.txt.
+        try "a2".write(to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "b2".write(to: dir.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+
+        let session = SyncSession()
+        let result = GithubCommit.commit(
+            paths: ["a.txt"],
+            message: "only a",
+            workingCopy: dir,
+            session: session
+        )
+        XCTAssertTrue(result.isSuccess, "commit failed: \(result.stderr)")
+
+        // a.txt is clean; b.txt is still modified (never add -A).
+        let entries = GitClone.statusEntries(at: dir)
+        let paths = entries.map(\.path)
+        XCTAssertFalse(paths.contains("a.txt"), "committed file should be clean: \(paths)")
+        XCTAssertTrue(paths.contains("b.txt"), "unpicked file must stay modified: \(paths)")
+    }
+
+    func testCommitMissingIdentityFailsVerbatim() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gitcommit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try runGit(["init", "-b", "main"], in: dir)
+        // `user.useConfigOnly` is git's documented opt-out of
+        // auto-derived identity (username@hostname). Without it git
+        // silently synthesizes one — this is the honest way to exercise
+        // the real missing-identity path. No user.name / user.email
+        // anywhere; the machine's global config is isolated.
+        try runGit(["config", "user.useConfigOnly", "true"], in: dir)
+        try "one".write(to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: dir)
+
+        let session = SyncSession()
+        let result = GithubCommit.commit(
+            paths: ["a.txt"],
+            message: "no identity",
+            workingCopy: dir,
+            session: session,
+            environment: ["GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"]
+        )
+        XCTAssertFalse(result.isSuccess)
+        XCTAssertTrue(
+            result.stderr.contains("user.email") || result.stderr.contains("Please tell me who you are"),
+            "git's own identity error must surface verbatim, got: \(result.stderr)"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func runGit(_ arguments: [String], in dir: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.currentDirectoryURL = dir
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(bytes: data, encoding: .utf8) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, "git \(arguments) failed: \(output)")
+    }
+}

--- a/docs/M16-WRITE-REMOTE-DESIGN.md
+++ b/docs/M16-WRITE-REMOTE-DESIGN.md
@@ -65,9 +65,19 @@ explicit decision, not an accident: the only tree-writing git verb is
   `user.name`/`user.email` fails with git's own error — surfaced
   **verbatim** (D11), with a hint pointing at the repo config or a
   Settings identity row. The app never writes global config and never
-  synthesizes an identity. M16-1 may add a Settings row that writes
-  **repo-local** `user.name`/`user.email` only on the user's explicit
-  save (the working copy's `.git/config`, never `--global`).
+  synthesizes an identity (no `-c user.name` / `user.email` flags,
+  ever). M16-1 may add a Settings row that writes **repo-local**
+  `user.name`/`user.email` only on the user's explicit save (the
+  working copy's `.git/config`, never `--global`).
+  **Probed fact (recorded for the lane):** git auto-derives an
+  identity from username@hostname when none is configured, so a bare
+  `git commit` on a fresh clone **succeeds** silently unless the user
+  has set `user.useConfigOnly=true` (git's documented opt-out). The
+  app surfaces whatever git does — the verbatim-error path is what a
+  user with `useConfigOnly` (or a hardened setup) sees, and the
+  auto-derived-identity case is git's own behavior, not the app
+  inventing one. The test exercises the true error path via
+  `useConfigOnly` + isolated config.
 - **One-shots.** `GithubCommit`-style enum (or extend `GithubSync`)
   with the same `Session` cancel path as `SyncSession`. Watch keeps
   running (decision above); after the commit, `branchStatus` refreshes


### PR DESCRIPTION
## M16-1 — Commit verb (changed-files picker + git commit)

First slice of the M16 write-remote batch (#185). The Remote mailbox
gains the first remote *write* verb: pick files, write a message,
commit. Builds entirely on the M15 seams — one-shot git processes,
`SyncSession` cancel, `GitClone` porcelain parsing.

### What ships

- **`GitClone.statusEntries(at:)`** — `git status --porcelain=v1 -z`
  parsed (pure `parseStatusEntries` fed by bytes, so tests never need
  git for the parse). Renames come back destination-first
  (`XY <to>\0<from>`), so the picker's path is exactly what
  `git add -- <path>` accepts. `statusLabel` for the row UI.
- **`GithubCommit`** (`Sources/Workspace/GitHub/GithubCommit.swift`) —
  `git add -- <picked>` then `git commit -m <message>`, two one-shots
  sharing a `SyncSession`. **Never `git add -A`** — exactly the picked
  paths are staged (the design's core rule; the test proves an
  unpicked file stays modified).
- **`WorkspaceStore.commitGithub(_:paths:message:)`** — off-main-actor
  one-shots, branch refresh after, `cancelCommitGithub`. Watch is
  **not** suspended (design §2: commit touches only `.git`/the index,
  never the content tree watch serves).
- **Commit sheet** in `RemoteMailboxView` — changed files with
  checkboxes (nothing pre-selected), commit-message field, Commit
  button, verbatim git errors with a repo-config hint.

### Identity, honestly

The app **never** invents an identity — no `-c user.name` /
`user.email` flags, no global config writes. Git's own
missing-identity error surfaces verbatim. Two probe findings recorded
in the design doc for the lane:

1. git **auto-derives** identity from username@hostname by default, so
   a bare `git commit` on a fresh clone *succeeds* silently — the true
   error path only exists with `user.useConfigOnly=true` (git's
   documented opt-out). The app surfaces whatever git does; the test
   exercises the real error path via `useConfigOnly` + isolated config.
2. A live round-trip confirmed `git add -- <dest>` stages renames and
   deletions correctly (probed before parsing was written).

### Gates

`SKIP_EMBED_BORIS=1 make build` ✅ · **327 tests, 0 failures** (6 new:
3 pure -z parse cases incl. rename-destination-first, live status on a
real repo, stage-only-picked live commit, verbatim identity error) ✅ ·
`make lint` 0 violations ✅ · spike ✅.
