### PR TITLE
feat(github): M17-1 PR list seam (#192)

### DIFF
--- a/Sources/Workspace/GitHub/GithubAPIClient.swift
+++ b/Sources/Workspace/GitHub/GithubAPIClient.swift
@@ -34,6 +34,34 @@ struct GithubPullRequestCreated: Decodable, Equatable, Sendable {
     }
 }
 
+/// One row of the Pull Requests mailbox (M17 / #192). Full `/pulls`
+/// list objects — unlike the shallow issue-mix refs, these carry the
+/// draft state and the head/base refs a PR mailbox renders. `head`
+/// and `base` use GitHub's own labels: `owner:branch` for head (fork
+/// PRs show the fork owner, never a guessed one), plain branch for
+/// base.
+struct GithubPullRequest: Decodable, Equatable, Sendable {
+    struct Ref: Decodable, Equatable, Sendable {
+        /// `owner:branch` for head (fork PRs), `branch` for base.
+        let label: String
+        let ref: String
+    }
+
+    let number: Int
+    let title: String
+    let htmlURL: String
+    /// Open draft PRs are included by `state=open`; the mailbox badges them.
+    let draft: Bool
+    let state: String
+    let head: Ref
+    let base: Ref
+
+    enum CodingKeys: String, CodingKey {
+        case number, title, draft, state, head, base
+        case htmlURL = "html_url"
+    }
+}
+
 /// One row of the issues mailbox (M16-4 / #185). REST returns pull
 /// requests mixed into the issues list — `pullRequest` is present
 /// exactly for those, so the mailbox filters `== nil` and PRs never
@@ -81,6 +109,12 @@ enum GithubAPIClient {
 
     static func pullsURL(owner: String, repository: String) -> URL {
         URL(string: "https://api.github.com/repos/\(owner)/\(repository)/pulls")!
+    }
+
+    /// `GET /repos/{owner}/{repo}/pulls?state=…` — the PR mailbox
+    /// list endpoint (M17-1). The POST target stays plain `pullsURL`.
+    static func listPullsURL(owner: String, repository: String, state: String) -> URL {
+        URL(string: "https://api.github.com/repos/\(owner)/\(repository)/pulls?state=\(state)")!
     }
 
     /// `GET /repos/{owner}/{repo}/issues?state=open` — REST returns PRs
@@ -151,6 +185,26 @@ enum GithubAPIClient {
         )
         let issues = try decode([GithubIssue].self, from: data)
         return issues.filter { !$0.isPullRequest }
+    }
+
+    /// Open pull requests for the repo (M17-1 / #192): `GET
+    /// …/pulls?state=open` over the bearer-`get` seam. Uses the proper
+    /// `/pulls` endpoint — not the issues-list `pull_request` filter —
+    /// so rows carry draft + head/base. `state` defaults to `open` (the
+    /// mailbox's honest default, mirroring the issues mailbox); the
+    /// param exists for tests and a future closed/all toggle.
+    static func listPullRequests(
+        owner: String,
+        repository: String,
+        state: String = "open",
+        bearer: SecureBuffer,
+        transport: GithubOAuth.HTTPTransport
+    ) async throws -> [GithubPullRequest] {
+        let data = try await transport.get(
+            listPullsURL(owner: owner, repository: repository, state: state),
+            bearer: bearer
+        )
+        return try decode([GithubPullRequest].self, from: data)
     }
 
     /// Create an issue (M16-4): `POST …/issues` with title + body over

