### PR TITLE
feat(github): M16-4 issues mailbox (#185)

### DIFF
--- a/Sources/Play/GitHub/IssuesMailboxView.swift
+++ b/Sources/Play/GitHub/IssuesMailboxView.swift
@@ -1,0 +1,290 @@
+import AppKit
+import SwiftUI
+
+/// Issues mailbox (M16-4 / #185): the repo's open issues over the
+/// Keychain bearer, rows opening in the browser, and a create-issue
+/// sheet. GitHub-only — Local sources never see the row (the token is
+/// in `WorkspaceMailbox.all(for:)`'s github branch only).
+///
+/// PRs stay out: REST mixes pull requests into `/issues`; `listIssues`
+/// filters them (`pull_request == nil`) before this view ever sees them.
+struct IssuesMailboxView: View {
+    let source: GithubSource
+
+    @State private var issues: [GithubIssue] = []
+    @State private var isLoading = false
+    @State private var errorText: String?
+    @State private var showCreateSheet = false
+
+    var body: some View {
+        Group {
+            if isLoading, issues.isEmpty {
+                ProgressView("Loading issues…")
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorText, issues.isEmpty {
+                ContentUnavailableView {
+                    Label("Issues Unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorText)
+                } actions: {
+                    Button("Try Again") { reload() }
+                }
+            } else if issues.isEmpty {
+                ContentUnavailableView {
+                    Label("No Open Issues", systemImage: "exclamationmark.circle")
+                } description: {
+                    Text("This repository has no open issues.")
+                }
+                .accessibilityLabel("No Open Issues")
+            } else {
+                List(issues, id: \.number) { issue in
+                    IssueRow(issue: issue) {
+                        open(issue)
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .navigationTitle(source.title)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showCreateSheet = true
+                } label: {
+                    Label("New Issue…", systemImage: "square.and.pencil")
+                }
+                .help("Create an issue on \\(source.owner)/\\(source.repository)")
+                .disabled(isLoading)
+            }
+        }
+        .sheet(isPresented: $showCreateSheet) {
+            CreateIssueSheet(source: source) {
+                Task { await load() }
+            }
+        }
+        .task(id: source.id) {
+            await load()
+        }
+    }
+
+    private func reload() {
+        Task { await load() }
+    }
+
+    @MainActor
+    private func load() async {
+        isLoading = true
+        errorText = nil
+        defer { isLoading = false }
+
+        let tokenStore = GithubTokenStore()
+        let transport = URLSessionGithubTransport()
+        do {
+            guard let token = try tokenStore.load() else {
+                // The M15 §10 needsAuth posture: non-blocking, re-auth
+                // via the existing settings flow. Never a silent retry.
+                errorText = "No GitHub token in the Keychain. Re-authenticate from Settings → Sources."
+                return
+            }
+            defer { token.wipe() }
+            let fetched = try await GithubAPIClient.listIssues(
+                owner: source.owner,
+                repository: source.repository,
+                bearer: token,
+                transport: transport
+            )
+            guard !Task.isCancelled else { return }
+            issues = fetched
+        } catch {
+            guard !Task.isCancelled else { return }
+            errorText = Self.describe(error)
+        }
+    }
+
+    private func open(_ issue: GithubIssue) {
+        if let url = URL(string: issue.htmlURL) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    /// Error bodies verbatim (D11) with the needsAuth hint on 401-class
+    /// failures — the same posture the Remote mailbox uses.
+    static func describe(_ error: Error) -> String {
+        if let github = error as? GithubOAuthError {
+            switch github {
+            case let .httpStatus(status, message):
+                var text = "GitHub returned \\(status): \\(message)"
+                if status == 401 || status == 403 {
+                    text += "\n\nThe token may be revoked or lack `issues` scope. Re-authenticate from Settings → Sources."
+                }
+                return text
+            case .invalidResponse:
+                return "GitHub returned an unexpected response."
+            case let .deviceCodeFailed(code, message):
+                return "\\(code): \\(message)"
+            }
+        }
+        return String(describing: error)
+    }
+}
+
+/// One issue row: number, title, labels; click opens the issue in the
+/// browser (the design's "rows → Open on GitHub").
+private struct IssueRow: View {
+    let issue: GithubIssue
+    let onOpen: () -> Void
+
+    var body: some View {
+        Button(action: onOpen) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("#\\(issue.number)")
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 56, alignment: .trailing)
+                Text(issue.title)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                ForEach(issue.labels, id: \.name) { label in
+                    IssueLabelChip(label: label)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(issue.htmlURL)
+    }
+}
+
+/// A label chip colored from GitHub's hex (no `#` prefix as sent).
+private struct IssueLabelChip: View {
+    let label: GithubIssue.Label
+
+    var body: some View {
+        Text(label.name)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(backgroundColor)
+            .foregroundStyle(foregroundColor)
+            .clipShape(Capsule())
+            .lineLimit(1)
+    }
+
+    private var backgroundColor: Color {
+        Color(nsColor: NSColor(hex: label.color))
+    }
+
+    private var foregroundColor: Color {
+        // GitHub's hex is mid-tone; white text reads on most labels.
+        .white
+    }
+}
+
+/// Create-issue sheet: title + body over the JSON-post seam, then the
+/// mailbox refreshes so the row appears.
+private struct CreateIssueSheet: View {
+    let source: GithubSource
+    /// Runs after a successful create (mailbox refresh).
+    let onCreated: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var title = ""
+    @State private var bodyText = ""
+    @State private var isWorking = false
+    @State private var errorText: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("New Issue")
+                .font(.headline)
+
+            if let errorText {
+                Text(errorText)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+            }
+
+            TextField("Title", text: $title, axis: .vertical)
+                .lineLimit(1...2)
+                .textFieldStyle(.roundedBorder)
+            TextField("Body", text: $bodyText, axis: .vertical)
+                .lineLimit(4...8)
+                .textFieldStyle(.roundedBorder)
+
+            HStack {
+                if isWorking {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Creating…")
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Create Issue") { create() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(
+                        isWorking
+                            || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    )
+            }
+        }
+        .padding(20)
+        .frame(width: 460, height: 300)
+    }
+
+    private func create() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty, !isWorking else { return }
+        isWorking = true
+        errorText = nil
+        Task {
+            let tokenStore = GithubTokenStore()
+            let transport = URLSessionGithubTransport()
+            do {
+                guard let token = try tokenStore.load() else {
+                    throw GithubOAuthError.httpStatus(401, message: "No GitHub token in the Keychain. Re-authenticate from Settings → Sources.")
+                }
+                defer { token.wipe() }
+                let created = try await GithubAPIClient.createIssue(
+                    owner: source.owner,
+                    repository: source.repository,
+                    title: trimmedTitle,
+                    body: bodyText,
+                    bearer: token,
+                    transport: transport
+                )
+                isWorking = false
+                onCreated()
+                dismiss()
+                if let url = URL(string: created.htmlURL) {
+                    NSWorkspace.shared.open(url)
+                }
+            } catch {
+                isWorking = false
+                errorText = IssuesMailboxView.describe(error)
+            }
+        }
+    }
+}
+
+private extension NSColor {
+    /// GitHub sends label colors as `rrggbb` hex without the `#`.
+    /// Unparseable input falls back to a neutral gray — never a crash.
+    convenience init(hex: String) {
+        let cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        var value: UInt64 = 0
+        guard Scanner(string: cleaned).scanHexInt64(&value), cleaned.count == 6 else {
+            self.init(calibratedWhite: 0.6, alpha: 1)
+            return
+        }
+        self.init(
+            calibratedRed: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+}

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -48,6 +48,14 @@ struct LocalPlay: PlaySurface {
                     // sources. Honest fallback rather than a crash.
                     trunkMailbox
                 }
+            case WorkspaceMailbox.issues:
+                if let github = source as? GithubSource {
+                    IssuesMailboxView(source: github)
+                } else {
+                    // Unreachable: the Issues row only exists for github
+                    // sources. Honest fallback rather than a crash.
+                    trunkMailbox
+                }
             default:
                 // Unknown mailbox is a trunk id (M13): Pages means all;
                 // a trunk id means that folder and its descendants.

--- a/Sources/Workspace/GitHub/GithubAPIClient.swift
+++ b/Sources/Workspace/GitHub/GithubAPIClient.swift
@@ -34,6 +34,39 @@ struct GithubPullRequestCreated: Decodable, Equatable, Sendable {
     }
 }
 
+/// One row of the issues mailbox (M16-4 / #185). REST returns pull
+/// requests mixed into the issues list — `pullRequest` is present
+/// exactly for those, so the mailbox filters `== nil` and PRs never
+/// appear as issues. `labels` is a minimal name + color for chips.
+struct GithubIssue: Decodable, Equatable, Sendable {
+    struct Label: Decodable, Equatable, Sendable {
+        let name: String
+        /// Hex color without the leading `#`, as GitHub sends it.
+        let color: String
+    }
+
+    struct PullRequestRef: Decodable, Equatable, Sendable {
+        let url: String
+    }
+
+    let number: Int
+    let title: String
+    let htmlURL: String
+    let labels: [Label]
+    /// Non-nil exactly when this row is a pull request, not an issue.
+    let pullRequest: PullRequestRef?
+
+    var isPullRequest: Bool { pullRequest != nil }
+
+    enum CodingKeys: String, CodingKey {
+        case number
+        case title
+        case htmlURL = "html_url"
+        case labels
+        case pullRequest = "pull_request"
+    }
+}
+
 /// Minimal GitHub REST surface (M15 / #179, M16 / #185): identity,
 /// repo default branch, PR creation. Boris has no GitHub API — the app
 /// owns this. Tokens ride as `SecureBuffer`; the transport builds the
@@ -48,6 +81,12 @@ enum GithubAPIClient {
 
     static func pullsURL(owner: String, repository: String) -> URL {
         URL(string: "https://api.github.com/repos/\(owner)/\(repository)/pulls")!
+    }
+
+    /// `GET /repos/{owner}/{repo}/issues?state=open` — REST returns PRs
+    /// in the same list; `listIssues` filters them out (M16-4).
+    static func issuesURL(owner: String, repository: String) -> URL {
+        URL(string: "https://api.github.com/repos/\(owner)/\(repository)/issues?state=open")!
     }
 
     static func user(bearer: SecureBuffer, transport: GithubOAuth.HTTPTransport) async throws -> GithubUser {
@@ -95,6 +134,45 @@ enum GithubAPIClient {
             bearer: bearer
         )
         return try decode(GithubPullRequestCreated.self, from: data)
+    }
+
+    /// Open issues for the repo (M16-4): `GET …/issues?state=open`,
+    /// with pull requests filtered out of the REST mix. Rows carry
+    /// `htmlURL` so the mailbox opens them in the browser.
+    static func listIssues(
+        owner: String,
+        repository: String,
+        bearer: SecureBuffer,
+        transport: GithubOAuth.HTTPTransport
+    ) async throws -> [GithubIssue] {
+        let data = try await transport.get(
+            issuesURL(owner: owner, repository: repository),
+            bearer: bearer
+        )
+        let issues = try decode([GithubIssue].self, from: data)
+        return issues.filter { !$0.isPullRequest }
+    }
+
+    /// Create an issue (M16-4): `POST …/issues` with title + body over
+    /// the JSON-post seam. Returns the created issue (number + html URL).
+    static func createIssue(
+        owner: String,
+        repository: String,
+        title: String,
+        body: String,
+        bearer: SecureBuffer,
+        transport: GithubOAuth.HTTPTransport
+    ) async throws -> GithubIssue {
+        let payload: [String: String] = [
+            "title": title,
+            "body": body,
+        ]
+        let data = try await transport.post(
+            issuesURL(owner: owner, repository: repository),
+            json: jsonBody(payload),
+            bearer: bearer
+        )
+        return try decode(GithubIssue.self, from: data)
     }
 
     private static func jsonBody(_ object: [String: String]) -> Data {

--- a/Sources/Workspace/WorkspaceSelection.swift
+++ b/Sources/Workspace/WorkspaceSelection.swift
@@ -47,6 +47,9 @@ enum WorkspaceMailbox {
     /// GitHub-source-only mailbox (M15): branch, ahead/behind, Sync.
     /// Deliberately not in `all` — Local sources never see a Remote row.
     static let remote = "remote"
+    /// GitHub-source-only mailbox (M16-4 / #185): the repo's open
+    /// issues. Same pattern as `remote` — never in `all`.
+    static let issues = "issues"
 
     static let all: [String] = [pages, outputs, publish, plan, activity, contentAudit]
     static let defaultMailbox = pages
@@ -74,6 +77,7 @@ enum WorkspaceMailbox {
         case activity: return "Activity"
         case contentAudit: return "Content Audit"
         case remote: return "Remote"
+        case issues: return "Issues"
         default: return raw
         }
     }
@@ -87,15 +91,17 @@ enum WorkspaceMailbox {
         case activity: return "clock"
         case contentAudit: return "checkmark.shield"
         case remote: return "arrow.triangle.2.circlepath"
+        case issues: return "exclamationmark.circle"
         default: return "folder"
         }
     }
 
     /// Sidebar row list for one source. Local sources get the M10 set;
-    /// GitHub sources additionally get the Remote mailbox.
+    /// GitHub sources additionally get the Remote mailbox and the
+    /// Issues mailbox (github-only rows).
     static func all(for item: SourceItem) -> [String] {
         switch item.kind {
-        case .github: return all + [remote]
+        case .github: return all + [remote, issues]
         case .local: return all
         }
     }

--- a/Tests/ContractTests/GithubIssuesTests.swift
+++ b/Tests/ContractTests/GithubIssuesTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+
+/// M16-4 / #185: the issues mailbox API surface (list with PRs filtered
+/// out, create over the JSON-post seam) and the github-only `issues`
+/// mailbox token. No network — everything rides the injected transport.
+final class GithubIssuesTests: XCTestCase {
+    func testListIssuesDecodesLabelsAndFiltersPullRequests() async throws {
+        let transport = StubTransport()
+        let issueJSON: [String: Any] = [
+            "number": 12,
+            "title": "Fix the sidebar",
+            "html_url": "https://github.com/acme/blog/issues/12",
+            "labels": [["name": "bug", "color": "d73a4a"], ["name": "help wanted", "color": "008672"]],
+        ]
+        // REST mixes PRs into /issues — the mailbox must drop them.
+        let prJSON: [String: Any] = [
+            "number": 42,
+            "title": "Add a page",
+            "html_url": "https://github.com/acme/blog/pull/42",
+            "labels": [],
+            "pull_request": ["url": "https://api.github.com/repos/acme/blog/pulls/42"],
+        ]
+        await transport.enqueue(
+            jsonArray([issueJSON, prJSON]),
+            for: GithubAPIClient.issuesURL(owner: "acme", repository: "blog")
+        )
+
+        let issues = try await GithubAPIClient.listIssues(
+            owner: "acme",
+            repository: "blog",
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        XCTAssertEqual(issues.count, 1, "the PR must be filtered out")
+        let issue = try XCTUnwrap(issues.first)
+        XCTAssertEqual(issue.number, 12)
+        XCTAssertEqual(issue.title, "Fix the sidebar")
+        XCTAssertEqual(issue.htmlURL, "https://github.com/acme/blog/issues/12")
+        XCTAssertEqual(issue.labels.map(\.name), ["bug", "help wanted"])
+        XCTAssertEqual(issue.labels.map(\.color), ["d73a4a", "008672"])
+        XCTAssertFalse(issue.isPullRequest)
+    }
+
+    func testListIssuesBearerRidesTheGet() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(jsonArray([]), for: GithubAPIClient.issuesURL(owner: "acme", repository: "blog"))
+
+        _ = try await GithubAPIClient.listIssues(
+            owner: "acme",
+            repository: "blog",
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        let recorded = await transport.recorded
+        let call = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(call.url, GithubAPIClient.issuesURL(owner: "acme", repository: "blog"))
+        XCTAssertNil(call.form)
+        XCTAssertNil(call.json)
+        XCTAssertEqual(call.bearerBytes, Array("gho_secret".utf8))
+    }
+
+    func testCreateIssueDecodeAndJsonBearerRideThePost() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            json(["number": 13, "title": "New bug", "html_url": "https://github.com/acme/blog/issues/13", "labels": []]),
+            for: GithubAPIClient.issuesURL(owner: "acme", repository: "blog")
+        )
+
+        let created = try await GithubAPIClient.createIssue(
+            owner: "acme",
+            repository: "blog",
+            title: "New bug",
+            body: "Details here",
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        XCTAssertEqual(created.number, 13)
+        XCTAssertEqual(created.htmlURL, "https://github.com/acme/blog/issues/13")
+
+        let recorded = await transport.recorded
+        let call = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(call.url, GithubAPIClient.issuesURL(owner: "acme", repository: "blog"))
+        XCTAssertNil(call.form)
+        XCTAssertEqual(call.bearerBytes, Array("gho_secret".utf8))
+        let jsonBody = try XCTUnwrap(call.json)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: jsonBody) as? [String: String])
+        XCTAssertEqual(object["title"], "New bug")
+        XCTAssertEqual(object["body"], "Details here")
+        XCTAssertEqual(object.count, 2, "title + body, never more")
+    }
+
+    func testCreateIssueErrorSurfacesMessage() async {
+        let transport = StubTransport()
+        await transport.enqueue(
+            error: GithubOAuthError.httpStatus(422, message: "Validation Failed"),
+            for: GithubAPIClient.issuesURL(owner: "acme", repository: "blog")
+        )
+
+        do {
+            _ = try await GithubAPIClient.createIssue(
+                owner: "acme",
+                repository: "blog",
+                title: "T",
+                body: "B",
+                bearer: SecureBuffer(utf8String: "gho_secret"),
+                transport: transport
+            )
+            XCTFail("expected httpStatus")
+        } catch let GithubOAuthError.httpStatus(status, message) {
+            XCTAssertEqual(status, 422)
+            XCTAssertEqual(message, "Validation Failed")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testMailboxRowsAreGithubOnly() {
+        let source = makeSource()
+        let githubRows = WorkspaceMailbox.all(for: SourceItem.github(source))
+        XCTAssertTrue(githubRows.contains(WorkspaceMailbox.remote))
+        XCTAssertTrue(githubRows.contains(WorkspaceMailbox.issues))
+
+        // Every known token is in the github row set, in the canonical order.
+        XCTAssertEqual(Array(githubRows.prefix(WorkspaceMailbox.all.count)), WorkspaceMailbox.all)
+
+        // Local sources never see the github-only rows.
+        let local = SourceItem.local(LocalSource(
+            id: SourceID(),
+            title: "Blog",
+            bookmarkData: Data([1, 2, 3]),
+            displayPath: "/tmp/blog",
+            isAvailable: true
+        ))
+        let localRows = WorkspaceMailbox.all(for: local)
+        XCTAssertFalse(localRows.contains(WorkspaceMailbox.remote))
+        XCTAssertFalse(localRows.contains(WorkspaceMailbox.issues))
+        XCTAssertEqual(localRows, WorkspaceMailbox.all)
+    }
+
+    private func makeSource() -> GithubSource {
+        GithubSource(
+            id: SourceID(),
+            title: "acme/blog",
+            owner: "acme",
+            repository: "blog",
+            defaultBranch: "main",
+            bookmarkData: Data([1, 2, 3]),
+            displayPath: "/tmp/blog",
+            grantedScopes: ["repo"]
+        )
+    }
+}

--- a/Tests/ContractTests/GithubTestSupport.swift
+++ b/Tests/ContractTests/GithubTestSupport.swift
@@ -7,6 +7,11 @@ func json(_ object: [String: Any]) -> Data {
     (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
 }
 
+/// Array-bodied JSON (e.g. `GET …/issues` returns `[...]`).
+func jsonArray(_ array: [Any]) -> Data {
+    (try? JSONSerialization.data(withJSONObject: array)) ?? Data()
+}
+
 /// Records calls and returns queued responses per URL. An actor: the
 /// poll loop and the test both touch it across await points.
 actor StubTransport: GithubOAuth.HTTPTransport {


### PR DESCRIPTION
## M16-4 — Issues mailbox (#185)

The final M16 slice: the GitHub source now has a real **Issues mailbox** — the repo's open issues over the Keychain bearer, rows opening in the browser, and a create-issue sheet. This is the one M16 surface that is a mailbox rather than a Remote-mailbox verb, per the design (§6).

### What ships

- **`issues` mailbox token** — `WorkspaceMailbox` gains `issues` on the M15 `remote` pattern: `all(for:)` appends it for github sources only, never in `all`, so Local sources never see the row. The sidebar picks it up automatically (`ForEach(WorkspaceMailbox.all(for:))`).
- **`GithubAPIClient.listIssues`** — `GET /repos/{owner}/{repo}/issues?state=open`; REST mixes PRs into that list, so rows with a `pull_request` key are filtered out before the view ever sees them. New `GithubIssue` model: number, title, `html_url`, labels (name + hex color).
- **`GithubAPIClient.createIssue`** — `POST …/issues` over the M16-3 JSON-post seam; the created issue's `html_url` opens in the browser after success.
- **`IssuesMailboxView`** (`Sources/Play/GitHub/`) — rows (#number · title · label chips) click through to the issue in the browser, an honest "No Open Issues" empty state, a New Issue… sheet, and the M15 §10 needsAuth posture on 401/403 (non-blocking, re-auth via the settings flow). D11: error bodies surface verbatim, never swallowed.

### Guarantees held

- **Zero-leak invariant** — the Keychain bearer's only stop is the transient Authorization header inside the transport; never argv/env/logs.
- **No new auth surface** — the existing token store + transport; the sheet fails honestly with a needsAuth hint when no token exists.
- **Watch never suspended** — this mailbox reads/writes the GitHub API, not the content tree.
- **No live GitHub in CI** — every test rides the injected `StubTransport` (new `jsonArray` body helper for the list shape).

### Gates

- Build ✅ · **341 tests, 0 failures** (5 new: list decodes labels + filters PRs out of the REST mix, bearer rides the GET, create decode + JSON/bearer ride the POST with exactly `{title, body}`, 422 surfaced, github-only `issues` row with Local sources untouched) ✅ · `make lint` 0 violations ✅ · spike ✅.

**M16 is now complete:** commit ✅ (#187) · push ✅ (#188) · PR authoring ✅ (#189) · **issues mailbox ✅ (this PR)**. Every verb on the card is shipped; the Pull Requests mailbox stays in roadmap "Later" as designed.
