### PR TITLE
docs: M17 Pull Requests mailbox batch — design gate + three slice cards (#192)

### DIFF
--- a/docs/M17-PR-MAILBOX-DESIGN.md
+++ b/docs/M17-PR-MAILBOX-DESIGN.md
@@ -1,0 +1,186 @@
+# M17 — Pull Requests mailbox (the deferred "Later" item)
+
+**Status:** design gate for
+[#192](https://github.com/drawmeanelephant/solipsist/issues/192) (cards
+`cards/M17-pr-list.md` · `M17-pr-mailbox.md` · `M17-pr-authoring.md`).
+Drafted by the dispatcher after M16 fully shipped (PRs #187–#190). The
+lane owns this file and the implementation. This is the ROADMAP §3
+"Later" remainder of the GitHub-source deferral — *"A Pull Requests
+mailbox (the issues mailbox filters PRs out of the REST list; a
+dedicated PR mailbox stays later)"*. M16 built every seam this needs;
+nothing here is a new code path.
+
+## 1. What exists today (do not redo)
+
+| Piece | Current behavior |
+|-------|------------------|
+| `GithubSource` (`Sources/Workspace/GitHub/`) | Identity (`owner/repo`, default branch) + working-copy bookmark. `PlayFolderSource` conformance; github-only `remote` (M15) and `issues` (M16-4) mailbox tokens via `WorkspaceMailbox.all(for:)`. |
+| `GithubAPIClient` | `user`, `repository`, `createPullRequest` (returns `GithubPullRequestCreated` = `number` + `html_url`), `listIssues` (filters `pull_request == nil` — REST mixes PRs into `/issues`), `createIssue`. `pullsURL(owner:repository:)` exists. |
+| `GithubOAuth.HTTPTransport` | bearer `get` + form `post` + JSON `post` seams (M16-3). Token rides a `SecureBuffer`; the transport builds the Authorization header — zero-leak invariant. |
+| `IssuesMailboxView` (`Sources/Play/GitHub/`) | The mailbox pattern to mirror: rows → Open on GitHub, honest empty state, needsAuth posture on 401/403, D11 (error bodies verbatim). |
+| `RemoteMailboxView` | Sync / Commit / Push verbs + **New Pull Request…** sheet (`PullRequestSheet`, currently `private` to that file): push-first when the branch has no upstream, base = `defaultBranch`, success opens the PR in the browser. |
+| `GitClone` + `git-credential-solipsist` | The git verbs. The PR mailbox itself is **API-only** — it never touches the working copy, `.git`, or the engine. |
+
+## 2. What M17 is
+
+The read sibling of the M16-4 issues mailbox: a github-only mailbox
+token `pulls`, listing the repo's open pull requests via the **proper
+REST endpoint** (`GET /repos/{owner}/{repo}/pulls`), rows opening in
+the browser. Unlike the issues list (which mixes PRs in shallow form),
+`/pulls` returns full PR objects — draft state, head + base refs — so
+the mailbox renders what a PR mailbox should: `#number · title · head →
+base`, with a draft badge, no issues mixed in.
+
+Three slices, one worktree / one PR each (the #167 / M16 slice
+pattern), all behind this design gate:
+
+- **M17-1 PR list seam** — `GithubAPIClient.listPullRequests` +
+  `GithubPullRequest` model over the existing bearer-`get` transport.
+  No UI.
+- **M17-2 PR mailbox surface** — the `pulls` token (github-only rows,
+  M16-4 `issues` pattern), `PullRequestsMailboxView`, `LocalPlay`
+  case, sidebar row (automatic via `all(for:)`).
+- **M17-3 Authoring from the mailbox** — extract the M16-3
+  `PullRequestSheet` out of `RemoteMailboxView.swift` (it is `private`
+  there today) so the PR mailbox's toolbar can present it too. No new
+  git or API behavior — the M16-3 flow (push-first when no upstream →
+  `POST /pulls` → open in browser) is reused verbatim.
+
+**Watch arbitration:** none of the slices touch the content tree — the
+mailbox reads/writes the GitHub API, never the working copy. Watch is
+never suspended (the same decision M16-4 already made for issues).
+
+## 3. M17-1 — PR list seam
+
+- `GithubPullRequest` (new model, `Decodable, Equatable, Sendable`):
+  `number`, `title`, `htmlURL` (`html_url`), `draft: Bool`, `state`,
+  `head` + `base` as `{label, ref}` sub-structs (`head` is
+  `owner:branch` for fork PRs — the row renders `label`, which is the
+  GitHub-facing truth, never a guessed owner).
+- `GithubAPIClient.listPullRequests(owner:repository:state:bearer:
+  transport:)` → `GET pullsURL` with `?state=` (default `open` — the
+  mailbox's honest default, mirroring the issues mailbox; the param
+  exists for tests and a future closed/all toggle). Same error
+  contract as every other client call: non-2xx bodies surface as
+  `httpStatus(status, message)` (D11 — never swallow).
+- `createPullRequest` and `GithubPullRequestCreated` are **untouched**
+  (M16-3 ships as-is). The list model duplicates `number` + `html_url`;
+  folding `Created` into the rich model is a lane decision, not
+  required.
+
+## 4. M17-2 — PR mailbox surface
+
+- New github-only mailbox token `pulls` (M16-4 `issues` pattern:
+  `WorkspaceMailbox.all(for:)` appends it, never in `all`, `display`
+  passes through, `displayName` "Pull Requests", a branch-style
+  symbol). The sidebar picks the row up automatically — no Chrome
+  edit.
+- `PullRequestsMailboxView` (`Sources/Play/GitHub/`, new): rows
+  `#number · title · head → base` with a **draft badge** (open draft
+  PRs are included by `state=open`), click → Open on GitHub
+  (`NSWorkspace`, existing pattern). Honest empty state ("No Open Pull
+  Requests"), loading + error states, the M15 §10 needsAuth posture on
+  401/403 (non-blocking, re-auth via the settings flow).
+- `LocalPlay` switch case → the new view (github cast + honest trunk
+  fallback, exactly as `issues`/`remote` do).
+- No issues mixed in — this mailbox uses `/pulls`, not the
+  issues-list filter (see §7).
+
+## 5. M17-3 — Authoring from the mailbox
+
+- Extract `PullRequestSheet` from `RemoteMailboxView.swift` into a
+  shared file (e.g. `Sources/Play/GitHub/PullRequestSheet.swift`,
+  internal, `describe` helper included). `RemoteMailboxView` presents
+  it unchanged — the Remote mailbox's New Pull Request… button behaves
+  identically.
+- `PullRequestsMailboxView`'s toolbar gains **New Pull Request…**
+  presenting the same sheet. The M16-3 flow runs verbatim: branch with
+  no upstream → push first (the M16-2 one-shot through the credential
+  helper) → `POST /pulls` → success opens the PR and the mailbox
+  refreshes (the new PR appears).
+- Zero new auth surface, zero new git verbs, zero new API calls — this
+  slice is relocation + a toolbar entry, nothing invented.
+
+## 6. Files and lanes
+
+| File | Lane | Owns |
+|------|------|------|
+| `Sources/Workspace/GitHub/GithubAPIClient.swift` | workspace | `GithubPullRequest` model + `listPullRequests` (M17-1) |
+| `Sources/Workspace/WorkspaceSelection.swift` | workspace | `pulls` mailbox token, github-only rows (M17-2) |
+| `Sources/Play/GitHub/PullRequestsMailboxView.swift` (new) | play | rows → Open on GitHub, draft badge, empty state, needsAuth posture (M17-2) |
+| `Sources/Play/Local/LocalPlay.swift` | play | `pulls` switch case (M17-2) |
+| `Sources/Play/GitHub/PullRequestSheet.swift` (new, extracted) | play | shared authoring sheet; `RemoteMailboxView.swift` presents it unchanged (M17-3) |
+
+**Untouched:** `Sources/Engine/**` (boris never talks to GitHub), the
+git verbs (`GitClone`, `GithubSync`, `GithubCommit`, credential
+helper), `Sources/Chrome/MainWindow.swift`, watch primitives, and
+`createPullRequest`/`GithubPullRequestCreated` (M16-3, ships as-is).
+
+## 7. Do not
+
+- Reimplement git in Swift; invent a second credential seam; put the
+  token in argv/env/logs/plists (zero-leak invariant holds — the
+  bearer's only stop is the transient Authorization header).
+- **Merge, close, or review PRs.** The M16 "do not merge anything"
+  discipline holds; `/pulls/{n}/merge` and `PATCH /pulls/{n}` are out
+  of scope for this Later item. A close verb, if ever wanted, is a
+  separate design.
+- Build the mailbox on the issues-list `pull_request` filter — `/pulls`
+  is the proper source (full objects: draft, head, base). The issues
+  mailbox keeps filtering for its own correctness.
+- Change `createPullRequest`'s behavior or return type (M17-3 only
+  relocates its sheet).
+- Suspend watch; touch the working copy or `.git`; fetch repo/branch
+  lists without the user's pick; grow `Sources/Chrome/MainWindow.swift`.
+
+## 8. Gate (how the lane proves it)
+
+Manual, against the real app (`make build`; a GitHub source with a
+repo that has open PRs — including at least one draft):
+
+1. Pull Requests mailbox lists the repo's open PRs (no issues mixed
+   in); draft PRs show the draft badge; rows show `head → base`.
+2. Click a row → the PR opens in the browser.
+3. **New Pull Request…** works from the PR mailbox toolbar exactly as
+   it did from the Remote mailbox (new branch → pushed first → PR
+   opens; mailbox refreshes to show it).
+4. Empty repo → honest "No Open Pull Requests" state.
+5. Watch never suspended; preview keeps serving (API-only surface).
+6. `SKIP_EMBED_BORIS=1 make build` + `make test` green — **no live
+   GitHub in CI**.
+
+Automated (unit, injected transport, no network):
+
+- `listPullRequests` decode: draft true/false, head/base refs and fork
+  labels, `state=open` rides the URL, non-2xx bodies surface as
+  `httpStatus` (D11).
+- `WorkspaceMailbox.all(for:)` github-only `pulls` row; Local sources
+  untouched.
+- M17-3: the extracted sheet keeps the Remote flow — existing
+  `GithubAPIClientTests` (create-PR seam) and the Remote mailbox's
+  behavior are unchanged (compile-level proof + suite green).
+
+## 9. Edge cases
+
+- **Token revoked while composing:** the API read/write fails with 401
+  → `httpStatus(401, …)` surfaced, the M15 §10 `needsAuth` posture
+  (non-blocking, re-auth via the existing flow).
+- **Draft PRs:** shown with the draft badge, not hidden — open drafts
+  are part of `state=open`.
+- **Fork PRs:** `head.label` renders `owner:branch` (GitHub's own
+  label), never a guessed owner.
+- **PR list empty:** honest empty state, never a fake row.
+- **Working copy unrelated/deleted:** irrelevant — the mailbox is
+  API-only and needs only the source's identity, but the github row
+  set still requires a `GithubSource` (it cannot exist without one).
+- **Sheet extraction regression:** the Remote mailbox's New Pull
+  Request… must behave identically after the move (same tests, same
+  flow).
+
+## 10. Sequencing
+
+M17-1 (seam) first — it unblocks M17-2 (surface). M17-3 (authoring
+entry) depends on M17-2's toolbar and can run immediately after (or
+parallel with) it; the extraction is mechanical but touches the
+Remote mailbox, so sequence it after the surface lands. One worktree,
+one PR each, all against `main`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -120,13 +120,15 @@ No scraped prose. No homegrown graph. No third settings store.
   landed as **M16** (PRs #187–#190;
   [`M16-WRITE-REMOTE-DESIGN.md`](M16-WRITE-REMOTE-DESIGN.md),
   [#185](https://github.com/drawmeanelephant/solipsist/issues/185)).
+  A dedicated Pull Requests mailbox (the deferred "Later" item) is
+  **M17** — design gate
+  [`M17-PR-MAILBOX-DESIGN.md`](M17-PR-MAILBOX-DESIGN.md),
+  [#192](https://github.com/drawmeanelephant/solipsist/issues/192).
 - Content-audit mailbox (`boris-content-audit`)
 - Source-RAG export for AI assist
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)
 - Cooklang recipe-scale as a first-class mailbox (v1: available from
   the page inspector when the corpus has recipes)
-- A Pull Requests mailbox (the issues mailbox filters PRs out of the
-  REST list; a dedicated PR mailbox stays later)
 - Width-adaptive list-left-of-letter split (M10 default is stacked)
 - The fart app (CI job reserved, `make fart` refuses; do not build it)
 
@@ -154,6 +156,7 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M14** Watch contract | ✅ A1 `--watch-json` + letter SSE ([#143](https://github.com/drawmeanelephant/solipsist/issues/143); #147/#148 → PRs #157/#158) |
 | **M15** GitHub source | ✅ OAuth device flow + `SourceKind.github` payload, working copy, Remote mailbox Sync, sign-out ([#179](https://github.com/drawmeanelephant/solipsist/issues/179); PRs #180–#184) |
 | **M16** Write the remote | ✅ commit / push / PR authoring / issues mailbox ([#185](https://github.com/drawmeanelephant/solipsist/issues/185); PRs #187–#190) |
+| **M17** Pull Requests mailbox | filed — the deferred "Later" item: `/pulls` list + github-only mailbox ([#192](https://github.com/drawmeanelephant/solipsist/issues/192); design [`M17-PR-MAILBOX-DESIGN.md`](M17-PR-MAILBOX-DESIGN.md)) |
 
 **Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
 batch then landed: first-run and problem→page (#88/#94), graph filter /
@@ -609,13 +612,18 @@ here, it is not a v1 promise.
 M10–M14, the post-ship batch (#165/#166/#167), **M15** (GitHub
 source, PRs #180–#184), and **M16** (remote write verbs — commit /
 push / PR authoring / issues mailbox, PRs #187–#190) all landed.
-Remaining is **ship**, Apple-account only: notarization (#110) then
+Next **product** slice is M17, the Pull Requests mailbox — design
+[`docs/M17-PR-MAILBOX-DESIGN.md`](M17-PR-MAILBOX-DESIGN.md).
+Remaining **ship** stays Apple-account only: notarization (#110) then
 the clean-Mac proof (#111).
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
-| 1 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. |
-| 2 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
+| 1 | M17-1 PR list | [#192](https://github.com/drawmeanelephant/solipsist/issues/192) | the deferred "Later" item; M16 shipped every seam (`/pulls` URL, bearer-`get`, `issues` mailbox pattern) — the list seam is the first slice. |
+| 2 | M17-2 PR mailbox | #192 | after M17-1 — the github-only `pulls` surface, sibling of M16-4. |
+| 3 | M17-3 Authoring entry | #192 | after M17-2 — extract the M16-3 sheet so the mailbox can create PRs. |
+| 4 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. |
+| 5 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
 
 ### Landed depth (do not redo)
 
@@ -644,7 +652,7 @@ Out of v1 (unchanged): migration labs, Wasm in the app,
 `validate --watch` until A5 + pin. Clone-as-local is M12 / #131.
 GitHub source is M15 (landed); its remote *write* verbs are M16
 (landed — commit / push / PR authoring / issues mailbox, PRs
-#187–#190).
+#187–#190). A Pull Requests mailbox is M17 (#192, filed).
 Compose **depth** (diagnostics, bundle `oliver`) stays Later; the
 M10 compose window is #106 / #108.
 

--- a/docs/cards/M17-pr-authoring.md
+++ b/docs/cards/M17-pr-authoring.md
@@ -1,0 +1,46 @@
+# Card M17-3 — PR authoring from the mailbox (extract the M16-3 sheet)
+
+**Milestone:** M17 (Pull Requests mailbox) · **Issue:**
+[#192](https://github.com/drawmeanelephant/solipsist/issues/192)
+**Lane:** play. One worktree, one PR against `main`;
+branch suggestion `feat/github-pr-authoring-entry`.
+
+Design gate: [`docs/M17-PR-MAILBOX-DESIGN.md`](../M17-PR-MAILBOX-DESIGN.md)
+— the lane owns that file and the implementation.
+
+## Owns
+
+- `Sources/Play/GitHub/PullRequestSheet.swift` (new) — the M16-3
+  `PullRequestSheet` (currently `private` inside
+  `RemoteMailboxView.swift`) moved verbatim to file scope, internal,
+  `describe` helper included. **No behavior change.**
+- `Sources/Play/GitHub/RemoteMailboxView.swift` — presents the
+  extracted sheet unchanged; its New Pull Request… button behaves
+  identically.
+- `Sources/Play/GitHub/PullRequestsMailboxView.swift` — toolbar gains
+  **New Pull Request…** presenting the same sheet; on success the
+  mailbox refreshes so the new PR appears.
+
+## Do not touch
+
+- The M16-3 flow itself: push-first when the branch has no upstream
+  (M16-2 one-shot through the credential helper) → `POST /pulls` →
+  open in the browser. Reused verbatim, never rewritten.
+- `createPullRequest` / `GithubPullRequestCreated`; the git verbs;
+  `Sources/Engine/**`, `Sources/Compose/**`, `Sources/Chrome/MainWindow.swift`
+- Token in argv/env/logs; merge/close/review endpoints
+
+## Do
+
+1. Move the sheet (and its `describe`) out of `RemoteMailboxView.swift`
+   — the extraction must compile with the Remote mailbox unchanged.
+2. Add the toolbar entry to the PR mailbox; success → refresh the row
+   list.
+3. Verify the Remote mailbox's sheet still works (same flow, same
+   tests).
+
+## Gate
+
+New Pull Request… works from the PR mailbox toolbar exactly as it did
+from the Remote mailbox; the Remote surface is byte-for-byte the same
+behavior. `make build` + `make test` green, no live GitHub in CI.

--- a/docs/cards/M17-pr-list.md
+++ b/docs/cards/M17-pr-list.md
@@ -1,0 +1,44 @@
+# Card M17-1 — PR list seam (`GET /repos/{owner}/{repo}/pulls`)
+
+**Milestone:** M17 (Pull Requests mailbox) · **Issue:**
+[#192](https://github.com/drawmeanelephant/solipsist/issues/192)
+**Lane:** workspace. One worktree, one PR against `main`;
+branch suggestion `feat/github-pr-list`.
+
+Design gate: [`docs/M17-PR-MAILBOX-DESIGN.md`](../M17-PR-MAILBOX-DESIGN.md)
+— the lane owns that file and the implementation.
+
+## Owns
+
+- `Sources/Workspace/GitHub/GithubAPIClient.swift` — `GithubPullRequest`
+  model (`number`, `title`, `html_url`, `draft`, `state`, `head` +
+  `base` as `{label, ref}`) and
+  `listPullRequests(owner:repository:state:bearer:transport:)` →
+  `GET pullsURL` with `?state=` (default `open`). Same error contract
+  as every client call: non-2xx bodies surface as
+  `httpStatus(status, message)` (D11). Uses the existing bearer-`get`
+  transport seam — no new transport code.
+
+## Do not touch
+
+- `createPullRequest` / `GithubPullRequestCreated` (M16-3, ships as-is)
+- The issues-list `pull_request` filter (that mailbox keeps it; this
+  slice uses `/pulls`, the proper source)
+- `Sources/Engine/**`, `Sources/Compose/**`, `Sources/Chrome/MainWindow.swift`
+- Token in argv/env/logs; merge/close/review endpoints
+
+## Do
+
+1. `GithubPullRequest` + `GithubPullRequestRef` (head/base) decode,
+   `convertFromSnakeCase` not needed — explicit CodingKeys match the
+   GitHub wire (`html_url`, `head.ref`, `base.ref`).
+2. `listPullRequests` with `state` defaulting to `open`.
+3. Tests (injected `StubTransport`, no network): draft true/false
+   decode, fork `head.label` (`owner:branch`), `state=open` rides the
+   URL, non-2xx surfaced verbatim.
+
+## Gate
+
+`listPullRequests` decodes a real `/pulls` list shape (draft + head →
+base) and errors surface as `httpStatus`; `make build` + `make test`
+green, no live GitHub in CI.

--- a/docs/cards/M17-pr-mailbox.md
+++ b/docs/cards/M17-pr-mailbox.md
@@ -1,0 +1,48 @@
+# Card M17-2 — Pull Requests mailbox surface (`pulls` token + rows)
+
+**Milestone:** M17 (Pull Requests mailbox) · **Issue:**
+[#192](https://github.com/drawmeanelephant/solipsist/issues/192)
+**Lane:** workspace / play. One worktree, one PR against `main`;
+branch suggestion `feat/github-pr-mailbox`.
+
+Design gate: [`docs/M17-PR-MAILBOX-DESIGN.md`](../M17-PR-MAILBOX-DESIGN.md)
+— the lane owns that file and the implementation.
+
+## Owns
+
+- `Sources/Workspace/WorkspaceSelection.swift` — `pulls` mailbox token,
+  github-only via `WorkspaceMailbox.all(for:)` (M16-4 `issues`
+  pattern: never in `all`, `display` passes through, `displayName`
+  "Pull Requests", branch-style symbol).
+- `Sources/Play/GitHub/PullRequestsMailboxView.swift` (new) — rows
+  `#number · title · head → base` with a draft badge; click → Open on
+  GitHub (`NSWorkspace`, existing pattern); honest "No Open Pull
+  Requests" empty state; loading/error states; the M15 §10 needsAuth
+  posture on 401/403.
+- `Sources/Play/Local/LocalPlay.swift` — `pulls` switch case → the new
+  view (github cast + honest trunk fallback, exactly as `issues` /
+  `remote` do).
+
+## Do not touch
+
+- `Sources/Engine/**`, `Sources/Compose/**`, `Sources/Chrome/MainWindow.swift`
+- The issues mailbox / `listIssues` filter (keep)
+- Merge/close/review endpoints; token in argv/env/logs
+- Watch primitives — this mailbox is API-only, never suspended
+
+## Do
+
+1. `pulls` token + sidebar row for github sources only (the row
+   appears automatically via `all(for:)` — no Chrome edit).
+2. `PullRequestsMailboxView`: load via `GithubTokenStore` +
+   `URLSessionGithubTransport` + `listPullRequests` (M17-1), rows →
+   browser, draft badge, honest empty state, error bodies verbatim
+   (D11) with the needsAuth hint on 401/403.
+3. Tests: github-only `pulls` row (Local sources untouched), token
+   load path via the stub transport.
+
+## Gate
+
+Pull Requests mailbox lists the repo's open PRs (no issues mixed in,
+drafts badged); click opens the PR; empty repo → honest empty state.
+`make build` + `make test` green, no live GitHub in CI.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -147,11 +147,24 @@ Landed — PRs #187 (commit) · #188 (push) · #189 (PR authoring) ·
 | [M16-3 PR](M16-pr.md) | #185 | ✅ |
 | [M16-4 Issues](M16-issues.md) | #185 | ✅ |
 
+## M17 — Pull Requests mailbox (pickable)
+
+The ROADMAP §3 "Later" remainder of the GitHub-source deferral — a
+dedicated PR mailbox (the issues mailbox filters PRs out of the REST
+list; this mailbox uses `/pulls`, the proper source, and is the read
+sibling of M16-4). Design gate:
+[`docs/M17-PR-MAILBOX-DESIGN.md`](../M17-PR-MAILBOX-DESIGN.md).
+One slice per worktree/PR.
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [M17-1 PR list](M17-pr-list.md) | [#192](https://github.com/drawmeanelephant/solipsist/issues/192) | workspace | — | `GithubPullRequest` model + `listPullRequests` over the bearer-`get` seam; `state=open` default |
+| [M17-2 PR mailbox](M17-pr-mailbox.md) | #192 | workspace / play | after M17-1 | `pulls` github-only token + rows → browser, draft badge, empty state |
+| [M17-3 Authoring entry](M17-pr-authoring.md) | #192 | play | after M17-2 | extract the M16-3 sheet; toolbar entry on the mailbox; Remote flow unchanged |
+
 ## Do not start yet
 
-Wasm in the app. The fart app. A Pull Requests mailbox (REST mixes PRs
-into issues; the issues mailbox filters them — a PR mailbox stays
-later).
+Wasm in the app. The fart app.
 
 ## Shared noun kinds (play writes, inspector reads)
 


### PR DESCRIPTION
## M17 batch — Pull Requests mailbox (design gate + three slice cards)

The roadmap "Later" item — *"A Pull Requests mailbox (the issues mailbox filters PRs out of the REST list; a dedicated PR mailbox stays later)"* — is now a sliced milestone, following the M16 pattern (design gate first, then one worktree/one PR per slice). Lane tracker: **issue #192** (opened first so the docs reference the right number).

### What the batch ships (docs only)

- **`docs/M17-PR-MAILBOX-DESIGN.md`** — the design gate in COORDINATOR/GITHUB-OAUTH/M16 house style, grounding every slice in a seam M16 already shipped:
  - **M17-1 PR list seam** — `GithubPullRequest` model (number, title, `html_url`, `draft`, `state`, head/base as `{label, ref}`) + `listPullRequests` over the existing bearer-`get` seam (`GET /pulls?state=open`, default `open`). `createPullRequest` untouched.
  - **M17-2 PR mailbox surface** — github-only `pulls` token (the M16-4 `issues` pattern: never in `all`), `PullRequestsMailboxView` rows `#number · title · head → base` with a draft badge, click → Open on GitHub, honest empty state, needsAuth posture.
  - **M17-3 Authoring entry** — extract the M16-3 `PullRequestSheet` (private in `RemoteMailboxView.swift` today) and present it from the mailbox toolbar; the Remote flow is byte-for-byte unchanged.
- **Three cards** (`docs/cards/M17-pr-{list,mailbox,authoring}.md`, sequenced 1 → 2 → 3) + the board section in `cards/README.md` and roadmap updates (milestone row M17 filed, §8 pickup re-orders the M17 slices above the Apple-account ship, the Later bullet is cleaned, the CLI-vs-app mention notes M17).

### The one flagged decision

None of the M17 slices touch the working copy or the content tree — the mailbox is API-only (identity from `GithubSource`, rows over the GitHub REST), so **watch is never suspended**, the same call M16-4 already made for issues. Merge/close/review endpoints stay out (the M16 "never merge anything" discipline); a close verb, if ever wanted, is a separate design.

The board is pickable again: a conveyor agent can take **M17-1** straight off `docs/cards/M17-pr-list.md`.