--- a/Tests/ContractTests/GithubPullRequestTests.swift
+++ b/Tests/ContractTests/GithubPullRequestTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+
+/// M17-1 / #192: the Pull Requests mailbox list seam — decode of the
+/// `/pulls` list shape (draft + head/base refs) and the `state` query
+/// riding the bearer-`get` seam. No network — everything is injected.
+final class GithubPullRequestTests: XCTestCase {
+    func testListDecodesDraftAndHeadBase() async throws {
+        let transport = StubTransport()
+        let openPR: [String: Any] = [
+            "number": 42,
+            "title": "Add a page",
+            "html_url": "https://github.com/acme/blog/pull/42",
+            "draft": false,
+            "state": "open",
+            "head": ["label": "acme:feature/x", "ref": "feature/x"],
+            "base": ["label": "acme:main", "ref": "main"],
+        ]
+        let draftPR: [String: Any] = [
+            "number": 43,
+            "title": "WIP sidebar",
+            "html_url": "https://github.com/acme/blog/pull/43",
+            "draft": true,
+            "state": "open",
+            "head": ["label": "octocat:fork-branch", "ref": "fork-branch"],
+            "base": ["label": "acme:trunk", "ref": "trunk"],
+        ]
+        await transport.enqueue(
+            jsonArray([openPR, draftPR]),
+            for: GithubAPIClient.listPullsURL(owner: "acme", repository: "blog", state: "open")
+        )
+
+        let pulls = try await GithubAPIClient.listPullRequests(
+            owner: "acme",
+            repository: "blog",
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        XCTAssertEqual(pulls.count, 2)
+        let first = try XCTUnwrap(pulls.first)
+        XCTAssertEqual(first.number, 42)
+        XCTAssertEqual(first.title, "Add a page")
+        XCTAssertEqual(first.htmlURL, "https://github.com/acme/blog/pull/42")
+        XCTAssertFalse(first.draft)
+        XCTAssertEqual(first.state, "open")
+        XCTAssertEqual(first.head.label, "acme:feature/x")
+        XCTAssertEqual(first.head.ref, "feature/x")
+        XCTAssertEqual(first.base.ref, "main")
+
+        let draft = try XCTUnwrap(pulls.last)
+        XCTAssertTrue(draft.draft, "open draft PRs are included by state=open")
+        XCTAssertEqual(draft.head.label, "octocat:fork-branch", "fork PRs show the fork owner, never a guessed one")
+        XCTAssertEqual(draft.base.ref, "trunk")
+    }
+
+    func testDefaultStateRidesTheGet() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            jsonArray([]),
+            for: GithubAPIClient.listPullsURL(owner: "acme", repository: "blog", state: "open")
+        )
+
+        _ = try await GithubAPIClient.listPullRequests(
+            owner: "acme",
+            repository: "blog",
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        let recorded = await transport.recorded
+        let call = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(call.url, GithubAPIClient.listPullsURL(owner: "acme", repository: "blog", state: "open"))
+        XCTAssertNil(call.form)
+        XCTAssertNil(call.json)
+        XCTAssertEqual(call.bearerBytes, Array("gho_secret".utf8))
+    }
+
+    func testNonDefaultStateRidesTheURL() async throws {
+        let transport = StubTransport()
+        await transport.enqueue(
+            jsonArray([]),
+            for: GithubAPIClient.listPullsURL(owner: "acme", repository: "blog", state: "closed")
+        )
+
+        _ = try await GithubAPIClient.listPullRequests(
+            owner: "acme",
+            repository: "blog",
+            state: "closed",
+            bearer: SecureBuffer(utf8String: "gho_secret"),
+            transport: transport
+        )
+
+        let recorded = await transport.recorded
+        let call = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(call.url, GithubAPIClient.listPullsURL(owner: "acme", repository: "blog", state: "closed"))
+    }
+
+    func testErrorSurfacesMessage() async {
+        let transport = StubTransport()
+        await transport.enqueue(
+            error: GithubOAuthError.httpStatus(422, message: "Validation Failed"),
+            for: GithubAPIClient.listPullsURL(owner: "acme", repository: "blog", state: "open")
+        )
+
+        do {
+            _ = try await GithubAPIClient.listPullRequests(
+                owner: "acme",
+                repository: "blog",
+                bearer: SecureBuffer(utf8String: "gho_secret"),
+                transport: transport
+            )
+            XCTFail("expected httpStatus")
+        } catch let GithubOAuthError.httpStatus(status, message) {
+            XCTAssertEqual(status, 422)
+            XCTAssertEqual(message, "Validation Failed")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## M17-1 — PR list seam (#192)

The first slice of the Pull Requests mailbox: the list model + client method, no UI. Per the design (§3), this uses the **proper `/pulls` endpoint** — not the issues-list `pull_request` filter — so rows carry the draft state and head/base refs a PR mailbox renders.

### What ships

- **`GithubPullRequest`** (`Sources/Workspace/GitHub/GithubAPIClient.swift`) — full `/pulls` list object: `number`, `title`, `html_url`, `draft`, `state`, and `head`/`base` as `{label, ref}` sub-structs using **GitHub's own labels** (`owner:branch` for head, so fork PRs show the fork owner — never a guessed one; plain branch for base).
- **`GithubAPIClient.listPullRequests(owner:repository:state:bearer:transport:)`** — `GET …/pulls?state=…` over the existing bearer-`get` seam (zero new transport code). `state` defaults to `open` — the mailbox's honest default, mirroring the issues mailbox; the param exists for tests and a future closed/all toggle.
- **`listPullsURL(owner:repository:state:)`** — the list target; the POST target stays the plain `pullsURL`.

### Untouched, per the design

- `createPullRequest` / `GithubPullRequestCreated` (M16-3 ships as-is; the design flags folding `Created` into the rich model as a lane decision, not required).
- The issues mailbox's `pull_request` filter (it keeps filtering for its own correctness).
- No UI, no token-in-argv/env, no new auth surface — the bearer rides the existing `SecureBuffer` → Authorization-header path.

### Gates

- Build ✅ · **345 tests, 0 failures** (4 new, all injected-transport / no network: full decode incl. draft + fork `head.label`, default `state=open` rides the GET with the bearer, non-default `state` rides the URL, 422 surfaced verbatim as `httpStatus`) ✅ · `make lint` 0 violations ✅ · spike ✅.

**M17 progress: M17-1 ✅ (this PR)** — next is **M17-2 the github-only `pulls` mailbox surface** (`PullRequestsMailboxView`, rows → browser, draft badge), which consumes this seam directly.
