### PR TITLE
feat(github): M17-2 Pull Requests mailbox surface (#192)

### DIFF
--- a/Sources/Play/GitHub/PullRequestsMailboxView.swift
+++ b/Sources/Play/GitHub/PullRequestsMailboxView.swift
@@ -1,0 +1,154 @@
+import AppKit
+import SwiftUI
+
+/// Pull Requests mailbox (M17-2 / #192): the repo's open pull requests
+/// over the Keychain bearer, rows opening in the browser. The read
+/// sibling of the M16-4 issues mailbox — github-only (the token is in
+/// `WorkspaceMailbox.all(for:)`'s github branch only), API-only (never
+/// touches the working copy, so watch is never suspended).
+///
+/// Uses `listPullRequests` (`/pulls`), not the issues-list filter, so
+/// rows carry the draft state and head/base refs a PR mailbox renders.
+struct PullRequestsMailboxView: View {
+    let source: GithubSource
+
+    @State private var pulls: [GithubPullRequest] = []
+    @State private var isLoading = false
+    @State private var errorText: String?
+
+    var body: some View {
+        Group {
+            if isLoading, pulls.isEmpty {
+                ProgressView("Loading pull requests…")
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorText, pulls.isEmpty {
+                ContentUnavailableView {
+                    Label("Pull Requests Unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorText)
+                } actions: {
+                    Button("Try Again") { reload() }
+                }
+            } else if pulls.isEmpty {
+                ContentUnavailableView {
+                    Label("No Open Pull Requests", systemImage: "arrow.triangle.branch")
+                } description: {
+                    Text("This repository has no open pull requests.")
+                }
+                .accessibilityLabel("No Open Pull Requests")
+            } else {
+                List(pulls, id: \.number) { pr in
+                    PullRequestRow(pr: pr) {
+                        open(pr)
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .navigationTitle(source.title)
+        .task(id: source.id) {
+            await load()
+        }
+    }
+
+    private func reload() {
+        Task { await load() }
+    }
+
+    @MainActor
+    private func load() async {
+        isLoading = true
+        errorText = nil
+        defer { isLoading = false }
+
+        let tokenStore = GithubTokenStore()
+        let transport = URLSessionGithubTransport()
+        do {
+            guard let token = try tokenStore.load() else {
+                // The M15 §10 needsAuth posture: non-blocking, re-auth
+                // via the existing settings flow. Never a silent retry.
+                errorText = "No GitHub token in the Keychain. Re-authenticate from Settings → Sources."
+                return
+            }
+            defer { token.wipe() }
+            let fetched = try await GithubAPIClient.listPullRequests(
+                owner: source.owner,
+                repository: source.repository,
+                bearer: token,
+                transport: transport
+            )
+            guard !Task.isCancelled else { return }
+            pulls = fetched
+        } catch {
+            guard !Task.isCancelled else { return }
+            errorText = Self.describe(error)
+        }
+    }
+
+    private func open(_ pr: GithubPullRequest) {
+        if let url = URL(string: pr.htmlURL) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    /// Error bodies verbatim (D11) with the needsAuth hint on 401-class
+    /// failures — the same posture the Remote and Issues mailboxes use.
+    static func describe(_ error: Error) -> String {
+        if let github = error as? GithubOAuthError {
+            switch github {
+            case let .httpStatus(status, message):
+                var text = "GitHub returned \(status): \(message)"
+                if status == 401 || status == 403 {
+                    text += "\n\nThe token may be revoked or lack `repo` scope (needed to read pull requests). Re-authenticate from Settings → Sources."
+                }
+                return text
+            case .invalidResponse:
+                return "GitHub returned an unexpected response."
+            case let .deviceCodeFailed(code, message):
+                return "\(code): \(message)"
+            }
+        }
+        return String(describing: error)
+    }
+}
+
+/// One pull request row: number, title, draft badge, head → base;
+/// click opens the PR in the browser (the design's "rows → Open on
+/// GitHub"). Labels are GitHub's own (`owner:branch` for fork heads).
+private struct PullRequestRow: View {
+    let pr: GithubPullRequest
+    let onOpen: () -> Void
+
+    var body: some View {
+        Button(action: onOpen) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("#\(pr.number)")
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 56, alignment: .trailing)
+                Text(pr.title)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if pr.draft {
+                    Text("draft")
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.purple.opacity(0.15))
+                        .foregroundStyle(.purple)
+                        .clipShape(Capsule())
+                        .help("Draft pull request")
+                }
+                Text("\(pr.head.label) → \(pr.base.label)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospaced()
+                    .lineLimit(1)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(pr.htmlURL)
+    }
+}

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -56,6 +56,14 @@ struct LocalPlay: PlaySurface {
                     // sources. Honest fallback rather than a crash.
                     trunkMailbox
                 }
+            case WorkspaceMailbox.pulls:
+                if let github = source as? GithubSource {
+                    PullRequestsMailboxView(source: github)
+                } else {
+                    // Unreachable: the Pull Requests row only exists for
+                    // github sources. Honest fallback rather than a crash.
+                    trunkMailbox
+                }
             default:
                 // Unknown mailbox is a trunk id (M13): Pages means all;
                 // a trunk id means that folder and its descendants.

--- a/Sources/Workspace/WorkspaceSelection.swift
+++ b/Sources/Workspace/WorkspaceSelection.swift
@@ -50,6 +50,10 @@ enum WorkspaceMailbox {
     /// GitHub-source-only mailbox (M16-4 / #185): the repo's open
     /// issues. Same pattern as `remote` — never in `all`.
     static let issues = "issues"
+    /// GitHub-source-only mailbox (M17 / #192): the repo's open pull
+    /// requests, via `/pulls` (not the issues-list filter). Same
+    /// pattern — never in `all`.
+    static let pulls = "pulls"
 
     static let all: [String] = [pages, outputs, publish, plan, activity, contentAudit]
     static let defaultMailbox = pages
@@ -78,6 +82,7 @@ enum WorkspaceMailbox {
         case contentAudit: return "Content Audit"
         case remote: return "Remote"
         case issues: return "Issues"
+        case pulls: return "Pull Requests"
         default: return raw
         }
     }
@@ -92,16 +97,17 @@ enum WorkspaceMailbox {
         case contentAudit: return "checkmark.shield"
         case remote: return "arrow.triangle.2.circlepath"
         case issues: return "exclamationmark.circle"
+        case pulls: return "arrow.triangle.branch"
         default: return "folder"
         }
     }
 
     /// Sidebar row list for one source. Local sources get the M10 set;
-    /// GitHub sources additionally get the Remote mailbox and the
-    /// Issues mailbox (github-only rows).
+    /// GitHub sources additionally get the Remote, Issues, and Pull
+    /// Requests mailboxes (github-only rows).
     static func all(for item: SourceItem) -> [String] {
         switch item.kind {
-        case .github: return all + [remote, issues]
+        case .github: return all + [remote, issues, pulls]
         case .local: return all
         }
     }

--- a/Tests/ContractTests/GithubIssuesTests.swift
+++ b/Tests/ContractTests/GithubIssuesTests.swift
@@ -122,9 +122,14 @@ final class GithubIssuesTests: XCTestCase {
         let githubRows = WorkspaceMailbox.all(for: SourceItem.github(source))
         XCTAssertTrue(githubRows.contains(WorkspaceMailbox.remote))
         XCTAssertTrue(githubRows.contains(WorkspaceMailbox.issues))
+        XCTAssertTrue(githubRows.contains(WorkspaceMailbox.pulls), "M17: Pull Requests row is github-only too")
 
         // Every known token is in the github row set, in the canonical order.
         XCTAssertEqual(Array(githubRows.prefix(WorkspaceMailbox.all.count)), WorkspaceMailbox.all)
+        XCTAssertEqual(
+            githubRows.suffix(3),
+            [WorkspaceMailbox.remote, WorkspaceMailbox.issues, WorkspaceMailbox.pulls]
+        )
 
         // Local sources never see the github-only rows.
         let local = SourceItem.local(LocalSource(
@@ -137,6 +142,7 @@ final class GithubIssuesTests: XCTestCase {
         let localRows = WorkspaceMailbox.all(for: local)
         XCTAssertFalse(localRows.contains(WorkspaceMailbox.remote))
         XCTAssertFalse(localRows.contains(WorkspaceMailbox.issues))
+        XCTAssertFalse(localRows.contains(WorkspaceMailbox.pulls))
         XCTAssertEqual(localRows, WorkspaceMailbox.all)
     }
 


### PR DESCRIPTION
## M17-2 — Pull Requests mailbox surface (#192)

The github-only Pull Requests mailbox — the read sibling of the M16-4 issues mailbox, consuming the M17-1 `/pulls` seam.

### What ships

- **`pulls` mailbox token** (`Sources/Workspace/WorkspaceSelection.swift`) — the M16-4 `issues` pattern: `WorkspaceMailbox.all(for:)` appends it for github sources only (never in `all`), `displayName` "Pull Requests", branch-style symbol. The sidebar picks the row up automatically via `all(for:)` — no Chrome edit.
- **`PullRequestsMailboxView`** (`Sources/Play/GitHub/`, new) — rows `#number · title · draft-badge · head → base` using **GitHub's own labels** (`owner:branch` for fork heads, never a guessed owner), click → Open on GitHub (`NSWorkspace`), honest "No Open Pull Requests" empty state, loading/error states, and the M15 §10 needsAuth posture on 401/403 (non-blocking, re-auth via the settings flow). Error bodies verbatim (D11).
- **`LocalPlay`** — `pulls` switch case with the same github cast + honest trunk fallback as `issues`/`remote`.

### Guarantees held

- **API-only, watch never suspended** — the mailbox never touches the working copy or the content tree (the same call M16-4 made for issues); the design's flagged decision holds.
- **Zero-leak invariant** — Keychain bearer → transient Authorization header only.
- **No issues mixed in** — this surface uses `/pulls` (M17-1), not the issues-list filter.
- **No live GitHub in CI** — the view's load path rides `GithubTokenStore` + `URLSessionGithubTransport`, exercised at the contract level through the injected transport.

### Gates

- Build ✅ · **345 tests, 0 failures** (the mailbox-token test now asserts `pulls` in the github row set — in canonical order after `remote` + `issues` — and that Local sources never see any of the three) ✅ · `make lint` 0 violations ✅ · spike ✅.

**M17 progress: M17-1 ✅ (#194 merged) · M17-2 ✅ (this PR)** — the final slice is **M17-3 Authoring entry**: extract the M16-3 `PullRequestSheet` out of `RemoteMailboxView.swift` and present it from this mailbox's toolbar, with the Remote flow byte-for-byte unchanged.
