### PR TITLE
docs(roadmap): mark A5 validate --watch (#161) shipped

### DIFF
--- a/docs/ENGINE-CONTRACTS.md
+++ b/docs/ENGINE-CONTRACTS.md
@@ -82,7 +82,7 @@ data: 1
 - Prefer `--port 0` + stderr-line discovery over fixed ports (no collisions).
 - Graceful teardown: SIGTERM → exit 0, cleanup message (A12).
 
-### `validate --watch` (A5) — live problems daemon (design for #161)
+### `validate --watch` (A5) — live problems daemon (#161, landed)
 
 **Status: carried + probed (2026-08-19)** — [boris#647](https://github.com/drawmeanelephant/boris/issues/647)
 (`docs/issues/boris-A5-check-watch-rfc.md`) merged upstream (boris#651),
@@ -117,7 +117,7 @@ the `html-build-report-0.1.0` shape with `recoverable`; the daemon
 keeps watching after a failed build. The consumption design below
 holds as written.
 
-**Consumption design (pickable when the pin carries A5).**
+**Consumption design (landed — #161, PR #199).**
 
 - **Engine** — a `ValidateWatch` long-lived process mirroring
   `WatchServer`'s argv discipline: `validate --watch --watch-json

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,8 +36,9 @@ recut to the diagram above. Spatial detail: [`HARNESS.md`](HARNESS.md).
 **Engine baseline:** afterparty `boris/0.8.1`. **Pinned kit:** `bf464a0`
 (`bf464a02883d1dce1d9f990739183c248e68c5c3`). Contains A1/A14/A7 +
 A3/A4/A13 (boris#648 / #643 / #642 / #641) **plus A15 `open=`
-(boris#649) and A5 `validate --watch` (boris#647)** — #160/#161 are
-now pin-carrying, not upstream-blocked.
+(boris#649) and A5 `validate --watch` (boris#647)** — both consumed:
+#160 (A15 `open=`) and #161 (A5 live problems daemon) shipped
+(PRs #198/#199).
 
 ---
 
@@ -127,7 +128,8 @@ No scraped prose. No homegrown graph. No third settings store.
   [#192](https://github.com/drawmeanelephant/solipsist/issues/192)).
 - Content-audit mailbox (`boris-content-audit`)
 - Source-RAG export for AI assist
-- `validate --watch` once A5 exists (replaces save-triggered one-shots)
+- `validate --watch` (A5) — landed as #161 (PR #199): the live
+  problems daemon replaces save-triggered one-shots.
 - Cooklang recipe-scale as a first-class mailbox (v1: available from
   the page inspector when the corpus has recipes)
 - Width-adaptive list-left-of-letter split (M10 default is stacked)
@@ -545,9 +547,10 @@ SSE). Tracker
 [#143](https://github.com/drawmeanelephant/solipsist/issues/143);
 children #147 / #148. Cards in [`cards/`](cards/README.md).
 
-**Not this milestone.** A5 `validate --watch`. A15 `open=` (app
-already appends it; pin-follow). A second `Process`. Growing
-`WatchServer` argv on the letter card.
+**Not this milestone.** A5 `validate --watch` (landed later: #161 →
+PR #199). A15 `open=` (app already appends it; landed with the pin —
+#160 → PR #198). A second `Process`. Growing `WatchServer` argv on
+the letter card.
 
 Landed 2026-08-18 (#143; #147 → PR #157, #148 → PR #158). Live
 gate: Preview starts with `--watch-json`, the helper URL comes
@@ -567,7 +570,7 @@ here, it is not a v1 promise.
 | Closed frontmatter | M3, M6 | Inspector from `completion.json`; editor owns the buffer |
 | Trunk/Satellite graph, wiki-links, includes, relations | M3, M13 | Play list from `graph.json`; M13 trunks as Pages folders |
 | HTML + layouts + theme catalog | M4, M7 | Build target; theme picker |
-| `validate` | M4 | Save-triggered problems; A5 later |
+| `validate` | M4 | Save-triggered problems; A5 live daemon landed (#161, PR #199) |
 | `watch --serve` + SSE | M5, M10, M14 | Preview companion; M10 reading pane reuses the same session; M14 letter listens to SSE |
 | `--watch-json` (A1) | M14 | Replaces port regex + watch prose. Pin already contains it. |
 | `plan --profile` | M4, M8 | Settings lint; publish prelude |
@@ -645,8 +648,9 @@ Named in this file and **not** a product surface yet: browser OAuth,
 `github-pages-audit`, A1 `--watch-json` (M14), trunk mailbox
 folders (M13).
 
-Out of v1 (unchanged): migration labs, Wasm in the app,
-`validate --watch` until A5 + pin. Clone-as-local is M12 / #131.
+Out of v1 (unchanged): migration labs, Wasm in the app.
+Clone-as-local is M12 / #131. `validate --watch` (A5) is in v1 now —
+the live problems daemon landed (#161, PR #199).
 GitHub source is M15 (landed); its remote *write* verbs are M16
 (landed — commit / push / PR authoring / issues mailbox, PRs
 #187–#190). A Pull Requests mailbox is M17 (landed, PRs #194–#196).

--- a/docs/cards/M14-watch-contract.md
+++ b/docs/cards/M14-watch-contract.md
@@ -28,7 +28,7 @@ Engine is single-owner. M14-2 starts after M14-1.
 
 ## Not this tracker
 
-- A5 `validate --watch` (boris#647, still open)
+- A5 `validate --watch` (boris#647 → shipped as #161 / PR #199)
 - A15 `open=` (app already appends it; pin-follow)
 - A second `Process` or a second watch session
 - M13 trunk folders

--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -75,9 +75,9 @@ the agent-pack, `plan --out`.
 New work lives in the [delegation queue](../queue/README.md) — batch 2
 is landed and the queue is empty. M12 clone (#131), M13 graph folders
 (#142), and M14 watch contract (#143) all landed and closed. Apple-
-account ship (#110 / #111) is operator, not this lane. Two low-priority
-pin-follow trackers are filed for the named follow-ups: #160 (A15
-`open=`, boris#649) and #161 (A5 `validate --watch`, boris#647).
+account ship (#110 / #111) is operator, not this lane. The two
+pin-follow trackers are now shipped: #160 (A15 `open=`, boris#649)
+and #161 (A5 `validate --watch`, boris#647).
 
 Skip: fart app (`make fart` must keep failing). Skip GitHub-as-source.
 Skip publication flows. Skip Wasm in the app.

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -72,8 +72,7 @@ queue cards.
 The depth batch (#88–#91) landed. M9 (#78), M10 (#98), M11
 (#123), M12 (#131), M13 (#142), and M14 (#143) all landed and
 closed. Remaining ship is Apple-account only (#110 / #111) — not
-this queue. Two low-priority pin-follow trackers are filed for the
-named-but-untracked follow-ups: [#160](https://github.com/drawmeanelephant/solipsist/issues/160)
+this queue. The two pin-follow trackers are now shipped: [#160](https://github.com/drawmeanelephant/solipsist/issues/160)
 (A15 `open=`, boris#649) and [#161](https://github.com/drawmeanelephant/solipsist/issues/161)
 (A5 `validate --watch`, boris#647). The queue stays empty unless
 someone cuts a docs-only or `Tests/`-only slice.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -11,8 +11,8 @@ PR against boris from this repo.
 - A1 [boris#644](https://github.com/drawmeanelephant/boris/issues/644) → [#648](https://github.com/drawmeanelephant/boris/pull/648)
 - A14 [boris#645](https://github.com/drawmeanelephant/boris/issues/645) → [#648](https://github.com/drawmeanelephant/boris/pull/648)
 - A7 [boris#646](https://github.com/drawmeanelephant/boris/issues/646) → [#648](https://github.com/drawmeanelephant/boris/pull/648)
-- A15 [boris#649](https://github.com/drawmeanelephant/boris/issues/649) → [#650](https://github.com/drawmeanelephant/boris/pull/650) — optional `#token=…&open=<project-relative path>` fragment; the shell opens that author-owned file on launch (UI-only; the host still prints the token-only launch line). Solipsist's `EditorURL.opening` already appends `open=` from `sourcePath` — #160 is verify-only.
-- A5 [boris#647](https://github.com/drawmeanelephant/boris/issues/647) → [#651](https://github.com/drawmeanelephant/boris/pull/651) — zero-write validation daemon under `validate --watch` (the RFC merged). Consumption design: [`docs/ENGINE-CONTRACTS.md`](../ENGINE-CONTRACTS.md) §1 (unprobed — re-probe before trusting).
+- A15 [boris#649](https://github.com/drawmeanelephant/boris/issues/649) → [#650](https://github.com/drawmeanelephant/boris/pull/650) — optional `#token=…&open=<project-relative path>` fragment; the shell opens that author-owned file on launch (UI-only; the host still prints the token-only launch line). Solipsist's `EditorURL.opening` already appends `open=` from `sourcePath` — #160 verified and closed (PR #198).
+- A5 [boris#647](https://github.com/drawmeanelephant/boris/issues/647) → [#651](https://github.com/drawmeanelephant/boris/pull/651) — zero-write validation daemon under `validate --watch` (the RFC merged). Consumed as [#161](https://github.com/drawmeanelephant/solipsist/issues/161) (PR [#199](https://github.com/drawmeanelephant/solipsist/pull/199)); the contract is probed and recorded in [`docs/ENGINE-CONTRACTS.md`](../ENGINE-CONTRACTS.md) §1.
 
 **Filed (2026-08-18):**
 


### PR DESCRIPTION
## What

Docs-only. Flips the board for the A5 `validate --watch` thread — **#161 shipped via PR #199** — and tidies the now-stale "Later" mentions of it.

## Changed

- `docs/ROADMAP.md` — engine-baseline note (#160/#161 now *shipped*, not just pin-carrying); the §3 "Later" line for `validate --watch` becomes a landed note; M14 "Not this milestone" and the capability table's "A5 later" updated; the "Out of v1" line drops `validate --watch until A5 + pin`.
- `docs/ENGINE-CONTRACTS.md` §1 — section title and the "pickable when the pin carries A5" header become "landed (#161, PR #199)".
- `docs/issues/README.md` — A5 now "Consumed as #161 (PR #199); probed + recorded in §1"; A15's "#160 is verify-only" becomes "verified and closed (PR #198)".
- `docs/cards/M14-watch-contract.md` — "Not this tracker" A5 line (boris#647 "still open") → shipped.
- `docs/cards/queue/README.md` + `docs/cards/parallel/README.md` — the two "low-priority pin-follow trackers" (#160/#161) are now shipped.

## Guarantees

No code, no behavior change. Pure board/docs hygiene; #160/#161 both already closed upstream of this.
