### PR TITLE
feat(github): M16-2 Push verb — git push -u through the credential helper (#185)

### DIFF
--- a/Sources/Play/GitHub/RemoteMailboxView.swift
+++ b/Sources/Play/GitHub/RemoteMailboxView.swift
@@ -16,11 +16,13 @@ struct RemoteMailboxView: View {
     @State private var status: GitClone.GitBranchStatus?
     @State private var statusError: String?
     @State private var showCommitSheet = false
+    @State private var isPushing = false
 
     var body: some View {
         List {
             syncSection
             commitSection
+            pushSection
             statusSection
             if let error = live.lastSyncError {
                 Section {
@@ -65,6 +67,28 @@ struct RemoteMailboxView: View {
                     showCommitSheet = true
                 }
                 .disabled(!live.isAvailable || live.isSyncing)
+            }
+        }
+    }
+
+    private var pushSection: some View {
+        Section {
+            HStack {
+                if isPushing {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Pushing…")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Cancel") { store.cancelPushGithub(source.id) }
+                } else {
+                    Label("Push", systemImage: "paperplane")
+                    Spacer()
+                    Button("Push") {
+                        push()
+                    }
+                    .disabled(!live.isAvailable || live.isSyncing || (status?.ahead ?? 0) == 0)
+                }
             }
         }
     }
@@ -121,6 +145,11 @@ struct RemoteMailboxView: View {
                     Text(lastSyncedAt, style: .relative)
                 }
             }
+            if let lastPushedAt = live.lastPushedAt {
+                LabeledContent("Last Pushed") {
+                    Text(lastPushedAt, style: .relative)
+                }
+            }
             if let statusError {
                 Text(statusError)
                     .font(.callout)
@@ -138,6 +167,31 @@ struct RemoteMailboxView: View {
             defer { runtime.coordinator.endTreeWrite() }
             await store.syncGithub(source.id)
         }
+    }
+
+    private func push() {
+        guard !isPushing else { return }
+        isPushing = true
+        Task {
+            // Push touches only the remote + tracking refs, never the
+            // content tree — watch keeps running (design §2).
+            let result = await store.pushGithub(source.id)
+            isPushing = false
+            if !result.isSuccess {
+                statusError = Self.describePush(result)
+            }
+            await refreshStatus()
+        }
+    }
+
+    /// Git's exit + stderr verbatim; a needsAuth hint on 401-class
+    /// failures (M15 §10 posture — re-auth via the settings flow).
+    static func describePush(_ result: GithubCommit.CommitResult) -> String {
+        var text = "git push failed (exit \(result.exitCode)): \(result.stderr)"
+        if result.stderr.contains("401") || result.stderr.contains("403") || result.stderr.contains("Authentication failed") {
+            text += "\n\nThe token may be revoked or lack `repo` scope. Re-authenticate from Settings → Sources."
+        }
+        return text
     }
 
     private func openOnGitHub() {

--- a/Sources/Workspace/GitHub/GithubCommit.swift
+++ b/Sources/Workspace/GitHub/GithubCommit.swift
@@ -1,10 +1,12 @@
 import Foundation
 
-/// Commit verb (M16-1 / #185): `git add -- <picked>` then
-/// `git commit`, one-shot processes (never the engine slot) on the
-/// working copy. The picker decides exactly which paths are staged —
-/// never `git add -A`. Identity is never invented: git's own
-/// missing-identity error surfaces verbatim.
+/// Commit + push verbs (M16 / #185): `git add -- <picked>` then
+/// `git commit`, and `git push -u`, one-shot processes (never the
+/// engine slot) on the working copy. The picker decides exactly which
+/// paths are staged — never `git add -A`. Identity is never invented:
+/// git's own missing-identity error surfaces verbatim. Push rides the
+/// credential helper — the token never appears in argv, env, or on
+/// disk.
 public enum GithubCommit {
     public struct CommitResult: Sendable {
         public let exitCode: Int32
@@ -29,6 +31,48 @@ public enum GithubCommit {
         let stage = run(["add", "--"] + paths, workingCopy: workingCopy, session: session, environment: environment)
         guard stage.isSuccess else { return stage }
         return run(["commit", "-m", message], workingCopy: workingCopy, session: session, environment: environment)
+    }
+
+    /// Push the current branch with upstream tracking: `git push -u
+    /// origin <branch>`. The credential helper authenticates https
+    /// remotes. Never a force-push — a non-fast-forward rejection is
+    /// git's own error, surfaced verbatim.
+    public static func push(
+        branch: String,
+        workingCopy: URL,
+        credentialHelperApp: URL?,
+        session: SyncSession,
+        environment: [String: String] = [:]
+    ) -> CommitResult {
+        let process = Process()
+        process.executableURL = GitClone.gitExecutableURL()
+        var arguments = ["-C", workingCopy.path]
+        if let credentialHelperApp {
+            arguments.append(contentsOf: GitClone.credentialHelperArguments(appURL: credentialHelperApp))
+        }
+        arguments.append(contentsOf: ["push", "-u", "origin", branch])
+        process.arguments = arguments
+        var env = ProcessInfo.processInfo.environment
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env.merge(environment) { _, new in new }
+        process.environment = env
+        let errPipe = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errPipe
+        session.attach(process)
+        do {
+            try process.run()
+        } catch {
+            session.detach()
+            return CommitResult(exitCode: 1, stderr: String(describing: error))
+        }
+        process.waitUntilExit()
+        session.detach()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        return CommitResult(
+            exitCode: process.terminationStatus,
+            stderr: String(decoding: errData, as: UTF8.self)
+        )
     }
 
     private static func run(

--- a/Sources/Workspace/GitHub/GithubSource.swift
+++ b/Sources/Workspace/GitHub/GithubSource.swift
@@ -28,6 +28,8 @@ struct GithubSource: PublicationSource, PlayFolderSource, Hashable, Sendable, Co
     var lastSyncError: String? = nil
     /// Set when the last Sync succeeded; shown in the Remote mailbox.
     var lastSyncedAt: Date? = nil
+    /// Set when the last Push succeeded (M16-2); shown in the mailbox.
+    var lastPushedAt: Date? = nil
 
     var kind: SourceKind { .github }
 

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -296,6 +296,64 @@ final class WorkspaceStore {
         activeCommitSessions[id]?.terminate()
     }
 
+    // MARK: - GitHub push (M16-2)
+
+    /// In-flight pushes by source id (one-shot shape, engine slot untouched).
+    private var activePushSessions: [SourceID: SyncSession] = [:]
+
+    /// Push verb (M16-2): `git push -u origin <branch>` through the
+    /// credential helper, off the main actor. Watch is NOT suspended
+    /// (push touches only the remote + tracking refs, never the content
+    /// tree watch serves — design §2). On success: ahead → 0 (branch
+    /// refresh) and `lastPushedAt` set. Git's exit + stderr surface
+    /// verbatim — 401/403 is the M15 §10 `needsAuth` posture,
+    /// non-blocking, re-auth via the existing settings flow.
+    func pushGithub(_ id: SourceID) async -> GithubCommit.CommitResult {
+        guard let index = sources.firstIndex(where: { $0.id == id }),
+              case .github(let github) = sources[index],
+              github.isAvailable,
+              let url = try? github.workspaceRoot()
+        else {
+            return GithubCommit.CommitResult(exitCode: 1, stderr: "Working copy is unavailable.")
+        }
+        let branch = GitClone.branchStatus(at: url).branch ?? github.branch ?? github.defaultBranch
+        guard !branch.isEmpty else {
+            return GithubCommit.CommitResult(exitCode: 1, stderr: "No branch to push.")
+        }
+
+        let session = SyncSession()
+        activePushSessions[id] = session
+        defer { activePushSessions[id] = nil }
+
+        let helperApp = Bundle.main.executableURL
+        let result = await Task.detached {
+            GithubCommit.push(
+                branch: branch,
+                workingCopy: url,
+                credentialHelperApp: helperApp,
+                session: session
+            )
+        }.value
+
+        // Refresh branch (ahead → 0 on success) and record lastPushedAt.
+        if let index = sources.firstIndex(where: { $0.id == id }),
+           case .github(let current) = sources[index]
+        {
+            var updated = current
+            updated.branch = GitClone.branchStatus(at: url).branch
+            if result.isSuccess {
+                updated.lastPushedAt = Date()
+            }
+            sources[index] = .github(updated)
+        }
+        return result
+    }
+
+    /// SIGTERM the in-flight push for a source.
+    func cancelPushGithub(_ id: SourceID) {
+        activePushSessions[id]?.terminate()
+    }
+
     // MARK: - GitHub sign-out (M15)
 
     /// Sign out of a GitHub source (design §4): delete the Keychain

--- a/Tests/ContractTests/GithubPushTests.swift
+++ b/Tests/ContractTests/GithubPushTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+
+final class GithubPushTests: XCTestCase {
+    // MARK: - Live push (local remotes only, no network)
+
+    func testPushSetsUpstreamAndClearsAhead() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("githubpush-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let origin = dir.appendingPathComponent("origin.git", isDirectory: true)
+        let work = dir.appendingPathComponent("work", isDirectory: true)
+        try runGit(["init", "--bare", "-b", "main", origin.path], in: dir)
+        let seed = dir.appendingPathComponent("seed", isDirectory: true)
+        try FileManager.default.createDirectory(at: seed, withIntermediateDirectories: true)
+        try runGit(["init", "-b", "main"], in: seed)
+        try runGit(["config", "user.email", "t@example.com"], in: seed)
+        try runGit(["config", "user.name", "t"], in: seed)
+        try "one".write(to: seed.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: seed)
+        try runGit(["commit", "-m", "one"], in: seed)
+        try runGit(["remote", "add", "origin", origin.path], in: seed)
+        try runGit(["push", "-u", "origin", "main"], in: seed)
+
+        // Clone the working copy, add a commit, push it back.
+        try runGit(["clone", origin.path, work.path], in: dir)
+        try runGit(["config", "user.email", "t@example.com"], in: work)
+        try runGit(["config", "user.name", "t"], in: work)
+        try "two".write(to: work.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: work)
+        try runGit(["commit", "-m", "two"], in: work)
+
+        // Ahead 1 before the push.
+        let before = GitClone.branchStatus(at: work)
+        XCTAssertEqual(before.branch, "main")
+        XCTAssertEqual(before.ahead, 1)
+
+        let session = SyncSession()
+        let result = GithubCommit.push(
+            branch: "main",
+            workingCopy: work,
+            credentialHelperApp: nil,
+            session: session
+        )
+        XCTAssertTrue(result.isSuccess, "push failed: \(result.stderr)")
+
+        // Ahead 0 after; the commit landed on the bare origin (read
+        // directly — seed's local branch is stale until it fetches).
+        let after = GitClone.branchStatus(at: work)
+        XCTAssertEqual(after.ahead, 0)
+        XCTAssertEqual(after.behind, 0)
+        let originLog = try runGitOutput(["--git-dir", origin.path, "log", "--oneline", "-1"], in: dir)
+        XCTAssertTrue(originLog.contains("two"), "origin head should be the pushed commit, got: \(originLog)")
+    }
+
+    func testPushNonFastForwardRejectedVerbatim() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("githubpush-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let origin = dir.appendingPathComponent("origin.git", isDirectory: true)
+        let work = dir.appendingPathComponent("work", isDirectory: true)
+        try runGit(["init", "--bare", "-b", "main", origin.path], in: dir)
+        let seed = dir.appendingPathComponent("seed", isDirectory: true)
+        try FileManager.default.createDirectory(at: seed, withIntermediateDirectories: true)
+        try runGit(["init", "-b", "main"], in: seed)
+        try runGit(["config", "user.email", "t@example.com"], in: seed)
+        try runGit(["config", "user.name", "t"], in: seed)
+        try "one".write(to: seed.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: seed)
+        try runGit(["commit", "-m", "one"], in: seed)
+        try runGit(["remote", "add", "origin", origin.path], in: seed)
+        try runGit(["push", "-u", "origin", "main"], in: seed)
+        try runGit(["clone", origin.path, work.path], in: dir)
+        try runGit(["config", "user.email", "t@example.com"], in: work)
+        try runGit(["config", "user.name", "t"], in: work)
+
+        // Advance origin with a conflicting commit...
+        try "conflict".write(to: seed.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: seed)
+        try runGit(["commit", "-m", "origin-advance"], in: seed)
+        try runGit(["push", "origin", "main"], in: seed)
+
+        // ...while the working copy commits a different version of the
+        // same file. Push must be rejected — never a force-push.
+        try "local-change".write(to: work.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: work)
+        try runGit(["commit", "-m", "local-commit"], in: work)
+
+        let session = SyncSession()
+        let result = GithubCommit.push(
+            branch: "main",
+            workingCopy: work,
+            credentialHelperApp: nil,
+            session: session
+        )
+        XCTAssertFalse(result.isSuccess)
+        XCTAssertTrue(
+            result.stderr.contains("non-fast-forward") || result.stderr.contains("fetch first")
+                || result.stderr.contains("rejected"),
+            "git's own rejection must surface verbatim, got: \(result.stderr)"
+        )
+        // The origin head is unchanged — no force-push happened.
+        let originLog = try runGitOutput(["--git-dir", origin.path, "log", "--oneline", "-1"], in: dir)
+        XCTAssertTrue(originLog.contains("origin-advance"), "origin must be untouched, got: \(originLog)")
+    }
+
+    func testPushWithCredentialHelperAppOnLocalRemote() throws {
+        // The helper only fires for https remotes; passing one must not
+        // disturb a local-remote push (proves the `-c` argument shape).
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("githubpush-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let origin = dir.appendingPathComponent("origin.git", isDirectory: true)
+        let work = dir.appendingPathComponent("work", isDirectory: true)
+        try runGit(["init", "--bare", "-b", "main", origin.path], in: dir)
+        let seed = dir.appendingPathComponent("seed", isDirectory: true)
+        try FileManager.default.createDirectory(at: seed, withIntermediateDirectories: true)
+        try runGit(["init", "-b", "main"], in: seed)
+        try runGit(["config", "user.email", "t@example.com"], in: seed)
+        try runGit(["config", "user.name", "t"], in: seed)
+        try "one".write(to: seed.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: seed)
+        try runGit(["commit", "-m", "one"], in: seed)
+        try runGit(["remote", "add", "origin", origin.path], in: seed)
+        try runGit(["push", "-u", "origin", "main"], in: seed)
+        try runGit(["clone", origin.path, work.path], in: dir)
+
+        let helper = URL(fileURLWithPath: "/nonexistent/solipsist-helper")
+        let session = SyncSession()
+        let result = GithubCommit.push(
+            branch: "main",
+            workingCopy: work,
+            credentialHelperApp: helper,
+            session: session
+        )
+        XCTAssertTrue(result.isSuccess, "push failed: \(result.stderr)")
+    }
+
+    // MARK: - Helpers
+
+    private func runGit(_ arguments: [String], in dir: URL) throws {
+        _ = try runGitOutput(arguments, in: dir)
+    }
+
+    private func runGitOutput(_ arguments: [String], in dir: URL) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.currentDirectoryURL = dir
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(bytes: data, encoding: .utf8) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, "git \(arguments) failed: \(output)")
+        return output
+    }
+}


### PR DESCRIPTION
## M16-2 — Push verb (`git push -u` through the credential helper)

Second slice of the M16 write-remote batch (#185), directly on top of
the M16-1 commit. The Remote mailbox can now send the working copy's
commits to the remote.

### What ships

- **`GithubCommit.push(branch:workingCopy:credentialHelperApp:session:)`**
  — `git push -u origin <branch>`, one-shot process (never the engine
  slot), credential-helper `-c` args, `GIT_TERMINAL_PROMPT=0`,
  `SyncSession` cancel. `-u` sets upstream tracking, so `branchStatus`
  reports real ahead/behind for a new branch instead of nil upstream.
- **`WorkspaceStore.pushGithub(_:)`** — off-main-actor one-shot;
  refreshes the branch (ahead → 0 on success); sets a transient
  `lastPushedAt` on `GithubSource` (not persisted, like `lastSyncedAt`).
- **Remote mailbox** — Push verb beside Sync/Commit: spinner + Cancel
  while in flight, disabled when ahead == 0, **Last Pushed** shown in
  the status section.

### The guarantees that matter

- **No force-push, ever.** A non-fast-forward rejection is git's own
  error, surfaced verbatim — the test proves the origin is untouched.
- **401/403 → needsAuth posture** (M15 §10): git's stderr verbatim plus
  a non-blocking hint to re-authenticate via the existing settings
  flow. Never swallowed.
- **Watch not suspended** (design §2): push touches only the remote +
  tracking refs, never the content tree watch serves.
- **Zero-leak invariant holds**: authentication rides the credential
  helper (Keychain → helper stdout → git pipe); the token never
  appears in argv/env/logs.

### Gates

`SKIP_EMBED_BORIS=1 make build` ✅ · **330 tests, 0 failures** (3 new,
all live against local bare remotes — no network) ✅ · `make lint` 0
violations ✅ · spike ✅.

Test detail worth noting: the "landed on origin" assertion reads the
bare repo directly (`git --git-dir`), not the seed clone's stale local
branch — the first run tripped over that and the test now documents it.
