### PR TITLE
docs: milestone-10 editor polish specs + accessibility tracker & cards

### DIFF
--- a/docs/cards/A11Y-compose-toolbar.md
+++ b/docs/cards/A11Y-compose-toolbar.md
@@ -1,0 +1,52 @@
+# Card A11Y-1 — Compose toolbar + diagnostics accessibility
+
+**Milestone:** 10 (post-M17 polish) · **Issue:**
+[#239](https://github.com/drawmeanelephant/solipsist/issues/239)
+(parent [#236](https://github.com/drawmeanelephant/solipsist/issues/236))
+· **Lane:** Compose. One worktree, one PR against `main`; branch
+suggestion `feat/a11y-compose-toolbar`.
+
+Spec: [`docs/issues/editor-accessibility-compose-toolbar.md`](../issues/editor-accessibility-compose-toolbar.md).
+
+## Owns
+
+- `Sources/Compose/ComposeEditorView.swift` — toolbar control labels +
+  diagnostics-row announcements
+
+## Do not touch
+
+- `Sources/Companions/` (A11Y-3 / A11Y-4)
+- `Sources/Play/Local/ReadingPane.swift` (A11Y-2)
+- `Sources/Chrome/SourceSidebar.swift` (A11Y-5)
+- `Sources/Engine/**`
+- `Project.yml`
+
+## Why
+
+The Compose toolbar controls have `.help()` tooltips but no
+`accessibilityLabel`, and each diagnostics row reads as a bare `HStack`.
+VoiceOver users cannot act on the editor or read its problems.
+
+## Do
+
+1. Add `accessibilityLabel` + `accessibilityHint` to the Language picker,
+   Preview toggle, Front Matter toggle, Render Options menu, and Save button
+   (copy in the spec). Keep the existing `.help()` tooltips.
+2. In `ComposeDiagnosticsPane`, combine each row:
+   `.accessibilityElement(children: .combine)` with a label built from
+   severity + optional line + message ("Error on line 12: …").
+3. Use `String(localized:)` for every user-facing string.
+4. Tests: a diagnostic row's combined label contains severity, line, and
+   message; toolbar controls expose non-empty labels.
+
+## Do not
+
+- Build a separate accessibility mode.
+- Add a third-party accessibility library.
+- Touch the other lanes' files (above).
+
+## Gate
+
+VoiceOver (⌘F5) on the Compose window announces every toolbar control and a
+diagnostics row ("Error on line 12: …"). `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.

--- a/docs/cards/A11Y-editor-toolbar.md
+++ b/docs/cards/A11Y-editor-toolbar.md
@@ -1,0 +1,48 @@
+# Card A11Y-4 — Editor toolbar accessibility
+
+**Milestone:** 10 (post-M17 polish) · **Issue:**
+[#242](https://github.com/drawmeanelephant/solipsist/issues/242)
+(parent [#236](https://github.com/drawmeanelephant/solipsist/issues/236))
+· **Lane:** Editor companion. One worktree, one PR against `main`;
+branch suggestion `feat/a11y-editor-toolbar`.
+
+Spec: [`docs/issues/editor-accessibility-editor-toolbar.md`](../issues/editor-accessibility-editor-toolbar.md).
+
+## Owns
+
+- `Sources/Companions/Editor/EditorWindow.swift` — toolbar labels
+
+## Do not touch
+
+- `Sources/Companions/Preview/` (A11Y-3)
+- `Sources/Compose/` (A11Y-1)
+- `Sources/Play/Local/` (A11Y-2)
+- `Sources/Chrome/SourceSidebar.swift` (A11Y-5)
+- `Sources/Engine/**`
+- `Project.yml`
+
+## Why
+
+The Editor toolbar's nav buttons, Restart, Open-in-Browser, URL field, and
+Connect have `.help()` tooltips but no VoiceOver labels.
+
+## Do
+
+1. Label the URL field ("Editor URL. Paste a BORIS_EDITOR_URL line to connect
+   manually."), Connect, Restart, Back, Forward, and Reload (copy in the
+   spec).
+2. Make the phase indicator (`phaseLabel`) announce idle / starting /
+   connected / failed state.
+3. Use `String(localized:)` for every user-facing string.
+4. Tests: the toolbar controls expose non-empty labels.
+
+## Do not
+
+- Build a separate accessibility mode.
+- Add a third-party accessibility library.
+- Touch the other lanes' files (above).
+
+## Gate
+
+VoiceOver on the Editor window announces every toolbar control and the phase
+indicator. `SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/A11Y-preview-toolbar.md
+++ b/docs/cards/A11Y-preview-toolbar.md
@@ -1,0 +1,48 @@
+# Card A11Y-3 — Preview toolbar accessibility
+
+**Milestone:** 10 (post-M17 polish) · **Issue:**
+[#241](https://github.com/drawmeanelephant/solipsist/issues/241)
+(parent [#236](https://github.com/drawmeanelephant/solipsist/issues/236))
+· **Lane:** Preview companion. One worktree, one PR against `main`;
+branch suggestion `feat/a11y-preview-toolbar`.
+
+Spec: [`docs/issues/editor-accessibility-preview-toolbar.md`](../issues/editor-accessibility-preview-toolbar.md).
+
+## Owns
+
+- `Sources/Companions/Preview/PreviewWindow.swift` — toolbar labels
+
+## Do not touch
+
+- `Sources/Companions/Editor/` (A11Y-4)
+- `Sources/Compose/` (A11Y-1)
+- `Sources/Play/Local/` (A11Y-2)
+- `Sources/Chrome/SourceSidebar.swift` (A11Y-5)
+- `Sources/Engine/**`
+- `Project.yml`
+
+## Why
+
+The Preview toolbar's URL field, Reload, and Open-in-Browser buttons have no
+VoiceOver labels.
+
+## Do
+
+1. Label the URL field ("Preview URL. …"), Reload ("Reload the preview
+   page."), and Open in Browser ("Open in Safari.").
+2. Make the session status line (`session.statusText`) announce
+   connected / failure state.
+3. Use `String(localized:)` for every user-facing string.
+4. Tests: the toolbar controls expose non-empty labels.
+
+## Do not
+
+- Build a separate accessibility mode.
+- Add a third-party accessibility library.
+- Touch the other lanes' files (above).
+
+## Gate
+
+VoiceOver on the Preview window announces the URL field, Reload, and
+Open-in-Browser, plus the status line. `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.

--- a/docs/cards/A11Y-reading-header.md
+++ b/docs/cards/A11Y-reading-header.md
@@ -1,0 +1,48 @@
+# Card A11Y-2 — Reading pane header accessibility
+
+**Milestone:** 10 (post-M17 polish) · **Issue:**
+[#240](https://github.com/drawmeanelephant/solipsist/issues/240)
+(parent [#236](https://github.com/drawmeanelephant/solipsist/issues/236))
+· **Lane:** Reading. One worktree, one PR against `main`; branch
+suggestion `feat/a11y-reading-header`.
+
+Spec: [`docs/issues/editor-accessibility-reading-header.md`](../issues/editor-accessibility-reading-header.md).
+
+## Owns
+
+- `Sources/Play/Local/ReadingPane.swift` — the letter header announcement
+
+## Do not touch
+
+- `Sources/Compose/` (A11Y-1)
+- `Sources/Companions/` (A11Y-3 / A11Y-4)
+- `Sources/Chrome/SourceSidebar.swift` (A11Y-5)
+- `Sources/Engine/**`
+- `Project.yml`
+
+## Why
+
+The reading-pane header (title + caption with path · status · role) reads as
+separate pieces to VoiceOver instead of one announcement. The empty-state
+label already exists — keep it.
+
+## Do
+
+1. Combine the title `VStack` (title + caption) into one element announcing
+   "title, status, role" (`display(page.status)` handles the empty case).
+2. Leave the Preview / Edit / Compose buttons and the served badge outside the
+   combined element — they keep their own labels.
+3. Use `String(localized:)` for the label.
+4. Tests: the header combines title, status, role into one label.
+
+## Do not
+
+- Fold the action buttons into the combined element.
+- Build a separate accessibility mode.
+- Touch the other lanes' files (above).
+
+## Gate
+
+VoiceOver on the reading pane announces "Getting Started, published, Trunk"
+as one element; the action buttons still announce individually.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/A11Y-sidebar-counts.md
+++ b/docs/cards/A11Y-sidebar-counts.md
@@ -1,0 +1,57 @@
+# Card A11Y-5 — Mailbox sidebar counts
+
+**Milestone:** 10 (post-M17 polish) · **Issue:**
+[#243](https://github.com/drawmeanelephant/solipsist/issues/243)
+(parent [#236](https://github.com/drawmeanelephant/solipsist/issues/236))
+· **Lane:** Mailboxes. One worktree, one PR against `main`; branch
+suggestion `feat/a11y-sidebar-counts`.
+
+Spec: [`docs/issues/editor-accessibility-sidebar-counts.md`](../issues/editor-accessibility-sidebar-counts.md).
+
+## Owns
+
+- `Sources/Chrome/SourceSidebar.swift` — `accessibilityValue` counts on the
+  Pages and trunk rows
+
+## Do not touch
+
+- `Sources/Compose/` (A11Y-1)
+- `Sources/Play/Local/` (A11Y-2)
+- `Sources/Companions/` (A11Y-3 / A11Y-4)
+- `Sources/Engine/**`
+- `Project.yml`
+
+## Why
+
+VoiceOver announces mailbox row titles but not item counts, so users cannot
+tell how many pages sit under Pages or a trunk folder. **No new plumbing is
+needed**: `LocalPlay.apply` already calls `store.updateGraph(graph, for:
+source.id)`, and `PagesGroup` already reads the graph via `store.graph(for:)`
++ `LocalPlayGraph.trunks(from:)`. `LocalPlayGraph.pages(in:trunkID:)` already
+counts a trunk's pages.
+
+## Do
+
+1. Pages row: `.accessibilityValue("\(pageCount) items")` — page count from
+   `store.graph(for:)` (all pages in the graph).
+2. Each trunk row: `.accessibilityValue("\(count) items")` — per-trunk count
+   via `LocalPlayGraph.pages(in: trunkID:)`.
+3. Counts recompute when the graph rebuilds (they derive from the stored
+   graph — verify on `updateGraph`).
+4. Use `String(localized:)` for the "items" unit.
+5. Tests: with a decoded fixture graph in the store, the Pages row's value is
+   "N items" and a trunk row's value matches its page count; replacing the
+   graph updates the value.
+
+## Do not
+
+- Add counts for Outputs / Activity / Publish / Plan (the sidebar does not
+  hold that data — do not invent plumbing).
+- Parse `graph.json` in Chrome (the store already holds the decoded `Graph`).
+- Touch the other lanes' files (above).
+
+## Gate
+
+VoiceOver on the sidebar announces "Pages, 45 items" and each trunk row
+"FolderName, 7 items"; counts update after a rebuild. `SKIP_EMBED_BORIS=1
+make build` + `make test` green.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -23,7 +23,9 @@ M3–M8 **gates** are closed (#72–#77). The #87 depth batch is closed
 Mail body** (#98), and **M11 prove** (#123) landed. Remaining ship
 is Apple-account only (#110 / #111). Pickable product: **M12
 clone** ([#131](https://github.com/drawmeanelephant/solipsist/issues/131)).
-M13 graph folders and M14 watch contract are filed below.
+M13 graph folders and M14 watch contract are filed below. The milestone-10
+editor-polish **accessibility cards** (five lanes, tracker #236) are pickable
+below.
 
 **Legacy board (landed or withdrawn — do not pick):**
 
@@ -155,6 +157,28 @@ entry). Do not pick.
 | [M17-1 PR list](M17-pr-list.md) | [#192](https://github.com/drawmeanelephant/solipsist/issues/192) | ✅ |
 | [M17-2 PR mailbox](M17-pr-mailbox.md) | #192 | ✅ |
 | [M17-3 Authoring entry](M17-pr-authoring.md) | #192 | ✅ |
+
+## Editor accessibility — milestone 10 polish (pickable)
+
+VoiceOver across the editor surfaces, cut into five disjoint lanes from
+tracker [#236](https://github.com/drawmeanelephant/solipsist/issues/236).
+Each card is one worktree, one PR against `main`; all five are independent
+and can run at once. Specs live in
+[`docs/issues/`](../issues/README.md) (child-of-#236 drafts); the cards
+below are the session briefs.
+
+| Card | Issue | Lane | Parallel with | Gate |
+|------|-------|------|----------------|------|
+| [A11Y tracker](../issues/editor-compose-accessibility.md) | [#236](https://github.com/drawmeanelephant/solipsist/issues/236) | design | — | five children land; VoiceOver covers all surfaces |
+| [A11Y-1 Compose toolbar + diagnostics](A11Y-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | A11Y-2..A11Y-5 | every Compose toolbar control and diagnostics row announces |
+| [A11Y-2 Reading pane header](A11Y-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | A11Y-1, A11Y-3..A11Y-5 | header announces title, status, role |
+| [A11Y-3 Preview toolbar](A11Y-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | A11Y-1, A11Y-2, A11Y-4, A11Y-5 | URL / reload / open-in-browser labeled |
+| [A11Y-4 Editor toolbar](A11Y-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | A11Y-1..A11Y-3, A11Y-5 | URL / connect / restart / nav labeled |
+| [A11Y-5 Mailbox sidebar counts](A11Y-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | A11Y-1..A11Y-4 | Pages + trunk rows announce counts from the stored graph |
+
+Filed 2026-08-21 as #239–#243 (milestone 10). Close #236 when all five
+land. Do not grow a card into another card's lane — the Owns / Do-not-
+touch lists are the contract.
 
 ## Do not start yet
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -18,5 +18,38 @@ PR against boris from this repo.
 
 **File next:** none.
 
+---
+
+## Solipsist issue drafts (not boris)
+
+The `editor-*.md` files below are **Solipsist** issue drafts for milestone 10
+(macOS native editor improvements, #225–#238) — they file on
+`drawmeanelephant/solipsist`, never on boris. Each carries its issue number
+(children reference their tracker, #236); `Current state` is fact-checked
+against the code it names, each has a `Gate`, and the cards are cut so no
+two touch the same lane in the same PR.
+
+| Draft | Issue | Lane |
+|-------|-------|------|
+| [Find & Replace](editor-compose-find-replace.md) | [#225](https://github.com/drawmeanelephant/solipsist/issues/225) | `Sources/Compose/` |
+| [Line Numbers Gutter](editor-compose-line-numbers.md) | [#226](https://github.com/drawmeanelephant/solipsist/issues/226) | `Sources/Compose/` |
+| [Split Pane Resize + Auto-Save](editor-compose-split-resize.md) | [#227](https://github.com/drawmeanelephant/solipsist/issues/227) | `Sources/Compose/` |
+| [Status Bar — Cursor + Word Count](editor-compose-status-bar.md) | [#228](https://github.com/drawmeanelephant/solipsist/issues/228) | `Sources/Compose/` |
+| [Tab Key — Indent 2 Spaces](editor-compose-tab-key.md) | [#229](https://github.com/drawmeanelephant/solipsist/issues/229) | `Sources/Compose/` |
+| [Preview WKWebView](editor-compose-preview-webview.md) | [#230](https://github.com/drawmeanelephant/solipsist/issues/230) | `Sources/Compose/` |
+| [Toolbar Save Suspends Watch](editor-compose-toolbar-save-tree-write.md) | [#231](https://github.com/drawmeanelephant/solipsist/issues/231) | `Sources/Compose/` |
+| [Editor Auto-Reconnect](editor-companion-reconnect.md) | [#232](https://github.com/drawmeanelephant/solipsist/issues/232) | `Sources/Companions/Editor/` |
+| [Pages List Keyboard Nav](editor-reading-keyboard-nav.md) | [#233](https://github.com/drawmeanelephant/solipsist/issues/233) | `Sources/Play/Local/` |
+| [Preview Pinch-to-Zoom](editor-preview-zoom.md) | [#234](https://github.com/drawmeanelephant/solipsist/issues/234) | `Sources/Companions/Preview/` |
+| [Highlighting Edge Cases](editor-compose-highlight-edge-cases.md) | [#235](https://github.com/drawmeanelephant/solipsist/issues/235) | `Sources/Compose/` |
+| [Accessibility (tracker)](editor-compose-accessibility.md) | [#236](https://github.com/drawmeanelephant/solipsist/issues/236) | design — five child issues below |
+| [A-1 Compose toolbar + diagnostics](editor-accessibility-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | `Sources/Compose/` |
+| [A-2 Reading pane header](editor-accessibility-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | `Sources/Play/Local/` |
+| [A-3 Preview toolbar](editor-accessibility-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | `Sources/Companions/Preview/` |
+| [A-4 Editor toolbar](editor-accessibility-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | `Sources/Companions/Editor/` |
+| [A-5 Mailbox sidebar counts](editor-accessibility-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | `Sources/Chrome/` |
+| [Editor UX Polish](editor-companion-ux-polish.md) | [#237](https://github.com/drawmeanelephant/solipsist/issues/237) | `Sources/Companions/Editor/` |
+| [Go to Line (⌘L)](editor-compose-go-to-line.md) | [#238](https://github.com/drawmeanelephant/solipsist/issues/238) | `Sources/Compose/` |
+
 Do not ask: unifying `compiler` field names, library mode, relaxing
 editor token/CSP, shipping `boris-editor` in the agent-pack.

--- a/docs/issues/editor-accessibility-compose-toolbar.md
+++ b/docs/issues/editor-accessibility-compose-toolbar.md
@@ -1,0 +1,84 @@
+# Editor: Accessibility — Compose Toolbar + Diagnostics Pane
+
+**Track:** macOS native polish / accessibility
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#239](https://github.com/drawmeanelephant/solipsist/issues/239)
+**Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
+**Lane:** Compose — `Sources/Compose/`
+
+## Problem
+
+The Compose window's toolbar controls and diagnostics rows are not
+VoiceOver-accessible: the toolbar buttons have `.help()` tooltips but no
+`accessibilityLabel`, and each diagnostics row reads as a bare `HStack` with
+no severity / line / message announcement.
+
+## Verified current state
+
+`Sources/Compose/ComposeEditorView.swift`:
+- `toolbar` — Language picker, Preview toggle, Front Matter toggle, Render
+  Options menu, Save button. All have `.help()` tooltips; **none** has an
+  `accessibilityLabel` / `accessibilityHint`.
+- `ComposeDiagnosticsPane` — rows are `HStack`s (icon, line number, message)
+  with `.help("Jump to this diagnostic")`; no `.accessibilityElement(children:
+  .combine)` and no combined label.
+
+## Scope
+
+### Must land
+
+1. **Toolbar** — label + hint on every control:
+   - Language picker: "Language, currently Markdown. Select the authoring
+     frontend."
+   - Preview toggle: "Toggle Preview. Show or hide the rendered preview pane."
+   - Front Matter toggle: "Toggle Front Matter. Show or hide the front matter
+     editor."
+   - Render Options: "Render Options. Configure Oliver's parse extensions."
+   - Save: "Save. Write the buffer to disk. Command-S."
+2. **Diagnostics rows** — combine into a single announcement:
+   "Error on line 12: unexpected token" / "Warning: missing closing fence".
+   Use `.accessibilityElement(children: .combine)` and build the label from
+   severity + optional line + message.
+
+### Must not land
+
+- A separate accessibility mode.
+- A third-party accessibility library.
+- Touching `Sources/Companions/`, `Sources/Play/Local/`, or `Sources/Chrome/`
+  (other children own those).
+
+## Gate
+
+VoiceOver (⌘F5) on the Compose window: every toolbar control announces its
+label/hint, and a diagnostics row announces "Error on line 12: …".
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Implementation sketch
+
+1. Add `.accessibilityLabel(_:)` / `.accessibilityHint(_:)` to each toolbar
+   control. Keep the existing `.help()` tooltips.
+2. In `ComposeDiagnosticsPane`, per row:
+   ```swift
+   .accessibilityElement(children: .combine)
+   .accessibilityLabel(
+       (diagnostic.severity == .error ? "Error" : "Warning")
+       + (diagnostic.line.map { " on line \($0)" } ?? "")
+       + ": \(diagnostic.message)"
+   )
+   ```
+3. Use `String(localized:)` for every user-facing string.
+
+## Tests
+
+- `testDiagnosticsRowAccessibilityLabel` — a row's combined label contains
+  severity, line, and message (drive `ComposeDiagnostic` → label).
+- `testToolbarControlsHaveLabels` — the toolbar's buttons/picker expose
+  non-empty `accessibilityLabel` (via the label builder or the representable's
+  view hierarchy).
+- Manual: VoiceOver walk-through of the Compose toolbar + a diagnostics list.
+
+## Edge cases
+
+- A diagnostic with no line → the label reads "Error: message" (no "on line").
+- Labels update when the diagnostics list changes (rows re-render).
+- All labels use `String(localized:)`; no hardcoded English.

--- a/docs/issues/editor-accessibility-editor-toolbar.md
+++ b/docs/issues/editor-accessibility-editor-toolbar.md
@@ -1,0 +1,60 @@
+# Editor: Accessibility — Editor Toolbar
+
+**Track:** macOS native polish / accessibility
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#242](https://github.com/drawmeanelephant/solipsist/issues/242)
+**Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
+**Lane:** Editor companion — `Sources/Companions/Editor/`
+
+## Problem
+
+The Editor companion's toolbar controls are unlabeled for VoiceOver.
+
+## Verified current state
+
+`Sources/Companions/Editor/EditorWindow.swift` — `toolbar` renders nav buttons
+(Back / Forward / Reload), a phase indicator, Restart Host, Open-in-Browser, a
+URL `TextField`, and Connect. The nav buttons have `.help()` tooltips; none
+has an `accessibilityLabel` / `accessibilityHint`.
+
+## Scope
+
+### Must land
+
+- URL field: "Editor URL. Paste a BORIS_EDITOR_URL line to connect manually."
+- Connect: "Connect to the editor host."
+- Restart: "Restart the boris-editor host."
+- Back: "Back. Navigate to the previous page."
+- Forward: "Forward. Navigate to the next page."
+- Reload: "Reload the editor page."
+- The phase indicator announces as a single value (idle / starting /
+  connected / failed).
+
+### Must not land
+
+- Touching `Sources/Companions/Preview/`, `Sources/Compose/`, or
+  `Sources/Chrome/`.
+- A separate accessibility mode.
+
+## Gate
+
+VoiceOver on the Editor window: every toolbar control announces its label; the
+phase indicator announces connected / failed state. `SKIP_EMBED_BORIS=1 make
+build` + `make test` green.
+
+## Implementation sketch
+
+1. Add `.accessibilityLabel(_:)` / `.accessibilityHint(_:)` to the nav
+   buttons, Restart, Open-in-Browser, the URL field, and Connect.
+2. Ensure the phase `Text` (which renders `phaseLabel`) is
+   accessibility-relevant.
+
+## Tests
+
+- `testEditorToolbarLabels` — the toolbar controls expose non-empty labels.
+- Manual: VoiceOver walk-through of the Editor window.
+
+## Edge cases
+
+- Disabled states (nav buttons with no history) still announce their labels.
+- Failure phase → the phase indicator announces the error message.

--- a/docs/issues/editor-accessibility-preview-toolbar.md
+++ b/docs/issues/editor-accessibility-preview-toolbar.md
@@ -1,0 +1,56 @@
+# Editor: Accessibility — Preview Toolbar
+
+**Track:** macOS native polish / accessibility
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#241](https://github.com/drawmeanelephant/solipsist/issues/241)
+**Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
+**Lane:** Preview companion — `Sources/Companions/Preview/`
+
+## Problem
+
+The Preview companion's toolbar controls are unlabeled for VoiceOver.
+
+## Verified current state
+
+`Sources/Companions/Preview/PreviewWindow.swift` — `toolbar` renders a URL
+`TextField`, Reload, and Open-in-Browser buttons (plus a rejection line and
+the session status line). None has an `accessibilityLabel` /
+`accessibilityHint`.
+
+## Scope
+
+### Must land
+
+- URL field: "Preview URL. http://127.0.0.1:8080/__boris/"
+- Reload: "Reload the preview page."
+- Open in Browser: "Open in Safari."
+- The session status line announces as a single value (serve URL or failure).
+
+### Must not land
+
+- Touching `Sources/Companions/Editor/`, `Sources/Compose/`, or
+  `Sources/Chrome/`.
+- A separate accessibility mode.
+
+## Gate
+
+VoiceOver on the Preview window: the URL field, Reload, and Open-in-Browser
+announce their labels; the status line announces. `SKIP_EMBED_BORIS=1 make
+build` + `make test` green.
+
+## Implementation sketch
+
+1. Add `.accessibilityLabel(_:)` / `.accessibilityHint(_:)` to the text field
+   and both buttons.
+2. Mark the status `Text` (which renders `session.statusText`) as
+   accessibility-relevant so it announces connected / failure state.
+
+## Tests
+
+- `testPreviewToolbarLabels` — the toolbar controls expose non-empty labels.
+- Manual: VoiceOver walk-through of the Preview window.
+
+## Edge cases
+
+- The preview URL is loopback — safe to expose to VoiceOver.
+- Failure state → the status line announces the failure message.

--- a/docs/issues/editor-accessibility-reading-header.md
+++ b/docs/issues/editor-accessibility-reading-header.md
@@ -1,0 +1,66 @@
+# Editor: Accessibility — Reading Pane Header
+
+**Track:** macOS native polish / accessibility
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#240](https://github.com/drawmeanelephant/solipsist/issues/240)
+**Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
+**Lane:** Reading — `Sources/Play/Local/`
+
+## Problem
+
+The reading-pane header (page title, status, role) is not a single VoiceOver
+announcement; VoiceOver reads the pieces separately with no context.
+
+## Verified current state
+
+`Sources/Play/Local/ReadingPane.swift` — `header(for:)` renders an icon, a
+title stack (`page.title` + `headerCaption(for:)`, which already contains
+path · status · role), a served badge, and Preview / Edit / Compose buttons.
+There is no `.accessibilityElement(children: .combine)` on the title stack, so
+the title, caption, and badge announce separately. The "No Page Selected"
+empty state already has a label + hint.
+
+## Scope
+
+### Must land
+
+- Combine the title + caption into one announcement: "Getting Started,
+  published, Trunk" (title, status, role).
+- The served badge and the Preview / Edit / Compose buttons keep their own
+  labels (do not fold the action buttons into the combined element).
+- The "No Page Selected" empty state keeps its existing label/hint.
+
+### Must not land
+
+- Touching `Sources/Compose/`, `Sources/Companions/`, or `Sources/Chrome/`.
+- A separate accessibility mode.
+
+## Gate
+
+VoiceOver on the reading pane: selecting a page announces "Getting Started,
+published, Trunk" as one element; the action buttons still announce
+individually. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Implementation sketch
+
+1. Wrap the title `VStack` in `.accessibilityElement(children: .combine)` and
+   set:
+   ```swift
+   .accessibilityLabel(
+       "\(page.title), \(display(page.status)), \(page.role == .trunk ? "Trunk" : "Satellite")"
+   )
+   ```
+2. Leave the action buttons outside the combined element.
+
+## Tests
+
+- `testReadingHeaderAccessibilityLabel` — the header combines title, status,
+  role into one label.
+- Manual: VoiceOver announces the header as one element.
+
+## Edge cases
+
+- Empty status → the label reads "Title, —, Trunk" (reuse the existing
+  `display(_:)`).
+- Long titles → `lineLimit(1)` truncation stays; the label can use the full
+  title.

--- a/docs/issues/editor-accessibility-sidebar-counts.md
+++ b/docs/issues/editor-accessibility-sidebar-counts.md
@@ -1,0 +1,74 @@
+# Editor: Accessibility — Mailbox Sidebar Counts
+
+**Track:** macOS native polish / accessibility
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#243](https://github.com/drawmeanelephant/solipsist/issues/243)
+**Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
+**Lane:** Mailboxes — `Sources/Chrome/`
+
+## Problem
+
+The mailbox sidebar announces row titles but not item counts, so VoiceOver
+users cannot tell how many pages sit under Pages or a trunk folder.
+
+## Verified current state
+
+`Sources/Chrome/SourceSidebar.swift`:
+- `MailboxRow` has `.accessibilityLabel("\(item.title), \(displayName)")` — no
+  `accessibilityValue`.
+- `PagesGroup` renders the Pages row plus `TrunkRow` children from the decoded
+  graph.
+- `TrunkRow` has `.accessibilityLabel("\(item.title), \(trunk.title)")` — no
+  count.
+- **No new plumbing is needed**: `LocalPlay.apply` already calls
+  `store.updateGraph(graph, for: source.id)`, and `PagesGroup` already reads
+  the graph via `store.graph(for:)` + `LocalPlayGraph.trunks(from:)`.
+  `LocalPlayGraph.pages(in:trunkID:)` already counts a trunk's pages.
+
+## Scope
+
+### Must land
+
+- Pages row: `.accessibilityValue("\(pageCount) items")` — the page count from
+  `store.graph(for:)` (all pages in the graph).
+- Each trunk row: `.accessibilityValue("\(count) items")` — per-trunk count
+  via `LocalPlayGraph.pages(in: trunkID:)`.
+- Counts update when the graph rebuilds (they derive from the stored graph).
+
+### Must not land
+
+- Counts for Outputs / Activity / Publish / Plan (the sidebar does not hold
+  that data — do not invent plumbing).
+- Touching `Sources/Compose/`, `Sources/Play/Local/`, or
+  `Sources/Companions/`.
+- A separate accessibility mode.
+
+## Gate
+
+VoiceOver on the sidebar: the Pages row announces "Pages, 45 items" and each
+trunk row announces "FolderName, 7 items"; counts update after a rebuild.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Implementation sketch
+
+1. In `PagesGroup`, compute the page count from the stored graph and set
+   `.accessibilityValue("\(pageCount) items")` on the Pages `MailboxRow`.
+2. In `TrunkRow`, compute the trunk's page count via
+   `LocalPlayGraph.pages(in: trunk.id, ...)` and set
+   `.accessibilityValue("\(count) items")`.
+3. Use `String(localized:)` for the "items" unit.
+
+## Tests
+
+- `testPagesRowCountAccessibilityValue` — with a decoded fixture graph in the
+  store, the Pages row's value is "N items" (the fixture count).
+- `testTrunkRowCountAccessibilityValue` — a trunk row's value matches its page
+  count.
+- `testCountsUpdateOnGraphChange` — replacing the store's graph updates the
+  value.
+
+## Edge cases
+
+- No graph yet (source just added) → no rows, no counts; not an error.
+- A trunk with zero pages → "0 items".
+- Counts must recompute when `updateGraph` fires.

--- a/docs/issues/editor-companion-reconnect.md
+++ b/docs/issues/editor-companion-reconnect.md
@@ -1,0 +1,109 @@
+# Editor: Auto-Reconnect When boris-editor Crashes
+
+**Track:** Editor companion / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#232](https://github.com/drawmeanelephant/solipsist/issues/232)
+**Lane:** `Sources/Companions/Editor/`
+
+## Problem
+
+When the `boris-editor` host process crashes, the Editor companion shows a
+static error and the user must click "Restart Host". A companion window
+should feel integrated: a transient crash should auto-restart.
+
+## Verified current state
+
+`EditorSession` (`Sources/Companions/Editor/EditorSession.swift`):
+`handleExit(_:)` sets `phase = .idle` on exit 0 and
+`phase = .failed("Editor host exited (N)…")` on non-zero. `stop()` clears the
+`onConnect`/`onExit` callbacks and stops the server, so **`handleExit` only
+fires on spontaneous exit** — the "not user-initiated" distinction is already
+guaranteed by the current code; keep it that way. `restart()` reuses
+`lastContentRoot` / `lastProjectRoot` / `lastEngine`. `EditorWindow`'s
+`.onDisappear` calls `session.stop()`.
+
+## Scope
+
+### Must land
+
+- On a **spontaneous non-zero exit**, automatically restart after a short
+  delay, with **exponential backoff** (2s, 4s, 6s).
+- Show a **transient status** ("Editor host restarted") on success instead of
+  a static error.
+- Cap at **3 attempts within 30s**; past that, show the error state and
+  require manual restart.
+- **Reset the attempt counter on a successful connect** (`handleConnect`).
+- Must **not** fire on:
+  - exit code 0 (clean shutdown);
+  - window close (`.onDisappear` → `stop()`, which clears callbacks — keep);
+  - a manual "Restart Host" / "Stop" (they go through `stop()`/`restart()`,
+    which clear callbacks — keep);
+  - a host that fails to **start** (that is a config error, not a crash — the
+    failed phase comes from `start()` directly, not `handleExit`).
+
+### Nice-to-have (not gate)
+
+- A countdown ("Reconnecting in 2s…") in the status bar before each retry.
+- A `UNUserNotificationCenter` notification when auto-reconnect exhausts and
+  manual action is needed.
+- A "Don't Auto-Reconnect" toggle in the toolbar.
+
+### Must not land
+
+- Auto-reconnect on clean exit, window close, or start failure (above).
+- Auto-reconnect when the engine or editor binary is missing (permanent
+  errors — `start()` already fails them before a server exists).
+
+## Implementation sketch
+
+1. In `EditorSession`, add state:
+   ```swift
+   private var autoReconnectAttempts = 0
+   private var autoReconnectTask: Task<Void, Never>?
+   ```
+2. In `handleExit(_:)` (the non-zero branch only), schedule a reconnect:
+   ```swift
+   autoReconnectAttempts += 1
+   if autoReconnectAttempts <= 3 {
+       let delay = Double(autoReconnectAttempts) * 2 // 2, 4, 6
+       autoReconnectTask = Task { [weak self] in
+           try? await Task.sleep(for: .seconds(delay))
+           guard !Task.isCancelled else { return }
+           self?.restart()   // reuses lastContentRoot / projectRoot / engine
+       }
+   } else {
+       phase = .failed("Editor host crashed 3 times. Manual restart required.")
+   }
+   ```
+3. Reset `autoReconnectAttempts = 0` in `handleConnect(_:)`.
+4. **Cancel the pending task in `stop()`** (and in `start()`'s early-return /
+   `fail()` paths). A `restart()` calls `stop()` first, so a manual restart
+   cancels any pending auto-reconnect — correct.
+5. **Source switch is already safe**: `EditorWindow`'s `.task(id: source.id)`
+   re-runs `startEditor` → `session.start(...)`, and `start()` calls `stop()`
+   when the root differs, cancelling the pending task. Verify, do not regress.
+
+## Gate
+
+While connected, kill the `boris-editor` process → the window shows a
+transient "restarting" state and reconnects automatically (2s) → kill it three
+times within 30s → the error state requires manual restart → a manual Restart
+Host works and resets the counter → closing the window never triggers a
+reconnect. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Tests
+
+- `testAutoReconnectFiresOnNonZeroExit` — a non-zero exit schedules a
+  restart.
+- `testAutoReconnectDoesNotFireOnCleanExit` — exit 0 does not.
+- `testAutoReconnectStopsAfterMaxAttempts` — 3 failures → manual state.
+- `testAutoReconnectResetsOnSuccess` — a connect resets the counter.
+- `testAutoReconnectDoesNotFireOnWindowClose` — `stop()` cancels the task.
+
+## Edge cases
+
+- The 2s delay prevents a new host from starting while the old one is still
+  shutting down.
+- Engine / editor binary missing → permanent failed phase, no reconnect.
+- Source switch while a reconnect is pending → the pending task is cancelled
+  and the new source's session starts fresh.

--- a/docs/issues/editor-companion-ux-polish.md
+++ b/docs/issues/editor-companion-ux-polish.md
@@ -1,0 +1,104 @@
+# Editor: Companion Window UX Polish
+
+**Track:** Editor companion / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#237](https://github.com/drawmeanelephant/solipsist/issues/237)
+**Lane:** `Sources/Companions/Editor/`
+
+## Problem
+
+The Editor companion window has UX rough edges: the URL field shows the raw
+`BORIS_EDITOR_URL=…` launch line (confusing, leaks internals), the toolbar is
+cluttered, error states give no guidance, and there is no menu-bar
+"Open in Browser" item.
+
+## Verified current state
+
+`EditorWindow` (`Sources/Companions/Editor/EditorWindow.swift`):
+- The URL `TextField` is bound to `urlText`, which is set to the **full**
+  tokenized URL (`EditorURL.opening(...).absoluteString`) — raw, on display.
+- The toolbar always shows nav buttons, phase indicator, Restart, Open-in-
+  Browser, **and** the URL field + Connect.
+- `headerTitle(for:)` **already falls back to `source.title`** when no page is
+  selected — the draft's "header fallback" item is **already implemented**;
+  do not rebuild it.
+- Failed phases render the raw message (`phase = .failed("Editor host exited
+  (N)…")`) with no guidance.
+- `Commands.swift` has no "Open Editor in Browser" menu item (the window
+  toolbar's Open-in-Browser button exists).
+
+## Scope — must land
+
+1. **Redacted URL field.** Show only `host:port`
+   (`127.0.0.1:49152`), with the full URL on hover tooltip and on double-click
+   (or a small reveal toggle). The field is **read-only** in normal use; it
+   becomes editable only in a "Manual Connect" mode (below). Handle IPv6
+   (`[::1]:9000`) and `localhost`.
+2. **Toolbar collapse.** Hide the URL field + Connect behind a **"Manual
+   Connect"** disclosure / menu item. The default toolbar shows: nav buttons,
+   phase indicator, Restart, Open-in-Browser. The URL field appears when the
+   user opens Manual Connect or when the phase is `.idle` / `.failed`.
+3. **Error guidance.** Map known failures to actionable copy:
+   - "boris-editor binary not found" → "Install boris-editor or set
+     SOLIPSIST_BORIS_EDITOR_BIN."
+   - "did not report a token URL within 15s" → "The host may be slow to start.
+     Try again or check its logs."
+   - "Editor host exited (N)" → "The editor host crashed. Check its logs."
+   - Unknown messages → show the raw message with no invented guidance.
+   - Add a "Copy Error" button on the error state.
+4. **Menu-bar item.** Add **"Open Editor in Browser"** to the View menu
+   (`Commands.swift`, `CommandGroup(after: .sidebar)` next to Preview/Editor/
+   Compose), enabled only when a loopback editor URL is current — same action
+   as the toolbar's Open-in-Browser.
+
+### Nice-to-have (not gate)
+
+5. Window title shows the page title ("Editor — Getting Started").
+6. Drag-and-drop a `BORIS_EDITOR_URL=` line from Terminal into the URL field.
+
+### Must not land
+
+- A full browser chrome (address bar, back/forward, bookmarks).
+- A custom URL parser — `EditorURL` is sufficient.
+- Rebuilding the header fallback (already implemented — see above).
+
+## Implementation sketch
+
+1. `reducedURL`: parse `session.editorURL` (or `urlText`) with `URLComponents`,
+   render `host:port`; `help()` shows the full string; a tap toggles a
+   full/reduced display.
+2. Wrap the URL field + Connect in a conditional `if showManualConnect ||
+   session.phase == .idle || session.phase == .failed { … }` with a
+   "Manual Connect" button toggling `showManualConnect`.
+3. In the idle/failed states, render a `VStack` of headline + guidance caption
+   + "Copy Error" button (copies the raw message to the pasteboard).
+4. In `Commands.swift`, add the View-menu item gated on
+   `session.editorURL != nil` (reach the session from the shared
+   `AppRuntime`/window state; if the session is window-local, expose the
+   current loopback URL through a small shared observable so the menu can
+   enable/disable).
+
+## Gate
+
+Open the Editor companion → the toolbar shows nav, phase, Restart, and
+Open-in-Browser only; the URL field shows `127.0.0.1:49152` (full URL on
+hover), and the raw launch line is not visible → "Manual Connect" reveals the
+editable field → a failed host shows actionable guidance + a Copy Error button
+→ View → Open Editor in Browser is enabled when connected and opens the URL in
+the default browser. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Tests
+
+- `testReducedURLShowsHostPort` — `host:port` rendered, not the full URL.
+- `testReducedURLHandlesIPv6` — `[::1]:9000` renders correctly.
+- `testManualConnectHiddenByDefault` — URL field hidden when connected.
+- `testErrorGuidanceShown` — a known failure maps to guidance; unknown shows
+  the raw message.
+- `testMenuOpenInBrowserEnabledWhenConnected` — the View item enables only
+  with a loopback URL.
+
+## Edge cases
+
+- IPv6 and `localhost` host rendering (see tests).
+- Very long source titles → `lineLimit(1)` truncation (already present).
+- Unknown error messages → raw message, no invented guidance.

--- a/docs/issues/editor-compose-accessibility.md
+++ b/docs/issues/editor-compose-accessibility.md
@@ -1,0 +1,56 @@
+# Editor: Accessibility — VoiceOver + Keyboard Across Editor Surfaces (tracker)
+
+**Track:** macOS native polish / accessibility
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
+**Lane:** design (this file) + five child issues. Does **not** own
+`Sources/`. Children do.
+
+## Why
+
+VoiceOver support is missing in five **disjoint** places: the Compose toolbar
+and diagnostics pane, the reading-pane header, the Preview toolbar, the
+Editor toolbar, and the mailbox sidebar counts. They share a goal (macOS
+accessibility) but own separate files in separate lanes, so one issue cannot
+be worked in one worktree. Split like M13 (#142) / M14 (#143): this is the
+tracker; each child is one lane, one worktree, one PR.
+
+## Children
+
+All five are independent — no child consumes another's file, state, or
+selection. They can run in five worktrees at once.
+
+| Child | Issue | Lane | Gate (short) |
+|-------|-------|------|----------------|
+| [A-1 Compose toolbar + diagnostics](editor-accessibility-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | every Compose toolbar control and diagnostics row announces |
+| [A-2 Reading pane header](editor-accessibility-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | header announces title, status, role |
+| [A-3 Preview toolbar](editor-accessibility-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | URL / reload / open-in-browser labeled |
+| [A-4 Editor toolbar](editor-accessibility-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | URL / connect / restart / nav labeled |
+| [A-5 Mailbox sidebar counts](editor-accessibility-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | Pages + trunk rows announce counts from the stored graph |
+
+Filed 2026-08-21 as #239–#243 (milestone 10). Close this tracker when all
+five land.
+
+## Shared nice-to-haves (not assigned — later)
+
+- VoiceOver rotor (headings / links / lines) in the Compose editor.
+- Dynamic Type scaling of the editor's monospaced font.
+- High-contrast pass on the highlighter palette (WCAG AA).
+- Switch Control reachability audit.
+
+## Must not land (any child)
+
+- A separate accessibility mode (accessibility is part of the main UI, not a
+  toggle).
+- A third-party accessibility library.
+- New count plumbing for Outputs / Activity (the sidebar does not hold that
+  data today).
+
+## Gate (whole)
+
+With all five children landed, VoiceOver (⌘F5) can navigate the Compose
+window, both companions, and the sidebar without visual assistance: every
+toolbar control announces, a diagnostics row announces "Error on line 12: …",
+the reading header announces "title, status, role", and the Pages / trunk rows
+announce item counts that update when the graph rebuilds.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/issues/editor-compose-find-replace.md
+++ b/docs/issues/editor-compose-find-replace.md
@@ -1,0 +1,101 @@
+# Editor: Find & Replace in Compose
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#225](https://github.com/drawmeanelephant/solipsist/issues/225)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The Compose editor has no Find & Replace. Authors editing large Markdown /
+Textile / Cooklang files cannot search the buffer, step through matches, or
+replace text. This is a basic macOS text-editing expectation (⌘F / ⌘G /
+⌘⇧G / replace).
+
+## Verified current state
+
+`ComposeTextView` (`Sources/Compose/ComposeTextView.swift`) creates a plain
+`NSTextView` in `makeNSView` with `isRichText = false` and
+`allowsUndo = true`. The view has no find-bar wiring: `usesFindBar` is never
+set, there is no `NSSearchToolbarItem`, and nothing calls
+`performTextFinderAction`. ⌘F does nothing today.
+
+## Scope
+
+### Must land
+
+- **⌘F** presents the **system** find bar over the text view
+  (`usesFindBar = true`; macOS handles the key equivalent).
+- **⌘G / ⌘⇧G** step next / previous through matches (the find bar's own
+  next/previous actions).
+- **Replace** is the find bar's built-in Replace tab (⌘⌥F focuses it, or the
+  segment in the bar). One / all replacement mutates `ComposeDocument.text`
+  and marks it dirty.
+- Match highlight must be visually distinct from the heuristic paint layer —
+  the system find bar draws its own selection highlight independent of the
+  attributed-string colors, so no conflict is expected; verify on a file with
+  headings/code/links painted.
+- Wrap-around at the end of the buffer (system default; verify).
+- Case-sensitive default with a case-insensitive toggle, and regex support —
+  both come from the system find bar's popover; do not build them.
+- The find bar is scoped to the current buffer, never the preview or the file
+  system.
+
+### Must not land
+
+- A custom find bar UI. Use the system `usesFindBar` path.
+- Find in the preview pane (that is a WKWebView surface, not our buffer).
+- Multi-file search (a content-tree feature, not Compose).
+- A third-party library. The NSTextView find bar is the path.
+
+## Gate
+
+Open a page in Compose (⌘⇧C) with a multi-line buffer → ⌘F shows the system
+find bar → typing a query highlights matches and ⌘G / ⌘⇧G walk them with
+wrap-around → Replace tab replaces one and all and marks the buffer dirty →
+the find bar is absent on the Compose empty state and does not survive a page
+switch. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Implementation sketch
+
+1. In `ComposeTextView.makeNSView`, enable the find bar:
+   ```swift
+   textView.usesFindBar = true
+   ```
+   The ⌘F / ⌘G / ⌘⇧G key equivalents are handled by the text view once this
+   is set. If they do not fire inside the SwiftUI window, wire them explicitly
+   in the Coordinator:
+   ```swift
+   textView.performTextFinderAction(NSSelectorFromString("showFindInterface:")) // ⌘F
+   textView.performTextFinderAction(NSSelectorFromString("showNextMatch:"))     // ⌘G
+   textView.performTextFinderAction(NSSelectorFromString("showPreviousMatch:")) // ⌘⇧G
+   ```
+2. `ComposeTextView` is an `NSViewRepresentable`; the find bar renders inside
+   the scroll view SwiftUI creates around the text view. If it does not appear,
+   build an explicit `NSScrollView` in `makeNSView` (the same change the
+   line-number gutter needs — see #226) and set `usesFindBar` on the text view
+   inside it.
+3. Replace writes through `ComposeDocument.text` (the buffer is the single
+   source of truth). The find bar edits the text storage; the Coordinator's
+   existing `textDidChange` already syncs storage → `document.text`, so no new
+   sync is needed — verify it fires for find-bar edits.
+4. No highlighter change is expected: the find bar's selection highlight is a
+   separate layer. Confirm visually with a painted buffer.
+
+## Tests
+
+- `testFindBarEnabled` — the text view reports `usesFindBar == true` after
+  `makeNSView` (unit-testable through the representable's view).
+- `testFindBarReplaceOne` — replacing one through the find bar updates
+  `ComposeDocument.text` and sets `isDirty`.
+- `testFindBarReplaceAll` — replace-all updates the buffer and marks dirty.
+- Manual (UI): ⌘F shows the bar; ⌘G wraps; case-insensitive and regex toggles
+  work; highlight does not fight the paint layer.
+
+## Edge cases
+
+- No document loaded → no find bar (the empty state has no `ComposeTextView`).
+- Page switch → the buffer changes; the view is recreated per document, so the
+  find bar closes naturally. Verify no stale find state persists.
+- Find-bar edits must not repaint the whole buffer — the existing incremental
+  `repaintChanged` path should handle them; verify.

--- a/docs/issues/editor-compose-go-to-line.md
+++ b/docs/issues/editor-compose-go-to-line.md
@@ -1,0 +1,86 @@
+# Editor: Go to Line Dialog (⌘L)
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#238](https://github.com/drawmeanelephant/solipsist/issues/238)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The Compose editor has no "Go to Line". Authors working from diagnostics (with
+line numbers) can jump via click-to-line, but there is no ⌘L dialog for a
+manual jump.
+
+## Verified current state
+
+`ComposeTextView` (`Sources/Compose/ComposeTextView.swift`) already has
+`jumpToCharacter` (a `var` on the representable) and the `Coordinator.jump(to:in:)`
+method that clamps, selects, and scrolls. `ComposeEditorView` computes a
+character offset from a diagnostic's `line` in `characterIndex(for:in:)`. There
+is no ⌘L shortcut, no line-number input, and no manual jump wiring.
+
+## Scope
+
+### Must land
+
+- **⌘L** opens a small **"Go to Line"** sheet over the editor.
+- The sheet has a **single text field** accepting a 1-based line number.
+- **Enter** / **Go** jumps the cursor to the start of that line and scrolls it
+  into view; **Escape** dismisses without jumping.
+- The field is **pre-filled with the current line number**.
+- **Validation**: non-integer input is rejected; a number beyond the buffer is
+  clamped to the last line.
+- The jump uses the existing `jumpToCharacter` seam — do not add a second
+  jump path.
+- The sheet must not appear when there is no document (empty state) or the
+  window is not key.
+
+### Nice-to-have (not gate)
+
+- Show the total line count: `Go to line (of 123):`.
+- Accept `line:column` (`12:45`).
+- A menu item Edit → Go to Line… (menus-first rule; only if cheap).
+
+### Must not land
+
+- A separate window or full-screen overlay.
+- A third-party library.
+- **"Undoable" jump.** Cursor moves are not part of `NSTextView`'s undo stack;
+  do not try to make a selection change undoable. (The draft asked for this —
+  it is not how AppKit undo works.)
+
+## Implementation sketch
+
+1. Add `@State private var showGoToLine = false` to `ComposeEditorView`; wire
+   ⌘L (`.keyboardShortcut("l", modifiers: .command)`) to set it true. Verify ⌘L
+   is not already taken in the Compose window (the Boris menu uses ⌘⇧L for
+   Plan, not ⌘L).
+2. Present the sheet (`.sheet(isPresented: $showGoToLine)`) with a small view:
+   a `TextField` pre-filled with the current line, Cancel / Go buttons, and
+   `onSubmit` → jump.
+3. `onJump(line:)` computes the character offset of that line via
+   `NSString.lineRange` (handle CRLF/CR/BOM the same way the diagnostics
+   click-to-line does) and sets the existing `jumpToCharacter` state.
+4. The `Coordinator.jump(to:in:)` already clamps, selects, and scrolls — no
+   new code there.
+
+## Gate
+
+Open a page in Compose → ⌘L opens the sheet pre-filled with the current line →
+entering `5` jumps to line 5 and scrolls it into view → entering `99999`
+clamps to the last line → entering `abc` does nothing → Escape dismisses
+without jumping → no sheet on the empty state. `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.
+
+## Tests
+
+- `testGoToLineJumpsToLine` — line 5 maps to the correct character offset.
+- `testGoToLineClampsToLastLine` — an out-of-range line clamps to the last.
+- `testGoToLineRejectsNonInteger` — non-integer input does not jump.
+- `testGoToLinePreFillsCurrentLine` — the field shows the current line.
+
+## Edge cases
+
+- Empty state (no document) → no sheet.
+- Window not key → no keyboard input, no sheet.
+- CR / CRLF / CR and a leading BOM → line→offset mapping stays correct.

--- a/docs/issues/editor-compose-highlight-edge-cases.md
+++ b/docs/issues/editor-compose-highlight-edge-cases.md
@@ -1,0 +1,127 @@
+# Editor: Compose Highlighting Edge Cases
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#235](https://github.com/drawmeanelephant/solipsist/issues/235)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The heuristic highlighter (`ComposeHighlighter`) has edge cases where the
+paint layer produces inconsistent results. These are not parser bugs (the
+grammar lives in Oliver) but visual regressions that make the editor feel
+unpolished.
+
+## Verified current state
+
+`ComposeHighlighter` (`Sources/Compose/ComposeHighlighter.swift`) applies
+ordered regex rules over the whole buffer; later rules repaint over earlier
+ones; front matter is painted last. Incremental repaint
+(`repaintChanged` in `ComposeTextView`) restyles only the changed line(s).
+Relevant rules today:
+
+- Inline code: `#"`[^`\n]+`"#` (single-line only).
+- Emphasis family: `***`/`___` first, then `**`/`__` with `(?<![*_])` /
+  `(?![*_])` guards, then single `*`/`_`.
+- Autolink: `#"<[^<>\s]+>"#` (paints the brackets too).
+- HTML comments: **no rule**.
+- Cooklang notes: `#"^>[ \t]?[^\n]*"#` (per-line).
+- Markdown fenced code already uses `dotMatchesLineSeparators`.
+
+## Method — test first, then fix
+
+For **each** item below: write the failing test in `ComposeHighlighterTests`
+first, confirm it fails on the current rules (proving the bug is real), then
+fix. Some items listed in the draft may already be handled by the existing
+lookbehind guards — a failing test is the only honest way to know, and it
+prevents "fixing" a non-bug.
+
+## Scope — must land (each gated on a failing test)
+
+1. **Bold/italic inside code spans** — `**bold**` inside backticks should stay
+   code-green. The inline-code rule paints first (it is earlier in the array)
+   but the strong rule repaints over it. Verify the ordering actually loses;
+   the region fenced-code rule already wins because it paints later.
+2. **Multi-line / unclosed backtick runs** — the `[^\n]` code rule stops at a
+   newline, so a backtick run that wraps lines paints inconsistently. Per
+   CommonMark, backtick code spans do **not** span lines — so the correct
+   outcome may be "leave the wrapped run unpainted / paint only the valid
+   single-line span," not "match across lines." Pin the decision with a test
+   and the rule comment.
+3. **Nested emphasis** — `***bold and italic***` should paint uniformly.
+   Verify whether the `(?<![*_])` / `(?![*_])` guards already prevent the
+   inner `**` rule from repainting (they likely do). If the test passes
+   already, drop the item and say so in the PR — do not churn the rules.
+4. **Autolink brackets** — `<https://x.dev>` paints the angle brackets
+   link-blue; the URL is the link, the brackets are not. Fix the rule to paint
+   only the inner URL (or add a follow-up rule that re-paints the brackets
+   plain).
+5. **HTML comments** — `<!-- comment -->` is unpainted. Add a comment rule
+   (`.secondaryLabelColor`, italic) placed **before** the inline rules so
+   inner markup does not repaint it.
+6. **Cooklang multi-line notes** — consecutive `> note` lines paint the
+   marker but not the whole block. Extend the note rule to match a run of
+   consecutive `>` lines (anchored), or accept per-line paint if that is the
+   intended shape — pin with a test.
+7. **Front matter with YAML block scalars** — `title: |` + indented lines
+   inside `---` must stay gray (front matter is painted last, so verify the
+   last-paint already wins; the draft claims a `#` inside the block repaints
+   as a heading — confirm with a failing test).
+
+### Nice-to-have (not gate)
+
+8. Diff highlighting (added/removed gutter marks on load).
+9. Bracket matching (highlight the matching `(`/`[`/`{`).
+10. Current-line highlight (subtle background tint).
+
+### Must not land
+
+- A full AST parser (the grammar lives in Oliver).
+- A tree-sitter integration (separate project scope).
+- A third-party highlighting library.
+
+## Implementation sketch
+
+- **Code-span priority**: the cleanest fix for #1/#2 is a two-pass order where
+  code spans are found and painted, then inline rules are blocked inside them
+  (the existing region rules already do this by painting last). Prefer that
+  over adding `dotMatchesLineSeparators` to the inline code rule (which would
+  violate CommonMark).
+- **HTML comments**: `rule(#"<!--[\s\S]*?-->", comment, dotMatches: true)`
+  placed before the inline family.
+- **Cooklang notes**: `rule(#"(?:^>[^\n]*\n?)+", note, anchors: true,
+  dotMatches: true)` — or keep per-line paint if the test says that is fine.
+- **Incremental repaint**: multi-line fixes interact with `repaintChanged`,
+  which only repaints the changed line(s). A multi-line rule that crosses the
+  edited line needs the repaint range expanded to the full rule match (or a
+  full repaint on that edit). Keep the incremental path honest — do not
+  silently fall back to full repaints that regress LATER-3.2.
+
+## Gate
+
+Each must-land item has a **failing test that starts passing** after the fix
+(`make test` green, no regressions in `ComposeHighlighterTests`). A painted
+`Stunts/happy` file shows consistent code-span, emphasis, autolink, comment,
+and front-matter paint. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Tests
+
+- `testCodeSpanSuppressesBold` — `**bold**` inside backticks stays code.
+- `testWrappedBacktickRunPaintedConsistently` — the pinned behavior for a
+  wrapped run (likely: only the valid single-line span is code).
+- `testNestedEmphasisPaintedConsistently` — `***bold italic***` uniform (may
+  pass already — confirm).
+- `testAutolinkBracketsNotPainted` — `<https://x.dev>` paints only the URL.
+- `testHTMLCommentPaintedAsComment` — `<!-- c -->` is `.secondaryLabelColor`.
+- `testCooklangMultiLineNotePainted` — consecutive `>` lines paint as notes.
+- `testFrontMatterBlockScalarNotPaintedAsHeading` — `#` inside a block scalar
+  stays gray.
+
+## Edge cases
+
+- The code-span fix must not break the incremental repaint (multi-line regions
+  need the repaint range expanded, not a full repaint).
+- The HTML comment rule must not match `--` inside fenced code blocks (region
+  rules paint last and win — verify).
+- The Cooklang note rule must not swallow `>` in Markdown blockquotes — the
+  language is Cooklang, not Markdown, so this is not a conflict, but verify.

--- a/docs/issues/editor-compose-line-numbers.md
+++ b/docs/issues/editor-compose-line-numbers.md
@@ -1,0 +1,99 @@
+# Editor: Line Numbers Gutter in Compose
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#226](https://github.com/drawmeanelephant/solipsist/issues/226)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The Compose editor has no line number gutter. Authors editing large files
+cannot orient by line number, and diagnostics (which carry `line` fields)
+have no visual counterpart in the buffer — click-to-jump exists but the user
+cannot verify the number.
+
+## Verified current state
+
+`ComposeTextView` (`Sources/Compose/ComposeTextView.swift`) returns a bare
+`NSTextView` from `makeNSView` (`isVerticallyResizable = true`,
+`widthTracksTextView = true`). There is no scroll view, no ruler, no gutter.
+`ComposeEditorView`'s diagnostics pane shows line numbers and click-to-jump
+works (`characterIndex(for:in:)` → `jumpToCharacter`), but the editor itself
+shows no line reference.
+
+## Scope
+
+### Must land
+
+- A **line number gutter** on the left of the text view, updating live as the
+  author types.
+- Numbers in a **monospaced font** at the editor size (13pt), colored
+  `.secondaryLabelColor`.
+- The gutter **scrolls vertically with the text** and stays fixed horizontally
+  (Xcode-style).
+- The currently selected line's number is **highlighted** (bolder or tinted)
+  so the cursor position is always visible.
+- Gutter width fits 3–4 digits (~9999 lines), minimum ~36pt.
+- The gutter is absent on the Compose empty state (no document).
+
+### Nice-to-have (not gate)
+
+- A thin separator between gutter and text.
+- Clicking a line number selects that line.
+
+### Must not land
+
+- A hand-rolled overlay that does not track the text view's scroll (the
+  number one way this card goes wrong).
+- Line numbers in the preview pane.
+- A third-party library.
+
+## Implementation sketch
+
+1. **Recommended: an `NSRulerView` subclass attached to the scroll view's
+   vertical ruler.** `NSScrollView` tracks ruler views with the content for
+   free — no manual scroll math. `LineNumberRulerView` overrides
+   `draw(_:)`, enumerates the visible line range from the text view's
+   `textContainer`, and draws numbers + the current-line highlight.
+2. `ComposeTextView.makeNSView` currently returns a bare `NSTextView` that
+   SwiftUI wraps. To attach a ruler you will likely need to build an explicit
+   `NSScrollView` in `makeNSView` containing the text view, then set
+   `scrollView.verticalRulerView = LineNumberRulerView(textView:)` and
+   `scrollView.hasVerticalRuler = true`. Keep the text view's existing
+   configuration (width tracking, inset, highlighting) intact.
+3. Invalidate on `textDidChange` (line count changed) and on selection change
+   (highlight moved). The Coordinator already receives both; forward them to
+   the ruler.
+4. Draw only the visible range (from `textView.bounds` + `textContainer` line
+   fragments) so huge buffers stay cheap.
+5. If the ruler approach fights the view (it should not — it is the standard
+   path), fall back to a sibling `NSView` overlay that mirrors the scroll
+   offset via `NSView.boundsDidChangeNotification` on the clip view. Prefer
+   the ruler; it is less code and cannot desync.
+
+## Gate
+
+Open a page in Compose → the gutter shows 1..N aligned with the buffer →
+typing adds/removes lines and the gutter updates → moving the cursor
+highlights the current line's number → scrolling keeps the gutter aligned →
+the gutter is absent on the empty state. `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.
+
+## Tests
+
+- `testLineGutterLineCount` — the ruler's line count matches the buffer's
+  `NSString` line count (empty buffer → 1).
+- `testLineGutterHighlightFollowsSelection` — moving the selection changes
+  the highlighted line.
+- Manual: gutter scrolls in lockstep; long lines do not wrap in the gutter;
+  the paint layer is unaffected.
+
+## Edge cases
+
+- Empty buffer → show line 1.
+- CR / LF / CRLF and a leading BOM → use `NSString.lineRange` /
+  `lineRange(for:)` so line 1 is not offset by the BOM.
+- Very long single lines (no wrap — `widthTracksTextView`) → the gutter
+  counts lines, not wrapped visual rows; that is fine and expected.
+- The gutter must not touch the text storage (it draws in its own view), so
+  it cannot fight the highlighter.

--- a/docs/issues/editor-compose-preview-webview.md
+++ b/docs/issues/editor-compose-preview-webview.md
@@ -1,0 +1,127 @@
+# Editor: Compose Preview — Replace NSAttributedString with WKWebView
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#230](https://github.com/drawmeanelephant/solipsist/issues/230)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The Compose preview pane renders HTML through
+`NSAttributedString(data:options:.documentType:html)`, which has no CSS, no
+JavaScript, no `<video>/<audio>/<iframe>`, blocks the main thread on large
+documents, and renders unsandboxed in-process.
+
+## Verified current state
+
+`ComposePreviewView` (`Sources/Compose/ComposePreview.swift`) debounces
+renders with a 300ms `.task(id:)` then calls the injected `MarkupRenderService`
+(Oliver-backed) and hands the HTML string to `ComposeHTMLPreview`, an
+`NSViewRepresentable` that sets the text on a non-editable `NSTextView` via
+`NSAttributedString(data:options:.documentType:html)`. The render pipeline
+(Oliver → HTML string) stays; only the host view changes.
+
+## Scope
+
+### Must land
+
+- Replace `ComposeHTMLPreview`'s `NSTextView` with a **`WKWebView`** that
+  renders the HTML fragment.
+- **Theme CSS**: apply the canonical HTML target's theme CSS (resolved from
+  the source's profile / `themes/` when present) as an **inlined `<style>`
+  element in the fragment's `<head>`**. When no theme resolves, fall back to
+  a minimal readable stylesheet. Do not build a theme picker.
+- **Sandboxed rendering**:
+  - non-persistent `WKWebsiteDataStore` (no disk cache);
+  - a `WKNavigationDelegate` that cancels every navigation except the initial
+    load;
+  - loopback-only posture — no external network.
+- **Preserve the existing 300ms debounce** (it lives in `ComposePreviewView`;
+  do not move it).
+- **Do not scroll to top on every re-render** — that is jarring while typing
+  mid-file. A full reload resets scroll anyway; preserving position is a
+  best-effort out-of-gate nicety, not a requirement.
+
+### Nice-to-have (not gate)
+
+- Scroll-position preservation across re-renders (minimal JS).
+- Dark-mode support (system appearance + theme dark variant).
+- Print (⌘P) from the preview.
+
+### Must not land
+
+- A second `WKWebView` session shared with the Preview companion (that is a
+  separate watch server).
+- An app-side HTTP server (D11: "no app-side HTTP server").
+- A third-party rendering library.
+
+## Design note — resolve the baseURL contradiction
+
+The draft said "load with a loopback `baseURL`" **and** "no app-side HTTP
+server". Those cannot both hold: a loopback baseURL makes relative URLs
+resolve to `http://127.0.0.1/...`, which only works if something serves that
+port. The clean resolution:
+
+- **Inline the theme CSS as a `<style>` tag** — the fragment becomes
+  self-contained, so styling needs no file or network access at all.
+- **Relative image/media URLs in the content are out of scope for the compose
+  preview.** Resolving them is the full-site Preview companion's job (it has
+  the watch server). Declare it in the card so the worker does not chase it.
+- Load the fragment with `loadHTMLString(_:baseURL: nil)` or a `data:` URL.
+  Do **not** use a `file://` baseURL: in the sandbox, WebKit's web-content
+  process may not hold the security-scoped extension for the user's folder,
+  so file subresources silently fail. That is exactly why the CSS is inlined.
+
+## Implementation sketch
+
+1. Rewrite `ComposeHTMLPreview` as a `WKWebView` `NSViewRepresentable`:
+   ```swift
+   struct ComposeHTMLPreview: NSViewRepresentable {
+       let html: String // fragment with theme <style> already inlined
+       func makeNSView(context: Context) -> WKWebView {
+           let config = WKWebViewConfiguration()
+           config.websiteDataStore = .nonPersistent()
+           let webView = WKWebView(frame: .zero, configuration: config)
+           webView.navigationDelegate = context.coordinator
+           return webView
+       }
+       func updateNSView(_ webView: WKWebView, context: Context) {
+           webView.loadHTMLString(html, baseURL: nil)
+       }
+   }
+   ```
+2. `WKNavigationDelegate.decidePolicyFor` returns `.cancel` for every request
+   after the initial load (and `.cancel` for any non-`about:`/`data:` scheme).
+3. Build the full fragment before handing it to the view: wrap Oliver's HTML
+   in `<html><head><style>…theme…</style></head><body>…</body></html>`, with
+   the theme CSS read from the source's `themes/` (canonical target's theme)
+   or the minimal fallback. This assembly is pure and unit-testable.
+4. Keep `ComposePreviewView` unchanged except that `html` is now the wrapped
+   fragment.
+
+## Gate
+
+Open a page in Compose → the preview renders styled HTML (theme CSS applied
+when present) instead of unstyled text → typing re-renders after the 300ms
+debounce without blocking the UI → clicking a link in the preview does not
+navigate → switching pages does not leak the previous fragment →
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Tests
+
+- `testPreviewFragmentWrapsHTML` — the assembled fragment contains the theme
+  `<style>` and the body content.
+- `testPreviewThemeCSSFallback` — no theme → the minimal stylesheet is used.
+- `testPreviewSandboxBlocksNavigation` — `decidePolicyFor` cancels a link
+  click / external URL.
+- Manual: large document renders without blocking; rapid re-renders do not
+  leak memory; malformed HTML does not crash.
+
+## Edge cases
+
+- Empty HTML → blank page, not an error.
+- Very large documents → WKWebView renders asynchronously; no main-thread
+  block.
+- Malformed HTML → WKWebView is forgiving; no crash.
+- Page switch → the view is recreated per document; no retained reference to
+  the previous fragment.

--- a/docs/issues/editor-compose-split-resize.md
+++ b/docs/issues/editor-compose-split-resize.md
@@ -1,0 +1,96 @@
+# Editor: Compose Split Pane Resize Handle + Auto-Save
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#227](https://github.com/drawmeanelephant/solipsist/issues/227)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The Compose editor's split has no visible resize handle and no persistence.
+The ratio resets on every window open, and dragging a divider can push a pane
+below its minimum.
+
+## Verified current state
+
+`ComposeEditorView` (`Sources/Compose/ComposeEditorView.swift`) uses a raw
+`HSplitView` with three children: `ComposeFrontmatterForm` (min 230),
+`ComposeTextView` (min 280), `ComposePreviewView` (min 240, conditional).
+`frame(minWidth:)` sets layout minimums but there is no `dividerStyle`, no
+`autosaveName`, and no delegate — the ratio is whatever the view computes on
+open and the dividers are thin by default with no persistence.
+
+## Scope
+
+### Must land
+
+- A **visible, draggable divider** between panes (`HSplitView` divider or
+  `NSSplitView` `.thin` style).
+- The split ratio **persists across sessions**, scoped per document type
+  (e.g. Markdown vs Cooklang) so each frontend keeps its own layout.
+- **Minimum pane widths enforced on drag**: editor ≥ 280, preview ≥ 240,
+  frontmatter ≥ 230. The `frame(minWidth:)` values must be the real clamp, not
+  just a layout hint.
+- Toggling the frontmatter form off expands the editor into the freed space
+  (no gap); toggling it on never collapses editor or preview below their
+  minimums.
+
+### Nice-to-have (not gate)
+
+- A toolbar button to reset the split to the default.
+- Double-click a divider to distribute panes evenly.
+- **Keyboard resize of the divider** — note: `NSSplitView` dividers are not
+  keyboard-resizable natively; this is real custom work. Keep it out of the
+  gate unless it falls out cheaply.
+
+### Must not land
+
+- A custom drag handle that fights `NSSplitView`'s built-in behavior.
+- A third-party split library.
+- A divider inside the preview pane (a WKWebView surface).
+
+## Implementation sketch
+
+1. **Autosave + clamping need `NSSplitView`.** SwiftUI's `HSplitView` does not
+   expose `autosaveName` or the delegate. Two workable options:
+   - **Preferred:** wrap the split in an `NSViewRepresentable` around an
+     `NSSplitView` (three subviews, `isVertical = true`, `dividerStyle = .thin`)
+     and set `autosaveName = "ComposeSplit-<language>"` plus
+     `NSSplitViewDelegate.splitView(_:constrainMinCoordinate:ofSubviewAt:)`
+     returning the min widths. This gives autosave and clamping in one place.
+   - Simpler if you want to stay in SwiftUI: keep `HSplitView`, persist the
+     divider positions to `UserDefaults` keyed by `"ComposeSplit-<language>"`
+     on change (track via the divider drag or the pane frames), and restore on
+     appear. Clamping still needs the `NSSplitView` delegate, so the
+     representable is the honest path for the minimum-width guarantee.
+2. Scope the autosave/persistence key by `document.language.rawValue` so the
+   Markdown ratio and the Cooklang ratio are independent.
+3. When the frontmatter pane is hidden, remove it from the split (today the
+   `if showFrontmatter` already removes the child) — the remaining panes
+   reflow; verify no gap.
+4. Keep the window's `minWidth: 640` (`ComposeWindow`) consistent with the
+   sum of the pane minimums.
+
+## Gate
+
+Open a page in Compose → drag the divider → panes clamp at their minimums
+(editor 280 / preview 240 / frontmatter 230) → close and reopen the window →
+the ratio is restored → toggle Front Matter → the editor expands without a
+gap and nothing collapses below its minimum. `SKIP_EMBED_BORIS=1 make build` +
+`make test` green.
+
+## Tests
+
+- `testSplitAutosavePersists` — two document types keep independent ratios
+  across window recreation (assert on the persisted positions).
+- `testSplitMinimumWidths` — dragging past the minimum clamps at the minimum
+  (assert via the delegate's `constrainMinCoordinate`).
+- Manual: frontmatter toggle never collapses editor/preview below minimums.
+
+## Edge cases
+
+- Only one pane visible (editor only, no preview) → no divider to drag;
+  verify the split handles a single child cleanly.
+- The autosave name must not collide with the Editor companion window's
+  split (different window, different key namespace).
+- Restoring a saved ratio must not fight the window's `minWidth: 640`.

--- a/docs/issues/editor-compose-status-bar.md
+++ b/docs/issues/editor-compose-status-bar.md
@@ -1,0 +1,98 @@
+# Editor: Compose Status Bar — Cursor Position + Word Count
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#228](https://github.com/drawmeanelephant/solipsist/issues/228)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The Compose status bar shows filename / language / frontmatter / dirty state
+but no **cursor position** (line:column) or **word / character count** —
+standard expectations for long-form editing and word-limit matching.
+
+## Verified current state
+
+`ComposeWindow.statusBar` (a `.safeAreaInset(edge: .bottom)` in
+`Sources/Compose/ComposeWindow.swift`) renders `document.statusText`
+(filename, language, frontmatter, dirty), a `saveStatus`, and the
+coordinator summary. Cursor position is not tracked; word count is not
+computed. `ComposeDocument` (`Sources/Compose/ComposeDocument.swift`) is an
+`@Observable` class with `text`, `language`, `isDirty`, `statusText`.
+
+## Scope
+
+### Must land
+
+- **Line:Column** in the status bar, updated on every cursor movement.
+  Format `Ln 12, Col 45` (Xcode-style).
+- **Word count**, updated on text change. Format `1,234 words`.
+- **Character count** as a secondary stat: `5,678 chars`.
+- Stats are **right-aligned**, opposite the save status.
+- Stats are absent on the Compose empty state (no document).
+
+### Nice-to-have (not gate)
+
+- **Selection character count**: with text selected, show `42 selected`
+  alongside the total.
+- **Reading-time estimate**: `~5 min read` at ~200 wpm.
+- Clicking the line:column opens the **Go to Line** sheet — that is
+  [#238](https://github.com/drawmeanelephant/solipsist/issues/238); do not
+  build it here.
+
+### Must not land
+
+- A popover or tooltip — the stats live in the status bar (Mail / Xcode).
+- A third-party word-count library. `NSString.enumerateSubstrings` with
+  `.byWords` is sufficient.
+
+## Implementation sketch
+
+1. **Track the selection.** `ComposeDocument` is `@Observable`, so add a plain
+   stored property `var selection: NSRange = NSRange(location: 0, length: 0)`
+   and update it from the Coordinator's `textViewDidChangeSelection(_:)`
+   (add the delegate method to `ComposeTextView.Coordinator`). `@Observable`
+   publishes plain properties — do not use `@Published` (that is
+   `ObservableObject`).
+2. **Line:Column** is computed in the status bar from `document.selection` +
+   `document.text` via `NSString.lineRange(for:)` (UTF-16 offsets; the buffer
+   is `String`, convert with `as NSString`).
+3. **Word count** is computed on text change, not per keystroke in the view.
+   The Coordinator's `textDidChange` already runs per edit — compute
+   `document.wordCount` there with `NSString.enumerateSubstrings(... .byWords)`
+   and store it. If profiling shows a large buffer is slow per keystroke,
+   debounce to ~100ms (out of the gate).
+4. In `ComposeWindow.statusBar`, add the right-aligned stats beside/over the
+   existing `saveStatus`:
+   ```swift
+   Spacer()
+   Text("Ln \(line), Col \(col)")
+   Text("\(wordCount) words")
+   Text("\(charCount) chars")
+   ```
+   `.font(.caption.monospacedDigit()).foregroundStyle(.secondary)`.
+
+## Gate
+
+Open a page in Compose → the status bar shows `Ln 1, Col 1` and `0 words` →
+arrow keys / clicking update Ln/Col live → typing updates the word and
+character counts → the stats are right-aligned and absent on the empty state.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Tests
+
+- `testWordCountUpdatesOnInsert` / `OnDelete` — inserting/deleting a word
+  changes `document.wordCount`.
+- `testWordCountHandlesMultipleSpaces` — consecutive spaces do not create
+  words.
+- `testCursorPositionUpdatesOnNavigation` — moving the selection updates
+  `document.selection`; the computed Ln/Col matches.
+- `testCursorPositionAtEndOfLine` — typing at a line end increments Col.
+
+## Edge cases
+
+- Empty buffer → `0 words`, `Ln 1, Col 1`.
+- Very long lines → word count stays cheap (see debounce note).
+- CR / LF / CRLF and a leading BOM → `lineRange(for:)` handles line endings;
+  verify the BOM does not offset column 1.
+- Stats must not render when the Compose window has no document (empty state).

--- a/docs/issues/editor-compose-tab-key.md
+++ b/docs/issues/editor-compose-tab-key.md
@@ -1,0 +1,107 @@
+# Editor: Tab Key — Indent with 2 Spaces
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#229](https://github.com/drawmeanelephant/solipsist/issues/229)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The Compose editor does not handle Tab intentionally. `NSTextView`'s default
+inserts a tab character (or moves focus), but authors expect Tab to **indent**
+the current or selected lines and Shift+Tab to **outdent** — like Xcode and
+TextEdit.
+
+## Verified current state
+
+`ComposeTextView` (`Sources/Compose/ComposeTextView.swift`) wraps an
+`NSTextView` with `isRichText = false`, `allowsUndo = true`. The `Coordinator`
+implements `NSTextViewDelegate` for `textDidChange` and completion
+(`maybeOpenCompletion` → `textView.complete(nil)` for Cooklang markers) but
+does **not** implement `textView(_:doCommandBy:)`, so Tab falls through to
+AppKit's default.
+
+## Scope
+
+### Must land
+
+- **Tab** inserts **2 spaces** (Boris's indentation convention for Markdown,
+  Textile, and Cooklang).
+- With **multiple lines selected**, Tab indents **every selected line** (it
+  must not replace the selection with spaces).
+- **Shift+Tab** outdents the current or every selected line — removes one
+  level of leading whitespace (2 spaces, or 1 tab if that is what is present).
+- Indent/outdent is **one undo group** (indenting 10 lines = one ⌘Z).
+- **Cooklang completion**: when the completion popup is open at a Cooklang
+  marker, Tab must **accept the selected suggestion**, not indent. The popup
+  is opened by `maybeOpenCompletion`; respect it.
+
+### Nice-to-have (not gate)
+
+- Tab mid-line inserts indentation; Tab mid-word inserts a literal tab
+  (Xcode's "Insert Tab" nuance).
+- A preference for 2 vs 4 spaces (app plist).
+
+### Must not land
+
+- Tab inserting a literal `\t` character (Boris content is space-indented).
+- Tab replacing the selection with a tab character.
+- A third-party key-binding library.
+
+## Implementation sketch
+
+1. In `ComposeTextView.Coordinator`, implement
+   `textView(_:doCommandBy:)`:
+   ```swift
+   func textView(_ textView: NSTextView, doCommandBy command: Selector) -> Bool {
+       if command == #selector(NSResponder.insertTab(_:)) {
+           // Cooklang completion open → let the default insert the
+           // selected suggestion instead of indenting.
+           if textView.rangeForUserCompletion != nil { return false }
+           indentSelection(textView, direction: .in)
+           return true
+       }
+       if command == #selector(NSResponder.insertBacktab(_:)) {
+           indentSelection(textView, direction: .out)
+           return true
+       }
+       return false
+   }
+   ```
+   Returning `true` consumes the key; `false` lets the default run.
+2. `indentSelection` operates on the selected line range(s) (expand the
+   selection to full lines via `NSString.lineRange`), prepending or removing
+   2 leading spaces per line, wrapped in a single undo group
+   (`textView.shouldChangeText(in:replacementString:)` + undo manager, or
+   `undoManager` grouping).
+3. Verify the Cooklang case: when the completion popup is up, `insertTab:` may
+   not even reach `doCommandBy` (the completion window consumes it). If it
+   does, the `rangeForUserCompletion != nil` check above handles it.
+
+## Gate
+
+Open a Markdown page → Tab indents the line with 2 spaces → select 3 lines +
+Tab indents all 3 → Shift+Tab outdents → ⌘Z reverts the whole indent in one
+step → Tab on an empty line inserts 2 spaces (focus does not move). In a
+Cooklang buffer with a completion open, Tab inserts the selected suggestion,
+not spaces. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Tests
+
+- `testTabInsertsTwoSpaces` — Tab at line start inserts 2 spaces.
+- `testTabIndentsMultipleLines` — 3 selected lines all get indented.
+- `testShiftTabOutdents` — removes 2 leading spaces; a leading tab is removed
+  as one level.
+- `testTabUndoable` — indenting 5 lines then ⌘Z reverts all 5 (one undo
+  group).
+- `testTabDoesNotReplaceSelection` — selecting "hello" and pressing Tab
+  indents the line, does not replace the selection.
+
+## Edge cases
+
+- Empty line → Tab inserts 2 spaces, does not move focus.
+- End of a long line → Tab indents the line, not the caret position.
+- Mixed spaces+tabs in a line → outdent removes whichever leading whitespace
+  is present (2 spaces or 1 tab), never both.
+- Find bar open → Tab focuses the find field; the editor's `doCommandBy` must
+  not fire (it is a different responder — verify).

--- a/docs/issues/editor-compose-toolbar-save-tree-write.md
+++ b/docs/issues/editor-compose-toolbar-save-tree-write.md
@@ -1,0 +1,112 @@
+# Editor: Compose Toolbar Save Must Suspend Preview Watch
+
+**Track:** Compose depth / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#231](https://github.com/drawmeanelephant/solipsist/issues/231)
+**Lane:** `Sources/Compose/`
+
+## Problem
+
+The toolbar Save button writes the file **before** the preview watch is
+suspended, so Boris can read a partially-written file and trigger a rebuild
+mid-write. The fix is a one-line change: route the toolbar through the
+window's save flow instead of saving directly.
+
+## Verified current state (read these two files before changing anything)
+
+`Sources/Compose/ComposeEditorView.swift` — the toolbar Save button:
+
+```swift
+Button {
+    do {
+        saveError = nil
+        if try document.save() {
+            onSave?()
+        }
+    } catch {
+        saveError = error.localizedDescription
+    }
+} label: {
+    Label("Save", systemImage: "square.and.arrow.down")
+}
+.keyboardShortcut("s", modifiers: .command)
+.disabled(!document.isDirty)
+```
+
+`Sources/Compose/ComposeWindow.swift` — the host wires `onSave: save`, and
+`save()` is the correct tree-writing flow:
+
+```swift
+private func save() {
+    saveStatus = nil
+    do {
+        runtime.coordinator.beginTreeWrite()
+        defer { runtime.coordinator.endTreeWrite() }
+        guard try document.save() else { return }
+        runtime.coordinator.noteSave()
+        saveStatus = "Saved · queued validate"
+    } catch {
+        saveStatus = error.localizedDescription
+    }
+}
+```
+
+**The bug, precisely:** the toolbar calls `document.save()` first — an
+**unsuspended** write — then calls `onSave?()` → `save()`, which suspends the
+watch and calls `document.save()` again (a no-op because `isDirty` is already
+false). So today the file is written exactly once, but **outside** the
+`beginTreeWrite()` / `endTreeWrite()` window. The window's own `save()` is
+already correct; only the toolbar bypasses it.
+
+## Scope
+
+### Must land
+
+- The toolbar Save button must **not** call `document.save()` directly. It
+  calls `onSave?()` only, which flows through `ComposeWindow.save()` and the
+  `beginTreeWrite()` / `endTreeWrite()` window:
+  ```swift
+  Button {
+      onSave?()
+  } label: {
+      Label("Save", systemImage: "square.and.arrow.down")
+  }
+  .keyboardShortcut("s", modifiers: .command)
+  .disabled(!document.isDirty)
+  ```
+- **Error surfacing moves.** Today the toolbar catches save errors into
+  `saveError` (inline red text). Routing through `save()` moves failures to
+  `saveStatus` in the status bar, which already renders red on failure
+  (`ComposeWindow.statusBar`). Decide one surface and remove the other —
+  `saveStatus` is the single source of truth; delete the toolbar's `saveError`
+  state and its red text.
+- Toolbar Save stays disabled when `!document.isDirty` (already true — keep).
+
+### Must not land
+
+- A second `beginTreeWrite()` / `endTreeWrite()` pair (one pair in `save()`
+  is correct; nested pairs are redundant).
+
+## Gate
+
+With a Compose document open and the preview watch running, click the toolbar
+Save → the file is written **exactly once**, inside
+`beginTreeWrite()`/`endTreeWrite()` (assert via the coordinator's tree-write
+state during the write) → `noteSave()` is queued → the watch does not rebuild
+mid-write → save errors appear in the status bar. `SKIP_EMBED_BORIS=1 make
+build` + `make test` green.
+
+## Tests
+
+- `testToolbarSaveWritesInsideTreeWrite` — the save path calls
+  `beginTreeWrite()` before the write and `endTreeWrite()` after.
+- `testToolbarSaveWritesOnce` — `document.save()` runs exactly once per Save
+  (no double write).
+- `testToolbarSaveQueuesValidation` — `noteSave()` is called after the write.
+
+## Edge cases
+
+- Watch already suspended → `beginTreeWrite()` is idempotent; no failure.
+- No watch running → `beginTreeWrite()` is a no-op; no failure.
+- Write fails → the `defer` in `save()` guarantees `endTreeWrite()` runs; the
+  error shows in `saveStatus`.

--- a/docs/issues/editor-preview-zoom.md
+++ b/docs/issues/editor-preview-zoom.md
@@ -1,0 +1,96 @@
+# Editor: Preview Companion — Pinch-to-Zoom + Zoom Controls
+
+**Track:** Preview companion / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#234](https://github.com/drawmeanelephant/solipsist/issues/234)
+**Lane:** `Sources/Companions/Preview/`
+
+## Problem
+
+The Preview companion's `WKWebView` does not support pinch-to-zoom or ⌘+/⌘-/
+⌘0 controls. Authors reviewing their published site cannot zoom in to inspect
+detail or zoom out to see the full layout.
+
+## Verified current state
+
+`PreviewWebModel` (`Sources/Companions/Preview/PreviewWindow.swift`) creates
+`let webView = WKWebView()` with default configuration — no
+`allowsMagnification`, no zoom methods, no zoom toolbar. The Reading pane's
+`ReadingWebModel` (`Sources/Play/Local/ReadingWebView.swift`) does set
+`webView.allowsMagnification = true`. The Preview toolbar has only a URL field,
+Reload, and Open-in-Browser.
+
+## Scope
+
+### Must land
+
+- **Pinch-to-zoom**: `webView.allowsMagnification = true`.
+- **⌘+ / ⌘- / ⌘0** shortcuts for zoom in / out / reset.
+- A **zoom percentage** readout in the Preview toolbar (e.g. `100%`).
+- A **zoom reset** control in the toolbar.
+- The zoom level **persists per source** (app plist / `UserDefaults` keyed by
+  source id) and is restored on the next session.
+
+### Nice-to-have (not gate)
+
+- **Zoom to Fit** (⌘9) — scale to window width.
+- A zoom slider in the toolbar.
+
+### Must not land
+
+- A custom zoom implementation that fights `WKWebView`'s built-in
+  magnification.
+- Zoom that persists across different sources (zoom is source-scoped).
+- Zoom in the Compose preview pane (a different surface).
+
+## Implementation sketch
+
+1. In `PreviewWebModel`, enable magnification and clamp it:
+   ```swift
+   webView.allowsMagnification = true
+   webView.minMagnification = 0.25
+   webView.maxMagnification = 4.0
+   ```
+2. Add zoom methods that read/write `webView.magnification`:
+   ```swift
+   func zoomIn()  { webView.magnification = min(webView.magnification * 1.25, 4.0) }
+   func zoomOut() { webView.magnification = max(webView.magnification / 1.25, 0.25) }
+   func zoomReset() { webView.magnification = 1.0 }
+   ```
+3. Publish `zoomLevel` (a `CGFloat`) so the toolbar label updates. Preferred:
+   KVO on `webView.magnification` (it is a plain property and is observable in
+   practice). If KVO proves unreliable, fall back to updating the model's own
+   value whenever the code changes it and reading `webView.magnification`
+   after pinch/scroll events — pick one path and verify it tracks both the
+   toolbar buttons and the trackpad pinch.
+4. Add the toolbar controls (`minus.magnifyingglass`, the `%` text, `plus`,
+   `1.magnifyingglass`) and the ⌘+/⌘-/⌘0 keyboard shortcuts.
+5. Persist per source: `UserDefaults` keyed by `source.id` (string). Load on
+   `startPreview`, apply `webView.magnification` after the first load; save on
+   change.
+6. **Reload / SSE reload already preserve zoom** — `magnification` is a
+   `WKWebView` property, not per-page, so `webView.reload()` keeps it. Verify,
+   do not add reload hooks.
+
+## Gate
+
+Open Preview → pinch on the trackpad zooms the page → ⌘+ / ⌘- / ⌘0 change and
+reset zoom (clamped 0.25–4.0) → the toolbar shows the live percentage → switch
+sources and back → each source restores its own zoom → a save-triggered reload
+keeps the zoom level. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Tests
+
+- `testZoomInOutReset` — the model's zoom methods change magnification and
+  reset to 1.0.
+- `testZoomClampsToMinMax` — zooming past 4.0 / below 0.25 clamps.
+- `testZoomPersistsPerSource` — setting 150% and recreating the model for the
+  same source id restores 150%; a different source id restores its own.
+- Manual: pinch and buttons stay in sync; reload keeps the zoom.
+
+## Edge cases
+
+- Pinch and toolbar must share the same magnification value (no double-zoom).
+- Switching sources must not leak one source's zoom into another.
+- A save-triggered / SSE reload must preserve the zoom level (WebKit keeps
+  magnification across `reload()` — verify).

--- a/docs/issues/editor-reading-keyboard-nav.md
+++ b/docs/issues/editor-reading-keyboard-nav.md
@@ -1,0 +1,111 @@
+# Editor: Keyboard Navigation in Pages List + Reading Pane
+
+**Track:** Mail body / macOS native polish
+**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
+**Issue:** [#233](https://github.com/drawmeanelephant/solipsist/issues/233)
+**Lane:** `Sources/Play/Local/`
+
+## Problem
+
+The Pages list and Reading pane do not fully support keyboard navigation.
+Authors cannot ⌘Return into the editor, Escape to deselect, or page through
+the list with Home/End/PageUp/PageDown.
+
+## Verified current state
+
+`LocalPlay.pageList` (`Sources/Play/Local/LocalPlay.swift`) renders a
+`List(filtered, selection: selectedPageID)` with a
+`.simultaneousGesture(TapGesture(count: 2))` that opens Compose, and an
+`.onKeyPress(.return)` that opens the Compose window. **Up/Down arrows already
+work** — SwiftUI `List` moves the selection through the `selection` binding;
+do not add arrow handlers. Return already opens Compose. What is missing:
+⌘Return → Editor, Escape → deselect, Home/End, Page Up/Down.
+
+## Scope
+
+### Must land
+
+- **⌘Return** opens the **Editor** companion for the selected page.
+- **Escape** deselects the current page (clears the Reading pane and resets
+  the drawer) when the list is focused.
+- **Page Up / Page Down** scroll the list by one visible page.
+- **Home / End** jump to the first / last page in the list.
+- **Up/Down arrows** keep working (List default — verify, add no handler).
+- **Return** keeps opening **Compose** (existing behavior — verify).
+
+### Nice-to-have (not gate)
+
+- **⌘↑ / ⌘↓** move to the previous / next page.
+- **Space** toggles the Reading pane's scroll position (Mail's "scroll
+  message").
+- **⌘/** focuses the Pages search field.
+
+### Must not land
+
+- A custom key-binding system (use SwiftUI's native `onKeyPress`).
+- A third-party keyboard library.
+- **Arrow-key handlers that return `.handled`** — that would block the
+  `List`'s built-in selection movement. This was the trap in the draft; the
+  arrows need no handler at all.
+
+## Implementation sketch
+
+1. Add to the `List` (alongside the existing `.onKeyPress(.return)`):
+   ```swift
+   .onKeyPress(.return, modifiers: .command) {
+       guard store.selection.canEditPage else { return .ignored }
+       openWindow(id: CompanionID.editor)
+       return .handled
+   }
+   .onKeyPress(.escape) {
+       if !searchText.isEmpty {
+           searchText = ""        // search focused? clear it, do not deselect
+           return .handled
+       }
+       store.select(noun: nil)
+       return .handled
+   }
+   .onKeyPress(.home) { selectFirst(); return .handled }
+   .onKeyPress(.end) { selectLast(); return .handled }
+   .onKeyPress(.pageUp) { scrollByPage(-1); return .handled }
+   .onKeyPress(.pageDown) { scrollByPage(1); return .handled }
+   ```
+   `onKeyPress` is macOS 14+; the deployment target is 26.0, so `.home`,
+   `.end`, `.pageUp`, `.pageDown` are all available.
+2. `selectFirst` / `selectLast` call `selectPage(pages.first/last)` through
+   the same `selectPage(_:)` the click path uses.
+3. Page Up/Down: scroll the list's scroll view by one visible page height
+   (via the list's enclosing `NSScrollView` or an `@State` offset). If the
+   native key equivalents already scroll the list, verify and skip the custom
+   code.
+4. **Focus discipline**: the handlers live on the list. When the search field
+   is focused, its own key handling wins (arrow keys edit text, Escape clears
+   the query) — the edge cases below pin this.
+
+## Gate
+
+With a source open in Pages: arrows move the selection; Return opens Compose;
+⌘Return opens the Editor companion; Escape clears the selection and the
+Reading pane; Page Up/Down scroll the list; Home/End select first/last; with
+the search field focused, arrows edit the query and Escape clears it instead
+of deselecting. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+
+## Tests
+
+- `testCommandReturnOpensEditor` — ⌘Return opens the Editor companion.
+- `testEscapeDeselects` — Escape clears the selection (list focused).
+- `testEscapeClearsSearch` — Escape with a query clears it, keeps selection.
+- `testHomeEndSelectFirstLast` — Home/End select first/last page.
+- Manual: arrows still move the selection (no handler added); Page Up/Down
+  scroll by a page.
+
+## Edge cases
+
+- Arrow keys must not move the selection while the search field is focused
+  (the field consumes them for text editing).
+- Return / ⌘Return must not open anything with no page selected
+  (`canEditPage` guard).
+- ⌘Return must not open the Editor when the editor binary is missing — the
+  Editor window already fails gracefully; do not add a new check here.
+- Escape must not deselect when the search field is focused (clears the query
+  instead).


### PR DESCRIPTION
Docs for milestone 10 (Editor Polish) — no code.

## What

- **Fact-checked issue specs** for #225–#238: Compose Find & Replace, line
  numbers, split resize, status bar, Tab indent, preview WKWebView, toolbar
  save, companion reconnect, keyboard nav, preview zoom, highlighting edge
  cases, accessibility, editor UX polish, Go to Line. Each has a `Current
  state` verified against the code, a `Gate`, disjoint lanes, and tests.
- **Accessibility tracker split** — #236 is now a tracker with five
  per-lane children (#239–#243), one per worktree, matching the M13/M14
  pattern.
- **Board cards** — `docs/cards/A11Y-*.md` session briefs + a pickable
  section in `docs/cards/README.md` (Owns / Do-not-touch contracts).
- `docs/issues/README.md` now registers the solipsist-side issue drafts.

## Why

The milestone-10 issues were filed (#225–#238) with thin specs; these
drafts give each a verified ground truth (current state, implementation
sketch, gate, tests) so a picking agent can work them one worktree per PR
without re-deriving the reality or colliding with another lane.

## Notes

- Children issues #239–#243 are already filed and milestone'd; the tracker
  table links them.
- No source code touched. `main` unaffected.

Generated with Codebuff 🤖
Co-Authored-By: Codebuff <noreply@codebuff.com>