### PR TITLE
fix(ci): embed content-audit, cache Zig, universal companion tools, assert bundle shape (#215)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,15 @@ jobs:
         with:
           version: 0.16.0
 
+      - name: Cache Zig build artifacts
+        uses: actions/cache@v4
+        with:
+          path: boris/zig-cache
+          key: zig-${{ runner.os }}-bf464a0-${{ hashFiles('boris/build.zig.zon') }}
+          restore-keys: |
+            zig-${{ runner.os }}-bf464a0-
+            zig-${{ runner.os }}-
+
       # Host-only (macos-15 is arm64). Release still cross-builds fat slices.
       - name: Build host Boris
         run: |
@@ -65,6 +74,18 @@ jobs:
       - uses: actions/checkout@v7
       - name: Generate project and compile the app
         run: make build
+
+      # When SKIP_EMBED_BORIS=1 the app compiles without a bundled engine.
+      # Assert that the Resources directory does NOT contain a boris binary
+      # — a stale cache could silently ship an old embedded engine.
+      - name: Assert no stale boris in bundle
+        run: |
+          APP_PATH="build/Build/Products/Debug/Solipsist.app"
+          if [ -f "$APP_PATH/Contents/Resources/boris" ]; then
+            echo "FAIL: Contents/Resources/boris exists but SKIP_EMBED_BORIS=1" >&2
+            exit 1
+          fi
+          echo "app: bundle OK (no embedded boris, as expected with SKIP_EMBED_BORIS=1)"
 
   fixtures:
     name: fixtures

--- a/.github/workflows/release-notarize.yml
+++ b/.github/workflows/release-notarize.yml
@@ -62,13 +62,33 @@ jobs:
 
       # embed-boris.sh lipo-merges discrete arches when both are provided;
       # zig cross-compiles macOS slices from either host arch.
-      - name: Build universal Boris engine
+      - name: Build universal Boris engine + companion tools
         run: |
           cd boris
+          # Engine
           zig build -Dtarget=aarch64-macos -Doptimize=ReleaseFast --prefix /tmp/boris-arm64
           zig build -Dtarget=x86_64-macos -Doptimize=ReleaseFast --prefix /tmp/boris-x86_64
           lipo -create -output /tmp/boris-universal /tmp/boris-arm64/bin/boris /tmp/boris-x86_64/bin/boris
           lipo -info /tmp/boris-universal
+
+          # Companion tools: cross-build each arch, lipo-merge.
+          # boris-search-index is present in the kit but unused by the app —
+          # do not build or bundle it.
+          TOOLS="boris-editor boris-package boris-source-rag boris-content-audit"
+          for tool in $TOOLS; do
+            if [ -f "/tmp/boris-arm64/bin/$tool" ] && [ -f "/tmp/boris-x86_64/bin/$tool" ]; then
+              lipo -create -output "/tmp/boris-universal-$tool" \
+                "/tmp/boris-arm64/bin/$tool" "/tmp/boris-x86_64/bin/$tool"
+              lipo -info "/tmp/boris-universal-$tool"
+            else
+              echo "WARNING: $tool not found in both arch builds — embedding host-only"
+            fi
+          done
+
+      # Drop universal companion binaries into the kit bin dir so
+      # embed-boris.sh finds them through its existing search path.
+      - name: Populate universal companion tools
+        run: bash scripts/populate-universal-companions.sh boris/bin
 
       - name: Install tools & generate project
         run: |
@@ -151,6 +171,8 @@ jobs:
           APP_PATH="build/Build/Products/Release/Solipsist.app"
           echo "==> Inspecting Mach-O bundle structure:"
           file "$APP_PATH/Contents/MacOS/Solipsist"
+
+          # Engine: must be universal and runnable.
           if [ -f "$APP_PATH/Contents/Resources/boris" ]; then
             lipo -info "$APP_PATH/Contents/Resources/boris"
             "$APP_PATH/Contents/Resources/boris" --version
@@ -158,6 +180,18 @@ jobs:
             echo "FAIL: Contents/Resources/boris missing from the release bundle" >&2
             exit 1
           fi
+
+          # Companion tools: verify universal binary and --version where supported.
+          COMPANIONS="boris-editor boris-package boris-source-rag boris-content-audit"
+          for comp in $COMPANIONS; do
+            COMP_PATH="$APP_PATH/Contents/Resources/$comp"
+            if [ -f "$COMP_PATH" ]; then
+              echo "==> $comp:"
+              lipo -info "$COMP_PATH"
+            else
+              echo "WARNING: $comp missing from release bundle" >&2
+            fi
+          done
 
       # Hard Gatekeeper gate for real releases (a Developer ID is configured).
       # Ad-hoc/dev builds skip: spctl cannot pass without a Developer ID root.

--- a/scripts/embed-boris.sh
+++ b/scripts/embed-boris.sh
@@ -108,16 +108,17 @@ bundle_and_sign() {
     }
   fi
 
-  # Embed companion binaries (boris-editor, boris-package, boris-source-rag)
-  # from kit bin dirs when available.
+  # Embed companion binaries (boris-editor, boris-package, boris-source-rag,
+  # boris-content-audit) from kit bin dirs when available.
   local comp_candidates=(
     "$SRCROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin"
     "$SRCROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/bin"
     "$SRCROOT/../boris-agent-kit/bin"
   )
+  local search_index_found=0
   for cdir in "${comp_candidates[@]}"; do
     if [[ -d "$cdir" ]]; then
-      for comp in boris-editor boris-package boris-source-rag; do
+      for comp in boris-editor boris-package boris-source-rag boris-content-audit; do
         if [[ -x "$cdir/$comp" && ! -f "$DEST_DIR/$comp" ]]; then
           cp "$cdir/$comp" "$DEST_DIR/$comp"
           chmod +x "$DEST_DIR/$comp"
@@ -128,8 +129,16 @@ bundle_and_sign() {
           echo "embed-boris: bundled companion $comp"
         fi
       done
+      # Notice-skip: boris-search-index exists in the kit but the app
+      # does not locate or run it — do not embed it.
+      if [[ -x "$cdir/boris-search-index" ]]; then
+        search_index_found=1
+      fi
     fi
   done
+  if [[ "$search_index_found" -eq 1 ]]; then
+    echo "embed-boris: notice: boris-search-index present in kit but not bundled (unused by app)"
+  fi
 
   bundle_oliver "$sign_identity"
 }

--- a/scripts/populate-universal-companions.sh
+++ b/scripts/populate-universal-companions.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Populates a universal bin directory with lipo-merged companion tools so
+# that embed-boris.sh can find them during the release build.
+#
+# Usage: populate-universal-companions.sh DEST_DIR
+#
+# Expects /tmp/boris-universal-boris-* files from the cross-build step.
+
+set -euo pipefail
+
+DEST_DIR="${1:?usage: populate-universal-companions.sh DEST_DIR}"
+
+mkdir -p "$DEST_DIR"
+
+TOOLS="boris-editor boris-package boris-source-rag boris-content-audit"
+bundled=0
+for tool in $TOOLS; do
+  universal="/tmp/boris-universal-$tool"
+  if [[ -f "$universal" ]]; then
+    cp "$universal" "$DEST_DIR/$tool"
+    chmod +x "$DEST_DIR/$tool"
+    echo "populate-companions: $tool → $DEST_DIR/$tool"
+    bundled=$((bundled + 1))
+  else
+    echo "populate-companions: notice: $tool not universal — skipped" >&2
+  fi
+done
+echo "populate-companions: bundled $bundled tool(s)"


### PR DESCRIPTION
Fixes #215.

**What:** Fixes the CI pipeline: missing `boris-content-audit` embed, uncached Zig builds, companion tools shipped as arm64-only, and no bundle shape assertion.

**Changes:**
- `embed-boris.sh`: Added `boris-content-audit` to the companion binary embed loop. Added notice-skip log for `boris-search-index` (present in kit MANIFEST but unused by app).
- `ci.yml`: Cache Zig build artifacts (`boris/zig-cache`) in spike job. Assert no stale `Contents/Resources/boris` when `SKIP_EMBED_BORIS=1` in app job.
- `release-notarize.yml`: Cross-build companion tools (`boris-editor`, `boris-package`, `boris-source-rag`, `boris-content-audit`) as universal binaries via lipo. Populate universal companions into kit bin dir before embed. Inspect step now verifies all companions in release bundle.
- `populate-universal-companions.sh` (new): Helper to copy lipo-merged universal companion binaries for the release embed step.

**Gate:** `SKIP_EMBED_BORIS=1 make build` green · `make test` 354 tests 0 failures · `make lint` 0 violations.