### PR TITLE
feat(engine): A5 validate --watch daemon — live problems without a one-shot subprocess (#161)

### DIFF
--- a/Sources/App/Coordinator.swift
+++ b/Sources/App/Coordinator.swift
@@ -24,6 +24,11 @@ final class Coordinator {
     private var watchdogTask: Task<Void, Never>?
     private var debounceTask: Task<Void, Never>?
     private weak var activeWatch: WatchServer?
+    /// The A5 problems daemon (#161), one per selected source (bound-root
+    /// rule: a foreign root is idle, never consumed). Sibling of the
+    /// preview watch — never a third watch.
+    private weak var activeValidateWatch: ValidateWatch?
+    private var validateWatchSourceID: SourceID?
     private var watchSuspends = 0
     private var saveGate = SaveValidateGate()
     @ObservationIgnored
@@ -117,7 +122,108 @@ final class Coordinator {
         saveWatcher.start(path: root.path)
     }
 
+    /// Start / stop the A5 problems daemon for the selected source (bound
+    /// root: idempotent for the same root, SIGTERM on switch, never consume
+    /// a foreign root). Runs alongside the save watcher; the daemon's own
+    /// debounce retires the one-shot save-validate while it is live.
+    func syncValidateWatch(store: WorkspaceStore, runtime: AppRuntime) {
+        let folder: (any PlayFolderSource)?
+        switch store.selectedSource {
+        case .local(let source): folder = source
+        case .github(let source): folder = source
+        case nil: folder = nil
+        }
+        guard let folder, folder.isAvailable,
+              let root = try? folder.contentRoot(),
+              FileManager.default.fileExists(atPath: root.path),
+              let engine = runtime.engine
+        else {
+            stopValidateWatch()
+            return
+        }
+        if validateWatchSourceID == folder.id, let watch = activeValidateWatch, watch.isRunning {
+            return
+        }
+        stopValidateWatch()
+        validateWatchSourceID = folder.id
+        do {
+            let watch = try engine.validateStart(
+                contentRoot: root,
+                workingDirectory: try folder.workspaceRoot()
+            )
+            activeValidateWatch = watch
+            watch.onBuild = { [weak self] outcome in
+                Task { @MainActor in self?.handleValidateBuild(outcome) }
+            }
+            watch.onProblem = { [weak self] message in
+                Task { @MainActor in self?.handleValidateProblem(message) }
+            }
+            watch.onExit = { [weak self] exit in
+                Task { @MainActor in self?.handleValidateExit(watch, exit) }
+            }
+        } catch {
+            validateWatchSourceID = nil
+            problems = CoordinatorProblems.fromFailure(
+                code: "validate-watch",
+                message: "could not start the validation daemon: \(error)"
+            )
+        }
+    }
+
+    private func stopValidateWatch() {
+        guard let watch = activeValidateWatch else {
+            validateWatchSourceID = nil
+            return
+        }
+        watch.onBuild = nil
+        watch.onProblem = nil
+        watch.onExit = nil
+        watch.stop()
+        activeValidateWatch = nil
+        validateWatchSourceID = nil
+    }
+
+    /// The daemon's build cycles drive the problems pane: `.failed`
+    /// replaces the problems with the stream's diagnostics (mapped by the
+    /// existing check-report path), `.succeeded` clears them.
+    private func handleValidateBuild(_ outcome: WatchBuildOutcome) {
+        switch outcome {
+        case .failed(let diagnostics):
+            problems = diagnostics.map(CoordinatorProblems.from(diagnostic:))
+        case .succeeded:
+            problems = []
+        }
+    }
+
+    /// `watch-error` / unexpected `watch-stopped` surface as a problem,
+    /// never swallowed (D11 — same rule as the preview watch).
+    private func handleValidateProblem(_ message: String) {
+        problems = CoordinatorProblems.fromFailure(code: "validate-watch", message: message)
+    }
+
+    /// Only spontaneous exits land here (callbacks are cleared before our
+    /// own `stop()`). A non-zero exit surfaces, never swallowed.
+    private func handleValidateExit(_ watch: ValidateWatch, _ exit: WatchExit) {
+        guard activeValidateWatch === watch else { return }
+        activeValidateWatch = nil
+        validateWatchSourceID = nil
+        if exit.exitCode != 0 {
+            let tail = exit.stderrTail.trimmingCharacters(in: .whitespacesAndNewlines)
+            let suffix = tail.isEmpty ? "" : " — \(tail.suffix(200))"
+            problems = CoordinatorProblems.fromFailure(
+                code: "validate-watch",
+                message: "validation daemon exited (\(exit.exitCode))\(suffix)"
+            )
+        }
+    }
+
     func noteSave() {
+        // While the A5 daemon is live, boris owns the debounce and `changed`
+        // gives per-save attribution — the one-shot save-validate retires.
+        if let watch = activeValidateWatch, watch.isRunning {
+            saveGate.dropAll()
+            return
+        }
         if saveGate.noteSave(now: .now, state: state) == .armDebounce {
             armDebounce()
         }
@@ -131,6 +237,7 @@ final class Coordinator {
         watchdogTask = nil
         saveWatcher.stop()
         watchingSourceID = nil
+        stopValidateWatch()
         if state != .terminating {
             stop(runtime: runtime)
         }

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -33,9 +33,11 @@ struct MainWindow: View {
         }
         .onAppear {
             runtime.coordinator.syncSaveWatch(store: store, runtime: runtime)
+            runtime.coordinator.syncValidateWatch(store: store, runtime: runtime)
         }
         .onChange(of: store.selection.sourceID) {
             runtime.coordinator.syncSaveWatch(store: store, runtime: runtime)
+            runtime.coordinator.syncValidateWatch(store: store, runtime: runtime)
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             statusBar

--- a/Sources/Engine/BorisEngine.swift
+++ b/Sources/Engine/BorisEngine.swift
@@ -551,6 +551,28 @@ public actor BorisEngine {
         return server
     }
 
+    // MARK: Validate watch (A5 / #161)
+
+    /// Starts `boris validate --watch --watch-json` for `contentRoot` and
+    /// returns the live problems daemon. `workingDirectory` is the project
+    /// folder (D1). Validate writes nothing, so the daemon is a sibling of
+    /// the preview watch — never a third watch — and needs no tree-write
+    /// suspend. The caller owns the lifetime — call `stop()` (SIGTERM →
+    /// graceful exit 0, A12) when done. `nonisolated`: reads only the
+    /// immutable `binaryURL`.
+    public nonisolated func validateStart(
+        contentRoot: URL,
+        workingDirectory: URL
+    ) throws -> ValidateWatch {
+        let watch = ValidateWatch(
+            binary: binaryURL,
+            contentRoot: contentRoot,
+            workingDirectory: workingDirectory
+        )
+        try watch.start()
+        return watch
+    }
+
     // MARK: Editor (M6)
 
     /// Starts `boris-editor` for the project at `workingDirectory` (A14).

--- a/Sources/Engine/ValidateWatch.swift
+++ b/Sources/Engine/ValidateWatch.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// The A5 live-problems daemon (#161 / boris#647): a long-lived
+/// `boris validate --watch --watch-json` subprocess, sibling of the M4
+/// preview `WatchServer` (never a third watch — one HTML watch for
+/// preview, one validate watch for problems).
+///
+/// Runs `boris validate --watch --watch-json --input <contentRoot>` with
+/// `cwd = workingDirectory` (D1: workspace-relative layouts/themes
+/// resolve), stderr → NDJSON. No `--serve` (no helper URL), no output
+/// flags, no `--report` (stream-only — the app already has the A1
+/// parser). Validate writes nothing, so the daemon never needs the
+/// tree-write suspend/resume the preview watch does.
+///
+/// The stream is the A1 protocol with `mode: "validate"` (probed at
+/// `bf464a0`): `hello` (schema 1) → `build-started` →
+/// `build-succeeded` / `build-failed` (with the `html-build-report`
+/// `diagnostics` shape) → `watcher-started`; rebuild cycles carry
+/// `changed`; SIGTERM → graceful `watch-stopped reason:"signal"`, exit 0
+/// (A12).
+///
+/// `onBuild` fires per build cycle with the structured outcome
+/// (handshake-gated by the parser, D8); `onProblem` fires for
+/// `watch-error` / unexpected `watch-stopped`; `onExit` fires exactly
+/// once when the process ends. Callbacks run on an arbitrary background
+/// thread — hop to the main actor before touching UI. One-shot: after
+/// `stop()` or a spontaneous exit it cannot be restarted.
+public final class ValidateWatch: @unchecked Sendable {
+    /// Fired per build cycle: `.failed(diagnostics)` replaces the pane's
+    /// problems, `.succeeded` clears them.
+    public var onBuild: ((WatchBuildOutcome) -> Void)?
+
+    /// Fired for `watch-error` / unexpected `watch-stopped` events —
+    /// problems the stream reports without ending the process.
+    public var onProblem: ((String) -> Void)?
+
+    /// Fired exactly once when the process ends (after `stop()` or on its own).
+    public var onExit: ((WatchExit) -> Void)?
+
+    private let lock = NSLock()
+    private var process: Process?
+    private let stderrPipe = Pipe()
+    private var stderrAccumulator = Data()
+    private var lineBuffer = Data()
+    private var parser = WatchStreamParser()
+    private var stderrTailText = ""
+    private var lastDeliveredOutcome: WatchBuildOutcome?
+    private var deliveredProblemCount = 0
+
+    public init(binary: URL, contentRoot: URL, workingDirectory: URL) {
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = [
+            "validate", "--watch", "--watch-json",
+            "--input", contentRoot.path,
+        ]
+        // D1: cwd = project folder; `--input` stays an explicit absolute root.
+        process.currentDirectoryURL = workingDirectory
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = stderrPipe
+        self.process = process
+    }
+
+    deinit {
+        stop()
+    }
+
+    public var isRunning: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return process?.isRunning ?? false
+    }
+
+    public var processIdentifier: Int32? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let process, process.isRunning else { return nil }
+        return process.processIdentifier
+    }
+
+    /// Launches the process. Throws `BorisRunnerError.launchFailed` when the
+    /// binary cannot be spawned.
+    public func start() throws {
+        lock.lock()
+        guard let process else {
+            lock.unlock()
+            throw BorisRunnerError.launchFailed("validate watch already stopped")
+        }
+        stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            self?.consume(data)
+        }
+        process.terminationHandler = { [weak self] process in
+            self?.finish(process)
+        }
+        lock.unlock()
+
+        do {
+            try process.run()
+        } catch {
+            lock.lock()
+            self.process = nil
+            lock.unlock()
+            throw BorisRunnerError.launchFailed(String(describing: error))
+        }
+    }
+
+    /// SIGTERM the daemon (afterparty exits 0 gracefully — A12). Cannot be
+    /// restarted; create a new `ValidateWatch` instead.
+    public func stop() {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        guard let process, process.isRunning else { return }
+        process.terminate()
+    }
+
+    /// SIGKILL if SIGTERM was ignored.
+    public func forceKill() {
+        lock.lock()
+        let pid = process?.isRunning == true ? process?.processIdentifier : nil
+        lock.unlock()
+        guard let pid else { return }
+        ChildProcessControl.forceKill(pid: pid)
+    }
+
+    // MARK: stderr streaming
+
+    private func consume(_ data: Data) {
+        lock.lock()
+        stderrAccumulator.append(data)
+        // Bound the buffer: only the tail is kept for diagnostics.
+        if stderrAccumulator.count > 65_536 {
+            stderrAccumulator.removeFirst(stderrAccumulator.count - 32_768)
+        }
+        stderrTailText = String(decoding: stderrAccumulator.suffix(4_096), as: UTF8.self)
+
+        // Feed complete NDJSON lines to the parser; keep the trailing
+        // fragment for the next chunk.
+        lineBuffer.append(data)
+        while let newline = lineBuffer.firstIndex(of: 0x0A) {
+            let lineData = lineBuffer[..<newline]
+            lineBuffer.removeSubrange(...newline)
+            if let line = String(data: lineData, encoding: .utf8) {
+                parser.consume(line: line)
+            }
+        }
+
+        // Fire each *new* build outcome exactly once (first and subsequent).
+        var builds: [WatchBuildOutcome] = []
+        if let outcome = parser.buildOutcome, outcome != lastDeliveredOutcome {
+            builds.append(outcome)
+            lastDeliveredOutcome = outcome
+        }
+        var problems: [String] = []
+        if parser.problems.count > deliveredProblemCount {
+            // Build-failed summaries ride the structured `.failed(diagnostics)`
+            // channel; a string summary would overwrite the pane's
+            // diagnostics. Everything else (watch-error, watch-stopped,
+            // handshake) is delivered as a problem.
+            problems = Array(parser.problems[deliveredProblemCount...])
+                .filter { !$0.hasPrefix(WatchStreamParser.buildFailedSummaryPrefix) }
+            deliveredProblemCount = parser.problems.count
+        }
+        let buildCallback = onBuild
+        let problemCallback = onProblem
+        lock.unlock()
+
+        for build in builds {
+            buildCallback?(build)
+        }
+        for problem in problems {
+            problemCallback?(problem)
+        }
+    }
+
+    private func finish(_ process: Process) {
+        lock.lock()
+        stderrPipe.fileHandleForReading.readabilityHandler = nil
+        let exit = WatchExit(
+            exitCode: process.terminationStatus,
+            signalled: process.terminationReason == .uncaughtSignal,
+            stderrTail: stderrTailText
+        )
+        let onExit = self.onExit
+        self.process = nil
+        lock.unlock()
+        onExit?(exit)
+    }
+}

--- a/Sources/Engine/WatchEvent.swift
+++ b/Sources/Engine/WatchEvent.swift
@@ -1,15 +1,22 @@
 import Foundation
 
 /// One line of the A1 `--watch-json` NDJSON stream (boris#648; contract
-/// `docs/issues/boris-A1-watch-events.md`). The pinned kit (`6b930b7`)
-/// emits `watch_events_schema: 1`.
+/// `docs/issues/boris-A1-watch-events.md`). The pinned kit emits
+/// `watch_events_schema: 1`; the A5 `validate --watch` daemon (boris#647)
+/// reuses the same protocol with `mode: "validate"` (probed at `bf464a0`).
 ///
 /// Additive decode: unknown fields are ignored, unknown `event` values
-/// decode as `.unknown` and are skipped — never fatal (D8).
+/// decode as `.unknown` and are skipped — never fatal (D8). `build-failed`
+/// carries the same `diagnostics` array as `html-build-report-0.1.0`, so it
+/// decodes straight into `[Diagnostic]` (A5; the HTML watch ignores them —
+/// the string summary is unchanged).
 enum WatchEvent: Decodable {
     case hello(schema: Int, compiler: String?)
     case serveStarted(url: URL?, helper: URL?, port: Int?)
-    case buildFailed(errors: Int, recoverable: Bool)
+    case buildFailed(errors: Int, recoverable: Bool, diagnostics: [Diagnostic])
+    /// A clean cycle. `changed` names the files that triggered the rebuild
+    /// (per-save attribution); `pages_written` is null for validate (A5).
+    case buildSucceeded(mode: String?, changed: [String]?)
     case watchError(message: String, recoverable: Bool)
     case watchStopped(reason: String?)
     case unknown
@@ -25,6 +32,9 @@ enum WatchEvent: Decodable {
         case recoverable
         case message
         case reason
+        case mode
+        case changed
+        case diagnostics
     }
 
     init(from decoder: Decoder) throws {
@@ -44,7 +54,13 @@ enum WatchEvent: Decodable {
         case "build-failed":
             self = .buildFailed(
                 errors: try c.decodeIfPresent(Int.self, forKey: .errors) ?? 0,
-                recoverable: try c.decodeIfPresent(Bool.self, forKey: .recoverable) ?? true
+                recoverable: try c.decodeIfPresent(Bool.self, forKey: .recoverable) ?? true,
+                diagnostics: try c.decodeIfPresent([Diagnostic].self, forKey: .diagnostics) ?? []
+            )
+        case "build-succeeded":
+            self = .buildSucceeded(
+                mode: try c.decodeIfPresent(String.self, forKey: .mode),
+                changed: try c.decodeIfPresent([String].self, forKey: .changed)
             )
         case "watch-error":
             self = .watchError(
@@ -67,19 +83,44 @@ enum WatchEvent: Decodable {
     }
 }
 
+/// The last completed build cycle, for the A5 validate daemon (#161):
+/// `.succeeded` clears the problems pane, `.failed(diagnostics)` replaces
+/// it (the diagnostics decode straight from the stream — the same shape as
+/// `html-build-report-0.1.0`). The HTML watch does not use this; its string
+/// `problems` surface is unchanged. Public because `ValidateWatch`'s
+/// `onBuild` carries it.
+public enum WatchBuildOutcome: Equatable, Sendable {
+    case succeeded(changed: [String]?)
+    case failed(diagnostics: [Diagnostic])
+}
+
 /// Pure, testable consumer of the A1 NDJSON stream. `WatchServer` feeds
 /// complete lines; the parser owns the handshake gate (D8), the helper-URL
 /// emission, and problem surfacing — so the behavior is testable without a
-/// live `watch` process.
+/// live `watch` process. The A5 daemon reads the same events through
+/// `buildOutcome` (handshake-gated, D8).
 struct WatchStreamParser {
     /// The only known `watch_events_schema`. Unknown versions degrade: the
     /// stream is not trusted and problems are surfaced — no crash.
     static let supportedSchema = 1
 
+    /// Prefix of the one-line summary `build-failed` appends to `problems`.
+    /// The HTML watch surfaces the full summary as its problem string;
+    /// `ValidateWatch` skips strings with this prefix (the same event is
+    /// delivered structurally as `.failed(diagnostics)` via `buildOutcome`)
+    /// so the daemon's diagnostics never get overwritten by the summary.
+    static let buildFailedSummaryPrefix = "build failed:"
+
+    static func buildFailedSummary(errors: Int, recoverable: Bool) -> String {
+        "\(buildFailedSummaryPrefix) \(errors) error\(errors == 1 ? "" : "s")\(recoverable ? " (recoverable)" : "")"
+    }
+
     private(set) var handshake: Int?
     private(set) var serveURL: URL?
     private(set) var didServe = false
     private(set) var problems: [String] = []
+    /// Last build cycle outcome, gated on the supported handshake (D8).
+    private(set) var buildOutcome: WatchBuildOutcome?
 
     mutating func consume(line: String) {
         guard let event = WatchEvent.decode(line: line) else { return }
@@ -103,10 +144,17 @@ struct WatchStreamParser {
             }
             didServe = true
             serveURL = helperURL
-        case .buildFailed(let errors, let recoverable):
+        case .buildFailed(let errors, let recoverable, let diagnostics):
             problems.append(
-                "build failed: \(errors) error\(errors == 1 ? "" : "s")\(recoverable ? " (recoverable)" : "")"
+                Self.buildFailedSummary(errors: errors, recoverable: recoverable)
             )
+            if handshake == Self.supportedSchema {
+                buildOutcome = .failed(diagnostics: diagnostics)
+            }
+        case .buildSucceeded(let mode, let changed):
+            if handshake == Self.supportedSchema {
+                buildOutcome = .succeeded(changed: changed)
+            }
         case .watchError(let message, _):
             problems.append("watch error: \(message)")
         case .watchStopped(let reason):

--- a/Sources/Models/BorisContracts.swift
+++ b/Sources/Models/BorisContracts.swift
@@ -21,7 +21,7 @@ import Foundation
 /// A single structured diagnostic (boris/docs/contracts/diagnostics.md).
 /// Field order is normative: severity, code, message, remediation,
 /// sourcePath, line, column, id.
-public struct Diagnostic: Codable, Sendable {
+public struct Diagnostic: Codable, Equatable, Sendable {
     public var severity: String
     public var code: String
     public var message: String

--- a/Tests/ContractTests/WatchEventTests.swift
+++ b/Tests/ContractTests/WatchEventTests.swift
@@ -37,11 +37,12 @@ final class WatchEventTests: XCTestCase {
                 line: #"{"event":"build-failed","phase":"rebuild","errors":1,"recoverable":true,"duration_ms":14}"#
             )
         )
-        guard case .buildFailed(let errors, let recoverable) = failed else {
+        guard case .buildFailed(let errors, let recoverable, let diagnostics) = failed else {
             return XCTFail("expected build-failed, got \(failed)")
         }
         XCTAssertEqual(errors, 1)
         XCTAssertTrue(recoverable)
+        XCTAssertTrue(diagnostics.isEmpty, "a build-failed without a diagnostics key decodes to an empty array")
 
         let watchError = try XCTUnwrap(
             WatchEvent.decode(line: #"{"event":"watch-error","message":"poll error (BrokenPipe)","recoverable":true}"#)
@@ -125,6 +126,73 @@ final class WatchEventTests: XCTestCase {
                 "watch stopped: signal",
             ]
         )
+    }
+
+    // MARK: A5 validate --watch (boris#647, #161) — probe-shaped fixtures
+
+    func testValidateStreamBuildSucceededOutcome() {
+        // The probed A5 shape at bf464a0: mode "validate", rebuild cycles
+        // carry `changed`, build-succeeded has pages_written null.
+        var parser = WatchStreamParser()
+        parser.consume(line: #"{"event":"hello","watch_events_schema":1,"compiler":"boris/0.8.1"}"#)
+        parser.consume(line: #"{"event":"build-started","phase":"initial","mode":"validate","targets":["default"]}"#)
+        parser.consume(line: #"{"event":"build-succeeded","phase":"initial","mode":"validate","targets":["default"],"pages_written":null,"duration_ms":22}"#)
+        XCTAssertEqual(parser.buildOutcome, .succeeded(changed: nil))
+        XCTAssertTrue(parser.problems.isEmpty)
+
+        // Probe-shaped build-failed (bf464a0): full diagnostic objects with
+        // nulls, built via the json() test helper so the line stays readable.
+        let failedObject: [String: Any] = [
+            "event": "build-failed", "phase": "rebuild", "mode": "validate",
+            "changed": ["guides.md"], "errors": 2, "recoverable": true, "duration_ms": 23,
+            "diagnostics": [
+                [
+                    "severity": "error", "code": "EROUTEMISSING",
+                    "message": "does not resolve to a published output [fix the path, or publish the file it names]",
+                    "remediation": "Fix the path, or publish the file it names",
+                    "sourcePath": "guides.html", "line": 133, "column": NSNull(), "id": NSNull(),
+                ],
+            ],
+        ]
+        let failedLine = String(data: json(failedObject), encoding: .utf8) ?? ""
+        parser.consume(line: failedLine)
+        guard case .failed(let diagnostics) = parser.buildOutcome else {
+            return XCTFail("expected .failed after build-failed")
+        }
+        XCTAssertEqual(diagnostics.count, 1)
+        XCTAssertEqual(diagnostics.first?.code, "EROUTEMISSING")
+        XCTAssertEqual(diagnostics.first?.sourcePath, "guides.html")
+        XCTAssertEqual(diagnostics.first?.line, 133)
+        // The summary string still surfaces for the HTML watch — the daemon
+        // filters it structurally, the parser keeps it.
+        XCTAssertEqual(parser.problems, ["build failed: 2 errors (recoverable)"])
+
+        parser.consume(line: #"{"event":"build-succeeded","phase":"rebuild","mode":"validate","changed":["guides.md"],"pages_written":null,"duration_ms":30}"#)
+        XCTAssertEqual(parser.buildOutcome, .succeeded(changed: ["guides.md"]))
+    }
+
+    func testValidateBuildOutcomeIsHandshakeGated() {
+        // D8: a build event before a supported hello is not trusted — no
+        // outcome drives the pane.
+        var parser = WatchStreamParser()
+        parser.consume(line: #"{"event":"build-succeeded","phase":"initial","mode":"validate"}"#)
+        XCTAssertNil(parser.buildOutcome)
+        XCTAssertTrue(parser.problems.isEmpty)
+
+        // An unknown schema also gates the outcome while surfacing the
+        // schema problem.
+        parser.consume(line: #"{"event":"hello","watch_events_schema":2}"#)
+        parser.consume(line: #"{"event":"build-failed","errors":1,"recoverable":true,"diagnostics":[]}"#)
+        XCTAssertNil(parser.buildOutcome)
+        XCTAssertEqual(parser.problems.first, "watch events schema 2 is not supported (supported: 1)")
+    }
+
+    func testBuildFailedSummaryPrefixMarksOnlyBuildFailures() {
+        XCTAssertTrue(
+            WatchStreamParser.buildFailedSummary(errors: 1, recoverable: true)
+                .hasPrefix(WatchStreamParser.buildFailedSummaryPrefix)
+        )
+        XCTAssertFalse("watch error: poll error".hasPrefix(WatchStreamParser.buildFailedSummaryPrefix))
     }
 
     func testFullFixtureStreamServesOnce() {

--- a/docs/ENGINE-CONTRACTS.md
+++ b/docs/ENGINE-CONTRACTS.md
@@ -84,30 +84,38 @@ data: 1
 
 ### `validate --watch` (A5) — live problems daemon (design for #161)
 
-**Status: carried by the pin** — [boris#647](https://github.com/drawmeanelephant/boris/issues/647)
-(`docs/issues/boris-A5-check-watch-rfc.md`) merged upstream (boris#651)
-and present in the pinned kit (`bf464a0`). This subsection is the
-Solipsist consumption design so
-[#161](https://github.com/drawmeanelephant/solipsist/issues/161) is
-pickable. **Nothing here is probed yet** — re-probe the RFC's claims
-before trusting a single line.
+**Status: carried + probed (2026-08-19)** — [boris#647](https://github.com/drawmeanelephant/boris/issues/647)
+(`docs/issues/boris-A5-check-watch-rfc.md`) merged upstream (boris#651),
+present in the pinned kit (`bf464a0`), and every claim below verified
+live against that binary (initial + rebuild cycles, error cycle,
+graceful SIGTERM). Implemented as [#161](https://github.com/drawmeanelephant/solipsist/issues/161)
+(`ValidateWatch` + decoder + coordinator + save-gate retirement).
 
-**The contract (from the RFC).** `boris validate --watch [--input DIR]
-[--report PATH]` joins the artifact-free preflight with the watch
-daemon: same debounce (100ms) / coalescing (2s cap) / ignore rules /
-signal handlers as HTML watch, but the rebuild action is `validate`
-instead of the HTML publish. Writes nothing but the optional report
-file (replaced every cycle, never appended). Output flags are rejected
-(exit 2). SIGTERM/SIGINT → graceful exit 0 (A12). When A1 is present it
-consumes the same NDJSON protocol with `mode: "validate"`:
+**The contract (probed at `bf464a0`).** `boris validate --watch [--input
+DIR] [--report PATH]` joins the artifact-free preflight with the watch
+daemon: same debounce / coalescing / ignore rules / signal handlers as
+HTML watch, but the rebuild action is `validate` instead of the HTML
+publish. Writes nothing but the optional report file (replaced every
+cycle, never appended). Output flags are rejected (exit 2).
+SIGTERM/SIGINT → graceful exit 0, `watch-stopped reason:"signal"` (A12).
+Consumes the same NDJSON protocol with `mode: "validate"` (events on
+**stderr**, same `hello` handshake at `watch_events_schema: 1`):
 
 ```
 {"event":"hello","watch_events_schema":1,"compiler":"boris/0.8.1"}
-{"event":"build-started","phase":"initial","mode":"validate"}
-{"event":"build-succeeded","phase":"initial","mode":"validate","errors":0}
-{"event":"build-failed","phase":"rebuild","mode":"validate","changed":["guides/overview.md"],"errors":1,"diagnostics":[{"severity":"error","code":"EFRONTMATTER","message":"…","remediation":"","sourcePath":"guides/overview.md","line":2,"column":1,"id":null}]}
+{"event":"build-started","phase":"initial","mode":"validate","targets":["default"]}
+{"event":"build-succeeded","phase":"initial","mode":"validate","targets":["default"],"pages_written":null,"duration_ms":22}
+{"event":"build-failed","phase":"rebuild","mode":"validate","changed":["guides.md"],"errors":2,"diagnostics":[{"severity":"error","code":"EROUTEMISSING","message":"does not resolve to a published output [fix the path, or publish the file it names]","remediation":"Fix the path, or publish the file it names","sourcePath":"guides.html","line":133,"column":null,"id":null}],"recoverable":true,"duration_ms":23}
+{"event":"watcher-started","mode":"validate","targets":["default"]}
 {"event":"watch-stopped","reason":"signal"}
 ```
+
+Probe corrections vs the RFC draft: `build-succeeded` carries
+`pages_written: null` (validate writes nothing) and **no** `errors`
+key; rebuild cycles carry `changed`; `build-failed` diagnostics are
+the `html-build-report-0.1.0` shape with `recoverable`; the daemon
+keeps watching after a failed build. The consumption design below
+holds as written.
 
 **Consumption design (pickable when the pin carries A5).**
 


### PR DESCRIPTION
## feat(engine): A5 `validate --watch` daemon — live problems, no one-shot subprocess (#161)

Consumes boris#647 (`validate --watch`) now that the pin (`bf464a0`, #198) carries it — per the `ENGINE-CONTRACTS.md` §1 consumption design, **confirmed by a live probe of the real binary** before a line of code (initial + rebuild cycles, an error cycle with diagnostics, graceful SIGTERM).

### What ships

- **`ValidateWatch`** (`Sources/Engine/`, new) — long-lived `validate --watch --watch-json --input <contentRoot>` subprocess (cwd = project folder, D1), the sibling of the preview watch (**never a third watch**); no `--serve`/`--report` (stream-only — the app already has the A1 parser). One-shot SIGTERM lifecycle (A12 graceful exit 0). Structured `onBuild` (`.succeeded` clears the pane / `.failed(diagnostics)` replaces it), `onProblem` for `watch-error`/`watch-stopped`, `onExit` — all hopped to the main actor by the coordinator.
- **Decoder** — `WatchEvent` gains `buildSucceeded` (was `.unknown`-skipped) and `build-failed` **diagnostics** decoding straight into `[Diagnostic]` (the `html-build-report-0.1.0` shape); `WatchStreamParser` gains a **handshake-gated** `buildOutcome` (D8 — a build event before a supported `hello` never drives the pane). The HTML watch's string `problems` surface is unchanged. Build-failed summaries ride the structured channel for the daemon (documented prefix), so the pane's diagnostics are never overwritten by the one-line summary.
- **Coordinator** — `syncValidateWatch` bound to the selected source (idempotent per root, SIGTERM on switch, never consume a foreign root), wired in `MainWindow` beside the save watcher. `build-failed` → problems replaced via the existing `CoordinatorProblems.from(diagnostic:)`; `build-succeeded` → cleared; `watch-error`/unexpected exit surfaced (D11). **`SaveValidateGate` retires the save-triggered one-shot while the daemon is live** — boris owns the debounce and `changed` gives per-save attribution; the manual Validate verb and `check` are unchanged.
- `Diagnostic` gains `Equatable` (needed for the daemon's outcome-delta tracking).

### Probe facts recorded in `ENGINE-CONTRACTS.md` §1

The RFC draft's `build-succeeded` example showed `errors:0`; the real stream has `pages_written: null` and no `errors` key; rebuild cycles carry `changed`; the daemon keeps watching after a failed build (`recoverable: true`). The consumption design held as written.

### Gates

- Build ✅ · **348 tests, 0 failures** (3 new: probe-shaped validate-mode stream — outcome transitions incl. the `changed`-carrying rebuild and diagnostics decode; handshake gating; summary-prefix marking) ✅ · `make lint` 0 violations ✅ · spike ✅. No live `validate --watch` in CI (parser fixtures only, per the design gate).
