### PR TITLE
feat(github): M16-3 PR authoring — bearer JSON POST + createPullRequest (#185)

### DIFF
--- a/Sources/Play/GitHub/RemoteMailboxView.swift
+++ b/Sources/Play/GitHub/RemoteMailboxView.swift
@@ -16,6 +16,7 @@ struct RemoteMailboxView: View {
     @State private var status: GitClone.GitBranchStatus?
     @State private var statusError: String?
     @State private var showCommitSheet = false
+    @State private var showPRSheet = false
     @State private var isPushing = false
 
     var body: some View {
@@ -23,6 +24,7 @@ struct RemoteMailboxView: View {
             syncSection
             commitSection
             pushSection
+            prSection
             statusSection
             if let error = live.lastSyncError {
                 Section {
@@ -53,6 +55,11 @@ struct RemoteMailboxView: View {
         }
         .sheet(isPresented: $showCommitSheet) {
             CommitSheet(source: source) {
+                Task { await refreshStatus() }
+            }
+        }
+        .sheet(isPresented: $showPRSheet) {
+            PullRequestSheet(source: source) {
                 Task { await refreshStatus() }
             }
         }
@@ -89,6 +96,19 @@ struct RemoteMailboxView: View {
                     }
                     .disabled(!live.isAvailable || live.isSyncing || (status?.ahead ?? 0) == 0)
                 }
+            }
+        }
+    }
+
+    private var prSection: some View {
+        Section {
+            HStack {
+                Label("Pull Request", systemImage: "arrow.triangle.branch")
+                Spacer()
+                Button("New Pull Request…") {
+                    showPRSheet = true
+                }
+                .disabled(!live.isAvailable || live.isSyncing || status?.branch == nil)
             }
         }
     }
@@ -148,6 +168,12 @@ struct RemoteMailboxView: View {
             if let lastPushedAt = live.lastPushedAt {
                 LabeledContent("Last Pushed") {
                     Text(lastPushedAt, style: .relative)
+                }
+            }
+            if let branch = status?.branch, let upstream = status?.upstream {
+                LabeledContent("Upstream") {
+                    Text(upstream)
+                        .monospaced()
                 }
             }
             if let statusError {
@@ -348,5 +374,166 @@ private struct CommitSheet: View {
             text += "\n\nSet user.name and user.email for this repository (git config user.name \"…\"; git config user.email …) — Solipsist never invents an identity."
         }
         return text
+    }
+}
+
+/// New Pull Request sheet (M16-3 / #185): title + body over the
+/// current branch, base defaulting to the source's `defaultBranch`
+/// (from the remote, never guessed). When the branch has no upstream
+/// it is pushed first (`-u`, M16-2's one-shot) so the PR has a branch
+/// to point at; then `POST /repos/{owner}/{repo}/pulls` with the
+/// Keychain bearer. Success opens the PR in the browser.
+private struct PullRequestSheet: View {
+    let source: GithubSource
+    /// Runs after a successful PR (branchStatus refresh).
+    let onCreated: () -> Void
+
+    @Environment(WorkspaceStore.self) private var store
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var title = ""
+    @State private var bodyText = ""
+    @State private var base = ""
+    @State private var isWorking = false
+    @State private var errorText: String?
+    @State private var branch: String?
+    @State private var hasUpstream = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("New Pull Request")
+                .font(.headline)
+
+            if let errorText {
+                Text(errorText)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+            }
+
+            LabeledContent("Branch") {
+                Text(branch ?? "—")
+                    .monospaced()
+            }
+            LabeledContent("Base") {
+                TextField("base branch", text: $base)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 180)
+            }
+
+            TextField("Title", text: $title, axis: .vertical)
+                .lineLimit(1...2)
+                .textFieldStyle(.roundedBorder)
+            TextField("Body", text: $bodyText, axis: .vertical)
+                .lineLimit(4...8)
+                .textFieldStyle(.roundedBorder)
+
+            HStack {
+                if isWorking {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(hasUpstream ? "Creating…" : "Pushing branch, then creating…")
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button(hasUpstream ? "Create Pull Request" : "Push & Create Pull Request") {
+                    create()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(
+                    isWorking
+                        || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || branch == nil
+                        || base.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
+            }
+        }
+        .padding(20)
+        .frame(width: 480, height: 340)
+        .task {
+            await load()
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        guard let root = try? source.workspaceRoot() else {
+            errorText = "Working copy is unavailable."
+            return
+        }
+        let result = await Task.detached {
+            GitClone.branchStatus(at: root)
+        }.value
+        branch = result.branch
+        hasUpstream = result.upstream != nil
+        // Base = the source's defaultBranch (from the remote, never
+        // guessed); the user may override it.
+        base = source.defaultBranch
+    }
+
+    private func create() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBase = base.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let branch, !trimmedTitle.isEmpty, !trimmedBase.isEmpty, !isWorking else { return }
+        isWorking = true
+        errorText = nil
+        Task {
+            // Push the branch first when it has no upstream — the PR
+            // needs a remote branch to point at. Reuses the M16-2
+            // one-shot; auth rides the credential helper.
+            if !hasUpstream {
+                let pushResult = await store.pushGithub(source.id)
+                guard pushResult.isSuccess else {
+                    isWorking = false
+                    errorText = RemoteMailboxView.describePush(pushResult)
+                    return
+                }
+            }
+
+            // Load the token from the Keychain (zero-leak: SecureBuffer,
+            // never argv/env/logs) and create the PR over the transport.
+            let tokenStore = GithubTokenStore()
+            let transport = URLSessionGithubTransport()
+            do {
+                guard let token = try tokenStore.load() else {
+                    throw GithubOAuthError.httpStatus(401, message: "No GitHub token in the Keychain. Re-authenticate from Settings → Sources.")
+                }
+                defer { token.wipe() }
+                let created = try await GithubAPIClient.createPullRequest(
+                    owner: source.owner,
+                    repository: source.repository,
+                    title: trimmedTitle,
+                    body: bodyText,
+                    head: branch,
+                    base: trimmedBase,
+                    bearer: token,
+                    transport: transport
+                )
+                isWorking = false
+                onCreated()
+                dismiss()
+                if let url = URL(string: created.htmlURL) {
+                    NSWorkspace.shared.open(url)
+                }
+            } catch {
+                isWorking = false
+                errorText = Self.describe(error)
+            }
+        }
+    }
+
+    static func describe(_ error: Error) -> String {
+        if let github = error as? GithubOAuthError {
+            switch github {
+            case let .httpStatus(status, message):
+                return "GitHub returned \(status): \(message)"
+            case .invalidResponse:
+                return "GitHub returned an unexpected response."
+            case let .deviceCodeFailed(code, message):
+                return "\(code): \(message)"
+            }
+        }
+        return String(describing: error)
     }
 }

--- a/Sources/Workspace/Git/GitClone.swift
+++ b/Sources/Workspace/Git/GitClone.swift
@@ -155,7 +155,7 @@ public enum GitClone {
     /// status with a nil branch — never an error.
     public static func branchStatus(at root: URL) -> GitBranchStatus {
         guard FileManager.default.fileExists(atPath: root.appendingPathComponent(".git").path) else {
-            return GitBranchStatus(branch: nil, ahead: 0, behind: 0)
+            return GitBranchStatus(branch: nil, upstream: nil, ahead: 0, behind: 0)
         }
         let process = Process()
         process.executableURL = gitExecutableURL()
@@ -167,14 +167,15 @@ public enum GitClone {
             try process.run()
             process.waitUntilExit()
         } catch {
-            return GitBranchStatus(branch: nil, ahead: 0, behind: 0)
+            return GitBranchStatus(branch: nil, upstream: nil, ahead: 0, behind: 0)
         }
         guard process.terminationStatus == 0 else {
-            return GitBranchStatus(branch: nil, ahead: 0, behind: 0)
+            return GitBranchStatus(branch: nil, upstream: nil, ahead: 0, behind: 0)
         }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let text = String(decoding: data, as: UTF8.self)
         var branch: String?
+        var upstream: String?
         var ahead = 0
         var behind = 0
         for line in text.split(separator: "\n") {
@@ -182,17 +183,33 @@ public enum GitClone {
             if let parsed = parseBranch(from: line) {
                 branch = parsed
             }
+            if let up = parseUpstream(from: line) {
+                upstream = up
+            }
             if let ab = parseAheadBehind(from: line) {
                 ahead = ab.ahead
                 behind = ab.behind
             }
         }
-        return GitBranchStatus(branch: branch, ahead: ahead, behind: behind)
+        return GitBranchStatus(branch: branch, upstream: upstream, ahead: ahead, behind: behind)
+    }
+
+    /// Parse the upstream out of one porcelain v2 line: `# branch.upstream
+    /// origin/main` → `origin/main`. Anything else returns nil.
+    public static func parseUpstream(from line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("# branch.upstream ") else { return nil }
+        let name = trimmed.dropFirst("# branch.upstream ".count)
+        return name.isEmpty ? nil : String(name)
     }
 
     /// Branch + ahead/behind parsed from `status --porcelain=v2 --branch`.
+    /// `upstream` is `origin/<branch>` when tracking is set (from
+    /// `# branch.upstream`), nil otherwise — the PR sheet (M16-3) uses
+    /// its absence to know a `-u` push is required first.
     public struct GitBranchStatus: Sendable, Equatable {
         public let branch: String?
+        public let upstream: String?
         public let ahead: Int
         public let behind: Int
     }

--- a/Sources/Workspace/GitHub/GithubAPIClient.swift
+++ b/Sources/Workspace/GitHub/GithubAPIClient.swift
@@ -22,15 +22,32 @@ struct GithubRepositoryInfo: Decodable, Equatable, Sendable {
     }
 }
 
-/// Minimal GitHub REST surface (M15 / #179): identity + repo default
-/// branch. Boris has no GitHub API — the app owns this. Tokens ride as
-/// `SecureBuffer`; the transport builds the Authorization header. Error
-/// bodies surface as `GithubOAuthError.httpStatus`, never swallowed.
+/// A created pull request (M16-3 / #185): the number + html URL the
+/// sheet opens in the browser.
+struct GithubPullRequestCreated: Decodable, Equatable, Sendable {
+    let number: Int
+    let htmlURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case number
+        case htmlURL = "html_url"
+    }
+}
+
+/// Minimal GitHub REST surface (M15 / #179, M16 / #185): identity,
+/// repo default branch, PR creation. Boris has no GitHub API — the app
+/// owns this. Tokens ride as `SecureBuffer`; the transport builds the
+/// Authorization header. Error bodies surface as
+/// `GithubOAuthError.httpStatus`, never swallowed.
 enum GithubAPIClient {
     static let userURL = URL(string: "https://api.github.com/user")!
 
     static func repositoryURL(owner: String, repository: String) -> URL {
         URL(string: "https://api.github.com/repos/\(owner)/\(repository)")!
+    }
+
+    static func pullsURL(owner: String, repository: String) -> URL {
+        URL(string: "https://api.github.com/repos/\(owner)/\(repository)/pulls")!
     }
 
     static func user(bearer: SecureBuffer, transport: GithubOAuth.HTTPTransport) async throws -> GithubUser {
@@ -49,6 +66,39 @@ enum GithubAPIClient {
             bearer: bearer
         )
         return try decode(GithubRepositoryInfo.self, from: data)
+    }
+
+    /// Create a pull request: `POST /repos/{owner}/{repo}/pulls` with
+    /// the Keychain bearer. `head` is the source branch, `base` the
+    /// target (defaults to `defaultBranch` in the sheet). The response
+    /// carries `number` + `html_url`. Non-2xx bodies surface as
+    /// `httpStatus(status, message)` — never swallowed (D11).
+    static func createPullRequest(
+        owner: String,
+        repository: String,
+        title: String,
+        body: String,
+        head: String,
+        base: String,
+        bearer: SecureBuffer,
+        transport: GithubOAuth.HTTPTransport
+    ) async throws -> GithubPullRequestCreated {
+        let payload: [String: String] = [
+            "title": title,
+            "body": body,
+            "head": head,
+            "base": base,
+        ]
+        let data = try await transport.post(
+            pullsURL(owner: owner, repository: repository),
+            json: jsonBody(payload),
+            bearer: bearer
+        )
+        return try decode(GithubPullRequestCreated.self, from: data)
+    }
+
+    private static func jsonBody(_ object: [String: String]) -> Data {
+        (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
     }
 
     private static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {

--- a/Sources/Workspace/GitHub/GithubOAuth.swift
+++ b/Sources/Workspace/GitHub/GithubOAuth.swift
@@ -43,12 +43,17 @@ enum GithubOAuth {
         case failed(code: String, message: String)
     }
 
-    /// Form-encoded POST + bearer GET transport. Tests inject a stub;
-    /// CI never touches GitHub. The bearer token stays in a
-    /// `SecureBuffer` — the transport builds the header from its bytes.
+    /// Form-encoded POST + bearer GET + bearer JSON POST transport.
+    /// Tests inject a stub; CI never touches GitHub. The bearer token
+    /// stays in a `SecureBuffer` — the transport builds the header from
+    /// its bytes and never logs it.
     protocol HTTPTransport: Sendable {
         func post(_ url: URL, form: [String: String]) async throws -> Data
         func get(_ url: URL, bearer: SecureBuffer) async throws -> Data
+        /// JSON body + bearer Authorization (M16-3 / #185): PR and
+        /// issue creation. Same error contract as `get` — non-2xx
+        /// surfaces `httpStatus(status, message)`, never swallowed.
+        func post(_ url: URL, json: Data, bearer: SecureBuffer) async throws -> Data
     }
 
     /// Clock seam: the poller sleeps and computes expiry through this,
@@ -225,6 +230,21 @@ struct URLSessionGithubTransport: GithubOAuth.HTTPTransport {
         var request = URLRequest(url: url)
         request.setValue(Self.bearerHeader(bearer), forHTTPHeaderField: "Authorization")
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw GithubOAuthError.httpStatus(status, message: Self.errorMessage(from: data))
+        }
+        return data
+    }
+
+    func post(_ url: URL, json: Data, bearer: SecureBuffer) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(Self.bearerHeader(bearer), forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = json
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1

--- a/Tests/ContractTests/GitCloneTests.swift
+++ b/Tests/ContractTests/GitCloneTests.swift
@@ -66,8 +66,43 @@ final class GitCloneTests: XCTestCase {
     func testBranchStatusParsesAheadBehind() {
         let status = GitClone.branchStatus(at: URL(fileURLWithPath: "/nonexistent/repo"))
         XCTAssertNil(status.branch)
+        XCTAssertNil(status.upstream)
         XCTAssertEqual(status.ahead, 0)
         XCTAssertEqual(status.behind, 0)
+    }
+
+    func testParseUpstreamPorcelainV2() {
+        XCTAssertEqual(GitClone.parseUpstream(from: "# branch.upstream origin/main"), "origin/main")
+        XCTAssertEqual(GitClone.parseUpstream(from: "# branch.upstream origin/feature/x"), "origin/feature/x")
+        XCTAssertNil(GitClone.parseUpstream(from: "# branch.head main"))
+        XCTAssertNil(GitClone.parseUpstream(from: "# branch.ab +0 -0"))
+        XCTAssertNil(GitClone.parseUpstream(from: "1 .M N..."))
+    }
+
+    func testBranchStatusUpstreamNilWithoutTracking() throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/git") else {
+            throw XCTSkip("git not available")
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gitclone-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try runGit(["init", "-b", "main"], in: dir)
+        try "hello".write(to: dir.appendingPathComponent("readme.md"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], in: dir)
+        try runGit([
+            "-c", "user.email=t@example.com",
+            "-c", "user.name=t",
+            "commit", "-m", "init",
+        ], in: dir)
+        // No remote → no upstream.
+        XCTAssertNil(GitClone.branchStatus(at: dir).upstream)
+        // After -u push to a local bare remote, upstream is set.
+        let bare = dir.appendingPathComponent("origin.git", isDirectory: true)
+        try runGit(["init", "--bare", "-b", "main", bare.path], in: dir)
+        try runGit(["remote", "add", "origin", bare.path], in: dir)
+        try runGit(["push", "-u", "origin", "main"], in: dir)
+        XCTAssertEqual(GitClone.branchStatus(at: dir).upstream, "origin/main")
     }
 
     // MARK: - Live branch read (local repo only, no network)

--- a/Tests/ContractTests/GithubAPIClientTests.swift
+++ b/Tests/ContractTests/GithubAPIClientTests.swift
@@ -121,6 +121,112 @@ final class GithubAPIClientTests: XCTestCase {
         let call = try XCTUnwrap(recorded.first)
         XCTAssertEqual(call.url, GithubAPIClient.userURL)
         XCTAssertNil(call.form)
+        XCTAssertNil(call.json)
         XCTAssertEqual(call.bearerBytes, Array("gho_secret".utf8))
+    }
+
+    // MARK: - PR creation (M16-3)
+
+    func testCreatePullRequestDecode() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["number": 42, "html_url": "https://github.com/acme/blog/pull/42"]),
+            for: GithubAPIClient.pullsURL(owner: "acme", repository: "blog")
+        )
+
+        let created = try await GithubAPIClient.createPullRequest(
+            owner: "acme",
+            repository: "blog",
+            title: "Add a page",
+            body: "Body",
+            head: "feature/x",
+            base: "main",
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        XCTAssertEqual(created.number, 42)
+        XCTAssertEqual(created.htmlURL, "https://github.com/acme/blog/pull/42")
+    }
+
+    func testCreatePullRequestJsonAndBearerRideThePost() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["number": 7, "html_url": "https://github.com/acme/blog/pull/7"]),
+            for: GithubAPIClient.pullsURL(owner: "acme", repository: "blog")
+        )
+
+        _ = try await GithubAPIClient.createPullRequest(
+            owner: "acme",
+            repository: "blog",
+            title: "T",
+            body: "B",
+            head: "h",
+            base: "b",
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        let recorded = await transport.recorded
+        let call = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(call.url, GithubAPIClient.pullsURL(owner: "acme", repository: "blog"))
+        XCTAssertNil(call.form)
+        XCTAssertEqual(call.bearerBytes, Array("gho_secret".utf8))
+        let json = try XCTUnwrap(call.json)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: json) as? [String: String])
+        XCTAssertEqual(object["title"], "T")
+        XCTAssertEqual(object["body"], "B")
+        XCTAssertEqual(object["head"], "h")
+        XCTAssertEqual(object["base"], "b")
+    }
+
+    func testCreatePullRequestErrorSurfacesMessage() async {
+        let transport = StubTransport()
+        await transport.enqueue(
+            error: GithubOAuthError.httpStatus(422, message: "Validation Failed"),
+            for: GithubAPIClient.pullsURL(owner: "acme", repository: "blog")
+        )
+
+        do {
+            _ = try await GithubAPIClient.createPullRequest(
+                owner: "acme",
+                repository: "blog",
+                title: "T",
+                body: "B",
+                head: "h",
+                base: "b",
+                bearer: SecureBuffer(utf8String: "gho_secret"),
+                transport: transport
+            )
+            XCTFail("expected httpStatus")
+        } catch let GithubOAuthError.httpStatus(status, message) {
+            XCTAssertEqual(status, 422)
+            XCTAssertEqual(message, "Validation Failed")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testCreatePullRequestMalformedBodyIsInvalidResponse() async {
+        let transport = StubTransport()
+        await transport.enqueue(json(["unexpected": true]), for: GithubAPIClient.pullsURL(owner: "acme", repository: "blog"))
+
+        do {
+            _ = try await GithubAPIClient.createPullRequest(
+                owner: "acme",
+                repository: "blog",
+                title: "T",
+                body: "B",
+                head: "h",
+                base: "b",
+                bearer: SecureBuffer(utf8String: "gho_secret"),
+                transport: transport
+            )
+            XCTFail("expected invalidResponse")
+        } catch GithubOAuthError.invalidResponse {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
     }
 }

--- a/Tests/ContractTests/GithubTestSupport.swift
+++ b/Tests/ContractTests/GithubTestSupport.swift
@@ -12,9 +12,11 @@ func json(_ object: [String: Any]) -> Data {
 actor StubTransport: GithubOAuth.HTTPTransport {
     struct RecordedCall: Equatable, Sendable {
         let url: URL
-        /// Form body for POSTs; nil for GETs.
+        /// Form body for form-POSTs; nil for GETs / JSON POSTs.
         let form: [String: String]?
-        /// Bearer token bytes for GETs; nil for POSTs.
+        /// JSON body for JSON POSTs; nil otherwise.
+        let json: Data?
+        /// Bearer token bytes for authenticated calls; nil for form-POSTs.
         let bearerBytes: [UInt8]?
     }
 
@@ -42,19 +44,24 @@ actor StubTransport: GithubOAuth.HTTPTransport {
     }
 
     func post(_ url: URL, form: [String: String]) async throws -> Data {
-        try await respond(to: url, form: form, bearerBytes: nil)
+        try await respond(to: url, form: form, json: nil, bearerBytes: nil)
     }
 
     func get(_ url: URL, bearer: SecureBuffer) async throws -> Data {
-        try await respond(to: url, form: nil, bearerBytes: bearer.copyBytes())
+        try await respond(to: url, form: nil, json: nil, bearerBytes: bearer.copyBytes())
+    }
+
+    func post(_ url: URL, json: Data, bearer: SecureBuffer) async throws -> Data {
+        try await respond(to: url, form: nil, json: json, bearerBytes: bearer.copyBytes())
     }
 
     private func respond(
         to url: URL,
         form: [String: String]?,
+        json: Data?,
         bearerBytes: [UInt8]?
     ) async throws -> Data {
-        calls.append(RecordedCall(url: url, form: form, bearerBytes: bearerBytes))
+        calls.append(RecordedCall(url: url, form: form, json: json, bearerBytes: bearerBytes))
         var queue = queues[url] ?? []
         let next = queue.isEmpty ? nil : queue.removeFirst()
         queues[url] = queue


### PR DESCRIPTION
## M16-3 — PR authoring (`POST /repos/{owner}/{repo}/pulls`)

Third slice of the M16 write-remote batch (#185), on top of commit
(M16-1) and push (M16-2). The Remote mailbox can now open a pull
request for the current branch.

### What ships

- **Transport seam** — `GithubOAuth.HTTPTransport` gains
  `post(_ url: URL, json: Data, bearer: SecureBuffer)`: URLSession
  impl clones `get` (Authorization + `application/vnd.github+json`,
  JSON Content-Type); `StubTransport` records the JSON body so tests
  assert exactly what rides the wire. The token's only stop outside
  the `SecureBuffer` is the transient Authorization header — zero-leak
  invariant holds.
- **`GithubAPIClient.createPullRequest(owner:repository:title:body:
  head:base:bearer:transport:)`** — POSTs `/repos/{owner}/{repo}/pulls`,
  decodes `number` + `html_url`; non-2xx bodies surface as
  `httpStatus(status, message)` (D11).
- **`GitClone.branchStatus` gains `upstream`** — parses
  `# branch.upstream origin/main` from the v2 porcelain the function
  already ran, so the sheet knows when a `-u` push is required first.
- **New Pull Request sheet** (`PullRequestSheet` in
  `RemoteMailboxView`) — title + body, base defaulting to the
  source's `defaultBranch` (from the remote, never guessed; the user
  may override). When the branch has no upstream it is pushed first
  (`-u`, the M16-2 one-shot), then the PR is created and **opens in
  the browser**. The mailbox also shows **Upstream** in its status
  section.

### Guarantees

- No repo/branch-list fetches without the user's pick; no merge or
  review endpoints; no force-push (push-first is the plain M16-2
  verb).
- 401/403 → the M15 §10 needsAuth posture, message surfaced verbatim.
- Watch not suspended (design §2) — PR authoring is API + push, never
  a content-tree write.

### Gates

`SKIP_EMBED_BORIS=1 make build` ✅ · **336 tests, 0 failures** (6 new:
create-PR decode, JSON+bearer ride the POST, 422 surfaced, malformed
body → invalidResponse, upstream porcelain parse, upstream
nil→origin/main live round trip) ✅ · `make lint` 0 violations ✅ ·
spike ✅.
