### PR TITLE
docs: mark M17 done on the board (#192)

### DIFF
--- a/docs/M17-PR-MAILBOX-DESIGN.md
+++ b/docs/M17-PR-MAILBOX-DESIGN.md
@@ -1,6 +1,7 @@
 # M17 — Pull Requests mailbox (the deferred "Later" item)
 
-**Status:** design gate for
+**Status:** landed — all three slices shipped (PRs #194 PR list ·
+#195 mailbox surface · #196 authoring entry) against
 [#192](https://github.com/drawmeanelephant/solipsist/issues/192) (cards
 `cards/M17-pr-list.md` · `M17-pr-mailbox.md` · `M17-pr-authoring.md`).
 Drafted by the dispatcher after M16 fully shipped (PRs #187–#190). The

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -120,10 +120,10 @@ No scraped prose. No homegrown graph. No third settings store.
   landed as **M16** (PRs #187–#190;
   [`M16-WRITE-REMOTE-DESIGN.md`](M16-WRITE-REMOTE-DESIGN.md),
   [#185](https://github.com/drawmeanelephant/solipsist/issues/185)).
-  A dedicated Pull Requests mailbox (the deferred "Later" item) is
-  **M17** — design gate
+  The dedicated Pull Requests mailbox (the deferred "Later" item)
+  landed as **M17** (PRs #194–#196;
   [`M17-PR-MAILBOX-DESIGN.md`](M17-PR-MAILBOX-DESIGN.md),
-  [#192](https://github.com/drawmeanelephant/solipsist/issues/192).
+  [#192](https://github.com/drawmeanelephant/solipsist/issues/192)).
 - Content-audit mailbox (`boris-content-audit`)
 - Source-RAG export for AI assist
 - `validate --watch` once A5 exists (replaces save-triggered one-shots)
@@ -156,7 +156,7 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M14** Watch contract | ✅ A1 `--watch-json` + letter SSE ([#143](https://github.com/drawmeanelephant/solipsist/issues/143); #147/#148 → PRs #157/#158) |
 | **M15** GitHub source | ✅ OAuth device flow + `SourceKind.github` payload, working copy, Remote mailbox Sync, sign-out ([#179](https://github.com/drawmeanelephant/solipsist/issues/179); PRs #180–#184) |
 | **M16** Write the remote | ✅ commit / push / PR authoring / issues mailbox ([#185](https://github.com/drawmeanelephant/solipsist/issues/185); PRs #187–#190) |
-| **M17** Pull Requests mailbox | filed — the deferred "Later" item: `/pulls` list + github-only mailbox ([#192](https://github.com/drawmeanelephant/solipsist/issues/192); design [`M17-PR-MAILBOX-DESIGN.md`](M17-PR-MAILBOX-DESIGN.md)) |
+| **M17** Pull Requests mailbox | ✅ `/pulls` list seam + github-only `pulls` mailbox + authoring entry ([#192](https://github.com/drawmeanelephant/solipsist/issues/192); PRs #194–#196) |
 
 **Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
 batch then landed: first-run and problem→page (#88/#94), graph filter /
@@ -610,20 +610,16 @@ here, it is not a v1 promise.
 ## 8. Pickup (what to do next)
 
 M10–M14, the post-ship batch (#165/#166/#167), **M15** (GitHub
-source, PRs #180–#184), and **M16** (remote write verbs — commit /
-push / PR authoring / issues mailbox, PRs #187–#190) all landed.
-Next **product** slice is M17, the Pull Requests mailbox — design
-[`docs/M17-PR-MAILBOX-DESIGN.md`](M17-PR-MAILBOX-DESIGN.md).
-Remaining **ship** stays Apple-account only: notarization (#110) then
-the clean-Mac proof (#111).
+source, PRs #180–#184), **M16** (remote write verbs — commit /
+push / PR authoring / issues mailbox, PRs #187–#190), and **M17**
+(the Pull Requests mailbox, PRs #194–#196) all landed. Remaining is
+**ship**, Apple-account only: notarization (#110) then the clean-Mac
+proof (#111).
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
-| 1 | M17-1 PR list | [#192](https://github.com/drawmeanelephant/solipsist/issues/192) | the deferred "Later" item; M16 shipped every seam (`/pulls` URL, bearer-`get`, `issues` mailbox pattern) — the list seam is the first slice. |
-| 2 | M17-2 PR mailbox | #192 | after M17-1 — the github-only `pulls` surface, sibling of M16-4. |
-| 3 | M17-3 Authoring entry | #192 | after M17-2 — extract the M16-3 sheet so the mailbox can create PRs. |
-| 4 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. |
-| 5 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
+| 1 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. |
+| 2 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
 
 ### Landed depth (do not redo)
 
@@ -652,7 +648,7 @@ Out of v1 (unchanged): migration labs, Wasm in the app,
 `validate --watch` until A5 + pin. Clone-as-local is M12 / #131.
 GitHub source is M15 (landed); its remote *write* verbs are M16
 (landed — commit / push / PR authoring / issues mailbox, PRs
-#187–#190). A Pull Requests mailbox is M17 (#192, filed).
+#187–#190). A Pull Requests mailbox is M17 (landed, PRs #194–#196).
 Compose **depth** (diagnostics, bundle `oliver`) stays Later; the
 M10 compose window is #106 / #108.
 

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -147,20 +147,16 @@ Landed — PRs #187 (commit) · #188 (push) · #189 (PR authoring) ·
 | [M16-3 PR](M16-pr.md) | #185 | ✅ |
 | [M16-4 Issues](M16-issues.md) | #185 | ✅ |
 
-## M17 — Pull Requests mailbox (pickable)
+## M17 — Pull Requests mailbox ✅
 
-The ROADMAP §3 "Later" remainder of the GitHub-source deferral — a
-dedicated PR mailbox (the issues mailbox filters PRs out of the REST
-list; this mailbox uses `/pulls`, the proper source, and is the read
-sibling of M16-4). Design gate:
-[`docs/M17-PR-MAILBOX-DESIGN.md`](../M17-PR-MAILBOX-DESIGN.md).
-One slice per worktree/PR.
+Landed — PRs #194 (PR list) · #195 (mailbox surface) · #196 (authoring
+entry). Do not pick.
 
-| Card | Issue | Lane | Parallel with | Gate |
-|------|-------|------|----------------|------|
-| [M17-1 PR list](M17-pr-list.md) | [#192](https://github.com/drawmeanelephant/solipsist/issues/192) | workspace | — | `GithubPullRequest` model + `listPullRequests` over the bearer-`get` seam; `state=open` default |
-| [M17-2 PR mailbox](M17-pr-mailbox.md) | #192 | workspace / play | after M17-1 | `pulls` github-only token + rows → browser, draft badge, empty state |
-| [M17-3 Authoring entry](M17-pr-authoring.md) | #192 | play | after M17-2 | extract the M16-3 sheet; toolbar entry on the mailbox; Remote flow unchanged |
+| Card | Issue | Fate |
+|------|-------|------|
+| [M17-1 PR list](M17-pr-list.md) | [#192](https://github.com/drawmeanelephant/solipsist/issues/192) | ✅ |
+| [M17-2 PR mailbox](M17-pr-mailbox.md) | #192 | ✅ |
+| [M17-3 Authoring entry](M17-pr-authoring.md) | #192 | ✅ |
 
 ## Do not start yet
 


### PR DESCRIPTION
## Mark M17 done on the board

M17 (the deferred "Later" Pull Requests mailbox) fully landed with **PRs #194 (PR list) · #195 (mailbox surface) · #196 (authoring entry)** — completion summary posted on [#192](https://github.com/drawmeanelephant/solipsist/issues/192).

Docs-only, following the M16 lane-done pattern:

- **`docs/cards/README.md`** — M17 section flipped from "(pickable)" to **✅** with the three cards and their PRs, "Do not pick."
- **`docs/ROADMAP.md`** — milestone table M17 row → ✅ (PRs #194–#196); the GitHub bullet now says the PR mailbox *landed* as M17; §8 Pickup is trimmed back to the only remaining work (Notarize #110 → Proof #111, both Apple-account/operator); the CLI-vs-app mention updated.
- **`docs/M17-PR-MAILBOX-DESIGN.md`** — status line: design gate → landed.

No code. The GitHub-source story (M15 identity, M16 write verbs, M17 PR mailbox) is complete; the board has no pickable product card left — only the Apple-account ship work.
