### PR TITLE
docs: recut A11Y child specs + cards to the post-polish delta (#239-#242)

### DIFF
--- a/docs/cards/A11Y-compose-toolbar.md
+++ b/docs/cards/A11Y-compose-toolbar.md
@@ -8,10 +8,16 @@ suggestion `feat/a11y-compose-toolbar`.
 
 Spec: [`docs/issues/editor-accessibility-compose-toolbar.md`](../issues/editor-accessibility-compose-toolbar.md).
 
+**Status: ⬜ partially covered.** The polish batch (#209/#210) already labeled
+Preview / Front Matter / Render Options / Save. This card is the **delta**:
+Language picker label, three hints, and the diagnostics rows.
+
 ## Owns
 
-- `Sources/Compose/ComposeEditorView.swift` — toolbar control labels +
-  diagnostics-row announcements
+- `Sources/Compose/ComposeEditorView.swift` — Language picker label + hints
+  (the delta)
+- `Sources/Compose/ComposeDiagnostic.swift` — `accessibilityLabel` helper
+  (already in the test target)
 
 ## Do not touch
 
@@ -23,30 +29,35 @@ Spec: [`docs/issues/editor-accessibility-compose-toolbar.md`](../issues/editor-a
 
 ## Why
 
-The Compose toolbar controls have `.help()` tooltips but no
-`accessibilityLabel`, and each diagnostics row reads as a bare `HStack`.
-VoiceOver users cannot act on the editor or read its problems.
+The polish batch labeled four toolbar controls, but the Language picker is
+still unlabeled, three controls lack hints, and each diagnostics row reads as
+a bare `HStack`. VoiceOver users cannot reliably act on the editor or read its
+problems.
 
 ## Do
 
-1. Add `accessibilityLabel` + `accessibilityHint` to the Language picker,
-   Preview toggle, Front Matter toggle, Render Options menu, and Save button
-   (copy in the spec). Keep the existing `.help()` tooltips.
-2. In `ComposeDiagnosticsPane`, combine each row:
-   `.accessibilityElement(children: .combine)` with a label built from
-   severity + optional line + message ("Error on line 12: …").
-3. Use `String(localized:)` for every user-facing string.
-4. Tests: a diagnostic row's combined label contains severity, line, and
-   message; toolbar controls expose non-empty labels.
+1. Language picker: label including the current language ("Language, currently
+   Markdown") + hint "Select the authoring frontend" (copy in the spec).
+2. Add `.accessibilityHint` to Front Matter, Render Options, Save — parity
+   with the Preview toggle (copy in the spec).
+3. In `ComposeDiagnostic.swift`, add a pure `accessibilityLabel` helper
+   ("Error on line 12: …" / "Warning: message"); apply it in
+   `ComposeDiagnosticsPane` with `.accessibilityElement(children: .combine)`.
+4. Strings: plain strings matching the file's existing style — do not
+   introduce `String(localized:)` (tracker marks it a later nice-to-have).
+5. Tests: `ComposeDiagnosticAccessibilityTests` in `Tests/ContractTests/` —
+   the one honest seam, since `ComposeDiagnostic` is in the test target.
 
 ## Do not
 
+- Re-add the four existing labels (already on main).
 - Build a separate accessibility mode.
 - Add a third-party accessibility library.
 - Touch the other lanes' files (above).
 
 ## Gate
 
-VoiceOver (⌘F5) on the Compose window announces every toolbar control and a
-diagnostics row ("Error on line 12: …"). `SKIP_EMBED_BORIS=1 make build` +
-`make test` green.
+VoiceOver (⌘F5) on the Compose window: the Language picker announces the
+current language, every toolbar control announces a hint, and a diagnostics
+row announces "Error on line 12: …". `SKIP_EMBED_BORIS=1 make build` +
+`make test` green (including the new `ComposeDiagnostic` label test).

--- a/docs/cards/A11Y-editor-toolbar.md
+++ b/docs/cards/A11Y-editor-toolbar.md
@@ -8,9 +8,14 @@ branch suggestion `feat/a11y-editor-toolbar`.
 
 Spec: [`docs/issues/editor-accessibility-editor-toolbar.md`](../issues/editor-accessibility-editor-toolbar.md).
 
+**Status: ⬜ not covered.** Toolbar controls carry only `.help()` or nothing;
+nav + phase were refactored into subviews but stayed unlabeled.
+
 ## Owns
 
-- `Sources/Companions/Editor/EditorWindow.swift` — toolbar labels
+- `Sources/Companions/Editor/EditorWindow.swift` — URL field, Connect, Restart
+- `Sources/Companions/Editor/` — `EditorNavButtons`, `EditorPhaseIndicator`
+  (refactored subviews from the polish batch)
 
 ## Do not touch
 
@@ -23,26 +28,32 @@ Spec: [`docs/issues/editor-accessibility-editor-toolbar.md`](../issues/editor-ac
 
 ## Why
 
-The Editor toolbar's nav buttons, Restart, Open-in-Browser, URL field, and
-Connect have `.help()` tooltips but no VoiceOver labels.
+The Editor toolbar's URL field, Connect, Restart, Back/Forward, and the phase
+indicator have no VoiceOver labels. The polish batch refactored nav into
+`EditorNavButtons` and the phase into `EditorPhaseIndicator` but left both
+unlabeled.
 
 ## Do
 
-1. Label the URL field ("Editor URL. Paste a BORIS_EDITOR_URL line to connect
-   manually."), Connect, Restart, Back, Forward, and Reload (copy in the
-   spec).
-2. Make the phase indicator (`phaseLabel`) announce idle / starting /
-   connected / failed state.
-3. Use `String(localized:)` for every user-facing string.
-4. Tests: the toolbar controls expose non-empty labels.
+1. Label the URL field ("Editor URL"), Connect, and Restart; add `.isButton`
+   to the buttons.
+2. In `EditorNavButtons`: label Back / Forward + `.isButton`.
+3. In `EditorPhaseIndicator`: label the current phase ("Engine running") +
+   `.isStaticText`; enumerate every phase value the indicator can render.
+4. Keep existing `.help()` tooltips.
+5. Strings: plain strings matching the file's existing style.
+6. Tests: no honest unit seam — verify manually per the Gate.
 
 ## Do not
 
+- Change layout, icons, or behavior.
 - Build a separate accessibility mode.
 - Add a third-party accessibility library.
 - Touch the other lanes' files (above).
 
 ## Gate
 
-VoiceOver on the Editor window announces every toolbar control and the phase
-indicator. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+VoiceOver on the Editor window announces "Editor URL", "Connect, button",
+"Restart, button", "Back, button" / "Forward, button", and the current phase
+("Engine running"); tooltips still appear on hover. `SKIP_EMBED_BORIS=1 make
+build` + `make test` green.

--- a/docs/cards/A11Y-preview-toolbar.md
+++ b/docs/cards/A11Y-preview-toolbar.md
@@ -8,9 +8,13 @@ branch suggestion `feat/a11y-preview-toolbar`.
 
 Spec: [`docs/issues/editor-accessibility-preview-toolbar.md`](../issues/editor-accessibility-preview-toolbar.md).
 
+**Status: ⬜ not covered.** No accessibility attributes on any toolbar control
+(only `.help()` tooltips).
+
 ## Owns
 
-- `Sources/Companions/Preview/PreviewWindow.swift` — toolbar labels
+- `Sources/Companions/Preview/` — toolbar labels (URL field, Reload,
+  Open in Browser)
 
 ## Do not touch
 
@@ -23,26 +27,29 @@ Spec: [`docs/issues/editor-accessibility-preview-toolbar.md`](../issues/editor-a
 
 ## Why
 
-The Preview toolbar's URL field, Reload, and Open-in-Browser buttons have no
-VoiceOver labels.
+The Preview toolbar's URL field, Reload, and Open-in-Browser controls carry
+only `.help()` tooltips (or nothing) — VoiceOver reads three anonymous
+buttons.
 
 ## Do
 
-1. Label the URL field ("Preview URL. …"), Reload ("Reload the preview
-   page."), and Open in Browser ("Open in Safari.").
-2. Make the session status line (`session.statusText`) announce
-   connected / failure state.
-3. Use `String(localized:)` for every user-facing string.
-4. Tests: the toolbar controls expose non-empty labels.
+1. Label the URL field ("Preview URL"), Reload ("Reload"), and Open in Browser
+   ("Open in Browser"); add `.isButton` to the two buttons.
+2. Keep the existing `.help()` tooltips for hover text.
+3. Strings: plain strings matching the file's existing style — do not
+   introduce `String(localized:)`.
+4. Tests: no honest unit seam (views are not in the test target) — verify
+   manually per the Gate.
 
 ## Do not
 
+- Change layout, icons, or behavior.
 - Build a separate accessibility mode.
 - Add a third-party accessibility library.
 - Touch the other lanes' files (above).
 
 ## Gate
 
-VoiceOver on the Preview window announces the URL field, Reload, and
-Open-in-Browser, plus the status line. `SKIP_EMBED_BORIS=1 make build` +
-`make test` green.
+VoiceOver on the Preview window announces "Preview URL", "Reload, button", and
+"Open in Browser, button"; tooltips still appear on hover. `SKIP_EMBED_BORIS=1
+make build` + `make test` green.

--- a/docs/cards/A11Y-reading-header.md
+++ b/docs/cards/A11Y-reading-header.md
@@ -8,9 +8,13 @@ suggestion `feat/a11y-reading-header`.
 
 Spec: [`docs/issues/editor-accessibility-reading-header.md`](../issues/editor-accessibility-reading-header.md).
 
+**Status: ⬜ not covered.** The header still announces as two separate
+elements; only the served badge has a11y work (polish batch — keep it).
+
 ## Owns
 
-- `Sources/Play/Local/ReadingPane.swift` — the letter header announcement
+- `Sources/Play/Local/ReadingPane.swift` — combine title + caption into one
+  announcement
 
 ## Do not touch
 
@@ -22,27 +26,30 @@ Spec: [`docs/issues/editor-accessibility-reading-header.md`](../issues/editor-ac
 
 ## Why
 
-The reading-pane header (title + caption with path · status · role) reads as
-separate pieces to VoiceOver instead of one announcement. The empty-state
-label already exists — keep it.
+The reading-pane header (title + caption "Served · 3 pages · edited 2m ago")
+reads as two separate stops to VoiceOver; the caption fragment is orphaned.
+The served badge already has its label + traits — keep them.
 
 ## Do
 
-1. Combine the title `VStack` (title + caption) into one element announcing
-   "title, status, role" (`display(page.status)` handles the empty case).
-2. Leave the Preview / Edit / Compose buttons and the served badge outside the
-   combined element — they keep their own labels.
-3. Use `String(localized:)` for the label.
-4. Tests: the header combines title, status, role into one label.
+1. Combine the header's title and caption into one element
+   (`.accessibilityElement(children: .combine)` or an explicit label) so it
+   announces "My Boris Site, Served · 3 pages · edited 2m ago" in one stop,
+   title first.
+2. Keep the served/draft badge's existing label + traits; make the
+   announcement order deterministic regardless of visual layout.
+3. Tests: no honest unit seam exists (views are not in the test target) — do
+   not invent a helper. Verify manually per the Gate.
 
 ## Do not
 
+- Re-do the served-badge label/traits (already on main).
 - Fold the action buttons into the combined element.
 - Build a separate accessibility mode.
 - Touch the other lanes' files (above).
 
 ## Gate
 
-VoiceOver on the reading pane announces "Getting Started, published, Trunk"
-as one element; the action buttons still announce individually.
-`SKIP_EMBED_BORIS=1 make build` + `make test` green.
+VoiceOver on the reading pane announces title + caption as one element, in
+order; the served/draft badge still announces its label. `SKIP_EMBED_BORIS=1
+make build` + `make test` green.

--- a/docs/cards/A11Y-sidebar-counts.md
+++ b/docs/cards/A11Y-sidebar-counts.md
@@ -8,6 +8,8 @@ suggestion `feat/a11y-sidebar-counts`.
 
 Spec: [`docs/issues/editor-accessibility-sidebar-counts.md`](../issues/editor-accessibility-sidebar-counts.md).
 
+**Status: ✅ merged (PR #244).** Kept as the record; do not reopen.
+
 ## Owns
 
 - `Sources/Chrome/SourceSidebar.swift` — `accessibilityValue` counts on the

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -162,23 +162,25 @@ entry). Do not pick.
 
 VoiceOver across the editor surfaces, cut into five disjoint lanes from
 tracker [#236](https://github.com/drawmeanelephant/solipsist/issues/236).
-Each card is one worktree, one PR against `main`; all five are independent
-and can run at once. Specs live in
+Each card is one worktree, one PR against `main`; the remaining four are
+independent and can run at once (#243 is merged). Specs live in
 [`docs/issues/`](../issues/README.md) (child-of-#236 drafts); the cards
 below are the session briefs.
 
 | Card | Issue | Lane | Parallel with | Gate |
 |------|-------|------|----------------|------|
 | [A11Y tracker](../issues/editor-compose-accessibility.md) | [#236](https://github.com/drawmeanelephant/solipsist/issues/236) | design | — | five children land; VoiceOver covers all surfaces |
-| [A11Y-1 Compose toolbar + diagnostics](A11Y-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | A11Y-2..A11Y-5 | every Compose toolbar control and diagnostics row announces |
-| [A11Y-2 Reading pane header](A11Y-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | A11Y-1, A11Y-3..A11Y-5 | header announces title, status, role |
-| [A11Y-3 Preview toolbar](A11Y-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | A11Y-1, A11Y-2, A11Y-4, A11Y-5 | URL / reload / open-in-browser labeled |
-| [A11Y-4 Editor toolbar](A11Y-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | A11Y-1..A11Y-3, A11Y-5 | URL / connect / restart / nav labeled |
-| [A11Y-5 Mailbox sidebar counts](A11Y-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | A11Y-1..A11Y-4 | Pages + trunk rows announce counts from the stored graph |
+| [A11Y-1 Compose toolbar + diagnostics](A11Y-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | A11Y-2..A11Y-5 | ⬜ partial — Language picker label + hints + diagnostics rows |
+| [A11Y-2 Reading pane header](A11Y-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | A11Y-1, A11Y-3..A11Y-5 | ⬜ header announces title + caption as one element |
+| [A11Y-3 Preview toolbar](A11Y-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | A11Y-1, A11Y-2, A11Y-4, A11Y-5 | ⬜ URL / reload / open-in-browser labeled |
+| [A11Y-4 Editor toolbar](A11Y-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | A11Y-1..A11Y-3, A11Y-5 | ⬜ URL / connect / restart / nav / phase labeled |
+| [A11Y-5 Mailbox sidebar counts](A11Y-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | — | ✅ merged (PR #244) |
 
-Filed 2026-08-21 as #239–#243 (milestone 10). Close #236 when all five
-land. Do not grow a card into another card's lane — the Owns / Do-not-
-touch lists are the contract.
+Filed 2026-08-21 as #239–#243 (milestone 10). **Status:** #243 landed
+(PR #244); #239 is partially covered by the polish batch (#209/#210) — its
+spec and card were recut to the remaining delta; the other three are
+untouched and pickable. Close #236 when all five land. Do not grow a card
+into another card's lane — the Owns / Do-not-touch lists are the contract.
 
 ## Do not start yet
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -51,5 +51,9 @@ two touch the same lane in the same PR.
 | [Editor UX Polish](editor-companion-ux-polish.md) | [#237](https://github.com/drawmeanelephant/solipsist/issues/237) | `Sources/Companions/Editor/` |
 | [Go to Line (⌘L)](editor-compose-go-to-line.md) | [#238](https://github.com/drawmeanelephant/solipsist/issues/238) | `Sources/Compose/` |
 
+Status (2026-08-21): #243 merged (PR #244); #239 partially covered by the
+polish batch (#209/#210) — its spec + card are recut to the remaining delta;
+#240/#241/#242 untouched and pickable.
+
 Do not ask: unifying `compiler` field names, library mode, relaxing
 editor token/CSP, shipping `boris-editor` in the agent-pack.

--- a/docs/issues/editor-accessibility-compose-toolbar.md
+++ b/docs/issues/editor-accessibility-compose-toolbar.md
@@ -8,77 +8,93 @@
 
 ## Problem
 
-The Compose window's toolbar controls and diagnostics rows are not
-VoiceOver-accessible: the toolbar buttons have `.help()` tooltips but no
-`accessibilityLabel`, and each diagnostics row reads as a bare `HStack` with
-no severity / line / message announcement.
+Compose's toolbar and diagnostics pane are only partly VoiceOver-accessible.
+The polish batch (#209/#210 a11y) already labeled four toolbar controls; this
+issue closes the remaining gaps: the Language picker is unlabeled, three
+controls have no hint, and diagnostics rows still read as a bare `HStack`.
 
-## Verified current state
+## What main already has (do not redo)
 
-`Sources/Compose/ComposeEditorView.swift`:
-- `toolbar` — Language picker, Preview toggle, Front Matter toggle, Render
-  Options menu, Save button. All have `.help()` tooltips; **none** has an
-  `accessibilityLabel` / `accessibilityHint`.
-- `ComposeDiagnosticsPane` — rows are `HStack`s (icon, line number, message)
-  with `.help("Jump to this diagnostic")`; no `.accessibilityElement(children:
-  .combine)` and no combined label.
+`Sources/Compose/ComposeEditorView.swift` (`toolbar`) today:
 
-## Scope
+| Control | Label | Hint | Traits |
+|---------|-------|------|--------|
+| Language picker | none (label text "Language" only) | none | — |
+| Preview toggle | `"Preview"` | `"Toggle the Oliver preview pane"` | `.isSelected` when on |
+| Front Matter toggle | `"Front Matter"` | **none** | `.isSelected` when on |
+| Render Options menu | `"Render Options"` | **none** | — |
+| Save button | `"Save"` | **none** | — |
 
-### Must land
+`ComposeDiagnosticsPane`: rows are `HStack`s (icon, line number, message) with
+only `.help("Jump to this diagnostic")` — **no** `.accessibilityElement` and
+no combined label.
 
-1. **Toolbar** — label + hint on every control:
-   - Language picker: "Language, currently Markdown. Select the authoring
-     frontend."
-   - Preview toggle: "Toggle Preview. Show or hide the rendered preview pane."
-   - Front Matter toggle: "Toggle Front Matter. Show or hide the front matter
-     editor."
-   - Render Options: "Render Options. Configure Oliver's parse extensions."
-   - Save: "Save. Write the buffer to disk. Command-S."
-2. **Diagnostics rows** — combine into a single announcement:
+## Scope — must land (the delta)
+
+1. **Language picker** — label that includes the **current** language
+   ("Language, currently Markdown") so VoiceOver announces state, plus
+   `.accessibilityHint("Select the authoring frontend")`. The label is
+   dynamic — bind it to `document.language.displayName`.
+2. **Hints on the three label-less controls**, for parity with the Preview
+   toggle:
+   - Front Matter: "Show or hide the front matter editor."
+   - Render Options: "Configure Oliver's parse extensions."
+   - Save: "Write the buffer to disk (⌘S)."
+3. **Diagnostics rows** — one announcement per row:
    "Error on line 12: unexpected token" / "Warning: missing closing fence".
-   Use `.accessibilityElement(children: .combine)` and build the label from
-   severity + optional line + message.
+   - Extract the label as a pure helper on `ComposeDiagnostic` (see Tests) so
+     it is unit-testable; the row applies `.accessibilityElement(children:
+     .combine)` + `.accessibilityLabel(helper)`.
 
 ### Must not land
 
-- A separate accessibility mode.
-- A third-party accessibility library.
-- Touching `Sources/Companions/`, `Sources/Play/Local/`, or `Sources/Chrome/`
-  (other children own those).
-
-## Gate
-
-VoiceOver (⌘F5) on the Compose window: every toolbar control announces its
-label/hint, and a diagnostics row announces "Error on line 12: …".
-`SKIP_EMBED_BORIS=1 make build` + `make test` green.
+- Re-adding the four existing labels (already on main).
+- A separate accessibility mode, or a third-party library.
+- Touching `Sources/Companions/`, `Sources/Play/Local/`, `Sources/Chrome/`
+  (other children), or `Project.yml` (the test target already compiles
+  `ComposeDiagnostic.swift`).
 
 ## Implementation sketch
 
-1. Add `.accessibilityLabel(_:)` / `.accessibilityHint(_:)` to each toolbar
-   control. Keep the existing `.help()` tooltips.
-2. In `ComposeDiagnosticsPane`, per row:
+1. In `toolbar`, on the Language `Picker`:
    ```swift
-   .accessibilityElement(children: .combine)
-   .accessibilityLabel(
-       (diagnostic.severity == .error ? "Error" : "Warning")
-       + (diagnostic.line.map { " on line \($0)" } ?? "")
-       + ": \(diagnostic.message)"
-   )
+   .accessibilityLabel("Language, currently \(document.language.displayName)")
+   .accessibilityHint("Select the authoring frontend")
    ```
-3. Use `String(localized:)` for every user-facing string.
+   (SwiftUI `Picker` already surfaces its label text; you may need to set the
+   label explicitly to control the wording.)
+2. Add `.accessibilityHint(...)` to Front Matter, Render Options, Save.
+3. In `ComposeDiagnostic.swift`, add:
+   ```swift
+   extension ComposeDiagnostic {
+       /// "Error on line 12: message" / "Warning: message" (no line → no count).
+       var accessibilityLabel: String { ... }
+   }
+   ```
+   and use it in `ComposeDiagnosticsPane` with `.accessibilityElement(children:
+   .combine)`.
+4. Strings: match the file's existing plain-string style. The repo has not
+   adopted `String(localized:)`; do not introduce it here (tracker marks
+   localization as a later nice-to-have).
+
+## Gate
+
+Manual VoiceOver (⌘F5) on the Compose window: the Language picker announces
+the current language, each toolbar control announces a hint, and a diagnostics
+row announces "Error on line 12: …". `SKIP_EMBED_BORIS=1 make build` +
+`make test` green (including the new `ComposeDiagnostic` label test).
 
 ## Tests
 
-- `testDiagnosticsRowAccessibilityLabel` — a row's combined label contains
-  severity, line, and message (drive `ComposeDiagnostic` → label).
-- `testToolbarControlsHaveLabels` — the toolbar's buttons/picker expose
-  non-empty `accessibilityLabel` (via the label builder or the representable's
-  view hierarchy).
-- Manual: VoiceOver walk-through of the Compose toolbar + a diagnostics list.
+- `ComposeDiagnosticAccessibilityTests` (in `Tests/ContractTests/`, compiled
+  against `ComposeDiagnostic.swift`): label contains severity + line + message;
+  a no-line diagnostic reads "Error: message".
+  This is the only honest unit test — the view wiring is manual.
+- Manual: VoiceOver walk-through of the toolbar + a diagnostics list.
 
 ## Edge cases
 
-- A diagnostic with no line → the label reads "Error: message" (no "on line").
-- Labels update when the diagnostics list changes (rows re-render).
-- All labels use `String(localized:)`; no hardcoded English.
+- No line on a diagnostic → "Error: message" (no "on line").
+- Language changes → the picker label updates (verify VoiceOver re-reads).
+- Diagnostics list re-renders when the render changes → labels follow (SwiftUI
+  recomputes).

--- a/docs/issues/editor-accessibility-editor-toolbar.md
+++ b/docs/issues/editor-accessibility-editor-toolbar.md
@@ -1,60 +1,103 @@
-# Editor: Accessibility — Editor Toolbar
+# A11Y-4: Editor Toolbar — label the controls
 
-**Track:** macOS native polish / accessibility
-**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
-**Issue:** [#242](https://github.com/drawmeanelephant/solipsist/issues/242)
-**Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
-**Lane:** Editor companion — `Sources/Companions/Editor/`
+- **Issue:** [#242](https://github.com/drawmeanelephant/solipsist/issues/242)
+- **Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236)
+- **Lane:** Editor companion
+- **Owns:** `Sources/Companions/Editor/`
 
 ## Problem
 
-The Editor companion's toolbar controls are unlabeled for VoiceOver.
+The Editor window's toolbar controls are **unlabeled** to assistive
+technology. They carry only `.help()` tooltips (which VoiceOver does not read
+as a name) or nothing at all. A VoiceOver user tabbing through the toolbar
+hears anonymous buttons and cannot tell the URL field from Connect, Restart,
+or the back/forward navigation, and the connection-phase indicator reads as an
+unlabeled graphic.
 
-## Verified current state
+## Verified current state (main `6ddffd7`)
 
-`Sources/Companions/Editor/EditorWindow.swift` — `toolbar` renders nav buttons
-(Back / Forward / Reload), a phase indicator, Restart Host, Open-in-Browser, a
-URL `TextField`, and Connect. The nav buttons have `.help()` tooltips; none
-has an `accessibilityLabel` / `accessibilityHint`.
+`Sources/Companions/Editor/EditorWindow.swift` (and the refactored subviews it
+uses):
+
+- **URL field** — no `.accessibilityLabel`.
+- **Connect button** — bare `.help()`; no label, no traits.
+- **Restart button** — bare `.help()`; no label, no traits.
+- **Navigation (back/forward)** — refactored into `EditorNavButtons` (a
+  separate view) in the polish batch; still no labels, no traits.
+- **Phase indicator** — `EditorPhaseIndicator` (separate view, also from the
+  polish batch) is unlabeled; it renders the engine phase (e.g. `idle`,
+  `running`, `error`) with no accessibility identity.
+- `EditorURL` and `LocalPlayGraph` are in the test target; the toolbar views
+  are not.
 
 ## Scope
 
-### Must land
+Give each toolbar control a real accessibility identity:
 
-- URL field: "Editor URL. Paste a BORIS_EDITOR_URL line to connect manually."
-- Connect: "Connect to the editor host."
-- Restart: "Restart the boris-editor host."
-- Back: "Back. Navigate to the previous page."
-- Forward: "Forward. Navigate to the next page."
-- Reload: "Reload the editor page."
-- The phase indicator announces as a single value (idle / starting /
-  connected / failed).
+1. **URL field** — label it (e.g. `"Editor URL"`) so it reads as a labeled
+   text field.
+2. **Connect** — `.accessibilityLabel("Connect")`, plus `.isButton` trait.
+3. **Restart** — `.accessibilityLabel("Restart")`, plus `.isButton` trait.
+4. **Back / Forward** (in `EditorNavButtons`) — `.accessibilityLabel("Back")`
+   / `"Forward"`, plus `.isButton` trait.
+5. **Phase indicator** (`EditorPhaseIndicator`) — give it an
+   `.accessibilityLabel` describing the current phase (e.g. `"Engine idle"` /
+   `"Engine running"` / `"Engine error"`), plus `.isStaticText`.
 
-### Must not land
-
-- Touching `Sources/Companions/Preview/`, `Sources/Compose/`, or
-  `Sources/Chrome/`.
-- A separate accessibility mode.
+Keep existing `.help()` tooltips. Do not change any visual appearance, layout,
+or behavior.
 
 ## Gate
 
-VoiceOver on the Editor window: every toolbar control announces its label; the
-phase indicator announces connected / failed state. `SKIP_EMBED_BORIS=1 make
-build` + `make test` green.
+With VoiceOver on in the Editor window toolbar:
+
+- URL field announces "Editor URL".
+- Connect / Restart announce "Connect, button" / "Restart, button".
+- Back / Forward announce "Back, button" / "Forward, button".
+- Phase indicator announces the current phase (e.g. "Engine running").
+- Tooltips (`.help`) still appear on hover.
 
 ## Implementation sketch
 
-1. Add `.accessibilityLabel(_:)` / `.accessibilityHint(_:)` to the nav
-   buttons, Restart, Open-in-Browser, the URL field, and Connect.
-2. Ensure the phase `Text` (which renders `phaseLabel`) is
-   accessibility-relevant.
+```swift
+TextField("", text: $url)
+    .accessibilityLabel("Editor URL")
+
+Button(action: connect) { … }
+    .accessibilityLabel("Connect")
+    .accessibilityAddTraits(.isButton)
+    .help("Connect")
+
+// EditorNavButtons:
+Button(action: back) { … }
+    .accessibilityLabel("Back")
+    .accessibilityAddTraits(.isButton)
+
+// EditorPhaseIndicator:
+Text(phase.rawValue)
+    .accessibilityLabel("Engine \(phase.rawValue)")
+    .accessibilityAddTraits(.isStaticText)
+```
 
 ## Tests
 
-- `testEditorToolbarLabels` — the toolbar controls expose non-empty labels.
-- Manual: VoiceOver walk-through of the Editor window.
+- The controls live in views that are not in the test target, so there is no
+  honest unit test seam here. Verify by build + manual VoiceOver check (or AX
+  probe) per the Gate.
+- Do not add UI-automation tests the project does not run.
 
 ## Edge cases
 
-- Disabled states (nav buttons with no history) still announce their labels.
-- Failure phase → the phase indicator announces the error message.
+- **Phase strings** — the label must read sensibly for every phase value the
+  indicator can render (idle, running, error, and any others in the enum);
+  enumerate them in the implementation.
+- **Icon-only buttons** — labels must not fall back to symbol names; the
+  explicit label is the source of truth.
+- **Keyboard focus** — labels must not break the existing focus/tab order.
+
+## Do not land
+
+- Changing the toolbar's layout, icons, or behavior.
+- Touching any file outside `Sources/Companions/Editor/`.
+- Accessibility work on the Reading pane header (#240) or Preview toolbar
+  (#241) — separate child issues.

--- a/docs/issues/editor-accessibility-preview-toolbar.md
+++ b/docs/issues/editor-accessibility-preview-toolbar.md
@@ -1,56 +1,86 @@
-# Editor: Accessibility — Preview Toolbar
+# A11Y-3: Preview Toolbar — label the controls
 
-**Track:** macOS native polish / accessibility
-**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
-**Issue:** [#241](https://github.com/drawmeanelephant/solipsist/issues/241)
-**Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
-**Lane:** Preview companion — `Sources/Companions/Preview/`
+- **Issue:** [#241](https://github.com/drawmeanelephant/solipsist/issues/241)
+- **Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236)
+- **Lane:** Preview companion
+- **Owns:** `Sources/Companions/Preview/`
 
 ## Problem
 
-The Preview companion's toolbar controls are unlabeled for VoiceOver.
+The Preview window's toolbar controls are **unlabeled** to assistive
+technology. They carry only `.help()` tooltips, which VoiceOver does not read
+as a name. A VoiceOver user tabbing through the toolbar hears three unlabeled
+buttons ("button", "button", "button") and has no way to tell which is the URL
+field, Reload, or Open-in-Browser.
 
-## Verified current state
+## Verified current state (main `6ddffd7`)
 
-`Sources/Companions/Preview/PreviewWindow.swift` — `toolbar` renders a URL
-`TextField`, Reload, and Open-in-Browser buttons (plus a rejection line and
-the session status line). None has an `accessibilityLabel` /
-`accessibilityHint`.
+`Sources/Companions/Preview/` (toolbar in the Preview window):
+
+- **URL field** — no `.accessibilityLabel`.
+- **Reload button** — `.help("Reload")` only; no label, no traits.
+- **Open in Browser button** — `.help("Open in Browser")` only; no label, no
+  traits.
+- No accessibility attributes on any of the three controls.
+- `PreviewURL` (the URL value type) is in the test target; the toolbar views
+  are not.
 
 ## Scope
 
-### Must land
+Give each toolbar control a real accessibility identity:
 
-- URL field: "Preview URL. http://127.0.0.1:8080/__boris/"
-- Reload: "Reload the preview page."
-- Open in Browser: "Open in Safari."
-- The session status line announces as a single value (serve URL or failure).
+1. **URL field** — label it (e.g. `"Preview URL"`) so it reads as a labeled
+   text field, not an anonymous editable area.
+2. **Reload** — `.accessibilityLabel("Reload")`, plus `.isButton` trait.
+3. **Open in Browser** — `.accessibilityLabel("Open in Browser")`, plus
+   `.isButton` trait.
 
-### Must not land
-
-- Touching `Sources/Companions/Editor/`, `Sources/Compose/`, or
-  `Sources/Chrome/`.
-- A separate accessibility mode.
+Keep the existing `.help()` tooltips where they add hover text; the label is
+what VoiceOver reads. Do not change any visual appearance, layout, or
+behavior.
 
 ## Gate
 
-VoiceOver on the Preview window: the URL field, Reload, and Open-in-Browser
-announce their labels; the status line announces. `SKIP_EMBED_BORIS=1 make
-build` + `make test` green.
+With VoiceOver on in the Preview window toolbar:
+
+- URL field announces "Preview URL".
+- Reload announces "Reload, button".
+- Open in Browser announces "Open in Browser, button".
+- Tooltips (`.help`) still appear on hover.
 
 ## Implementation sketch
 
-1. Add `.accessibilityLabel(_:)` / `.accessibilityHint(_:)` to the text field
-   and both buttons.
-2. Mark the status `Text` (which renders `session.statusText`) as
-   accessibility-relevant so it announces connected / failure state.
+```swift
+TextField("", text: $url)
+    .accessibilityLabel("Preview URL")
+
+Button(action: reload) { Image(systemName: "arrow.clockwise") }
+    .accessibilityLabel("Reload")
+    .accessibilityAddTraits(.isButton)
+    .help("Reload")
+
+Button(action: openInBrowser) { Image(systemName: "safari") }
+    .accessibilityLabel("Open in Browser")
+    .accessibilityAddTraits(.isButton)
+    .help("Open in Browser")
+```
 
 ## Tests
 
-- `testPreviewToolbarLabels` — the toolbar controls expose non-empty labels.
-- Manual: VoiceOver walk-through of the Preview window.
+- The controls live in views that are not in the test target, so there is no
+  honest unit test seam here. Verify by build + manual VoiceOver check (or AX
+  probe) per the Gate.
+- Do not add UI-automation tests the project does not run.
 
 ## Edge cases
 
-- The preview URL is loopback — safe to expose to VoiceOver.
-- Failure state → the status line announces the failure message.
+- **Icon-only buttons** — the label must not be empty or fall back to the
+  symbol name; the explicit label is the source of truth.
+- **Keyboard focus** — labels must not break the existing focus/tab order.
+
+## Do not land
+
+- Changing the toolbar's layout, icons, or behavior.
+- Touching any file outside `Sources/Companions/Preview/`.
+- Accessiblity work on the Reading pane header (#240) or Editor toolbar
+  (#242) — separate child issues.

--- a/docs/issues/editor-accessibility-reading-header.md
+++ b/docs/issues/editor-accessibility-reading-header.md
@@ -1,66 +1,97 @@
-# Editor: Accessibility — Reading Pane Header
+# A11Y-2: Reading Pane Header — one Announcement
 
-**Track:** macOS native polish / accessibility
-**Milestone:** 10 — macOS native editor improvements (post-M17 polish)
-**Issue:** [#240](https://github.com/drawmeanelephant/solipsist/issues/240)
-**Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
-**Lane:** Reading — `Sources/Play/Local/`
+- **Issue:** [#240](https://github.com/drawmeanelephant/solipsist/issues/240)
+- **Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236)
+- **Lane:** Reading
+- **Owns:** `Sources/Play/Local/ReadingPane.swift`
 
 ## Problem
 
-The reading-pane header (page title, status, role) is not a single VoiceOver
-announcement; VoiceOver reads the pieces separately with no context.
+The Reading pane header announces its title and its status caption as **two
+separate accessibility elements**. A VoiceOver user swiping through the header
+hears "My Boris Site" then, a separate stop later, "Served · 3 pages". The
+title is the only thing that tells them which page they're reading; the
+caption (`Served`/`Draft`, page count, edit time) gives the page's state. Split
+across two elements the state reads as an orphaned fragment, and nothing marks
+the header as a single unit.
 
-## Verified current state
+## Verified current state (main `6ddffd7`)
 
-`Sources/Play/Local/ReadingPane.swift` — `header(for:)` renders an icon, a
-title stack (`page.title` + `headerCaption(for:)`, which already contains
-path · status · role), a served badge, and Preview / Edit / Compose buttons.
-There is no `.accessibilityElement(children: .combine)` on the title stack, so
-the title, caption, and badge announce separately. The "No Page Selected"
-empty state already has a label + hint.
+`Sources/Play/Local/ReadingPane.swift`:
+
+- The header is `HStack { Text(title) …; Text(headerCaption) }` — two plain
+  `Text` views, no `.accessibilityElement(children: .combine)`, no label, no
+  traits.
+- `headerCaption` is built from the served/draft state, page count, and edit
+  time (e.g. `"Served · 3 pages · edited 2m ago"`).
+- The **served badge** (`Served`/`Draft` pill) already gained accessibility
+  work in the polish batch (#209/#210): it has `.accessibilityLabel("Served")`
+  / `"Draft"` plus `.accessibilityAddTraits(.isStaticText)`. That part is
+  **done** — do not redo it.
+- The header's `Text` views are not in the test target (views are not compiled
+  into ContractTests); the seam for any test lives in `LocalPlayGraph`
+  (`pages(in:trunkID:)`, already tested).
 
 ## Scope
 
-### Must land
+1. Make the header announce as **one element**: title + caption combined in
+   order, e.g. `"My Boris Site, Served · 3 pages · edited 2m ago"`.
+2. Keep the existing served-badge label/traits (already landed) — do not
+   regress them.
+3. The badge's **visual** appearance is unchanged; this is announcement-only.
 
-- Combine the title + caption into one announcement: "Getting Started,
-  published, Trunk" (title, status, role).
-- The served badge and the Preview / Edit / Compose buttons keep their own
-  labels (do not fold the action buttons into the combined element).
-- The "No Page Selected" empty state keeps its existing label/hint.
+Out of scope (already covered elsewhere, do not duplicate):
 
-### Must not land
-
-- Touching `Sources/Compose/`, `Sources/Companions/`, or `Sources/Chrome/`.
-- A separate accessibility mode.
+- The sidebar row counts (#243, merged) — `Sources/Chrome/SourceSidebar.swift`.
+- Preview toolbar (#241) and Editor toolbar (#242) — separate child issues.
 
 ## Gate
 
-VoiceOver on the reading pane: selecting a page announces "Getting Started,
-published, Trunk" as one element; the action buttons still announce
-individually. `SKIP_EMBED_BORIS=1 make build` + `make test` green.
+With VoiceOver on and focus in the Reading pane header of a page in a trunk:
+
+- Header announces **title and caption in a single stop**, in order (title
+  first, then the status caption).
+- The served/draft badge still announces its label (`Served` / `Draft`).
+- No other Reading-pane element changed.
 
 ## Implementation sketch
 
-1. Wrap the title `VStack` in `.accessibilityElement(children: .combine)` and
-   set:
-   ```swift
-   .accessibilityLabel(
-       "\(page.title), \(display(page.status)), \(page.role == .trunk ? "Trunk" : "Satellite")"
-   )
-   ```
-2. Leave the action buttons outside the combined element.
+```swift
+// ReadingPane header
+HStack {
+    Text(title)
+    Text(headerCaption)
+    // …
+}
+.accessibilityElement(children: .combine)
+// order = title then caption; the served badge keeps its own label/traits
+```
+
+`.combine` merges the children in layout order; if the badge sits between the
+title and caption in the `HStack`, either reorder it after the caption or use
+`.accessibilityLabel` with an explicit string so the announcement order is
+deterministic regardless of visual layout.
 
 ## Tests
 
-- `testReadingHeaderAccessibilityLabel` — the header combines title, status,
-  role into one label.
-- Manual: VoiceOver announces the header as one element.
+- No new seam exists to test: the announcement is a SwiftUI attribute on views
+  that are not in the test target. If a pure helper is extracted for the
+  caption string (e.g. `ReadingHeader.caption(state:count:edited:)`), add a
+  ContractTests case for it — but the repo's current pattern has no such
+  helper, so **do not invent one** unless the implementation naturally needs
+  it.
+- Verify by build + manual VoiceOver check (or AX probe) per the Gate.
 
 ## Edge cases
 
-- Empty status → the label reads "Title, —, Trunk" (reuse the existing
-  `display(_:)`).
-- Long titles → `lineLimit(1)` truncation stays; the label can use the full
-  title.
+- **Served vs Draft** — both states must read sensibly inside the combined
+  string ("Served · …" / "Draft · …").
+- **Zero pages** — caption must not emit "0 pages" as a confusing fragment;
+  match whatever the visual caption does.
+- **Long titles** — combined string is announced as one unit; no truncation
+  requirement beyond what the visual layout already does.
+
+## Do not land
+
+- Re-adding the served-badge label/traits work (already on main).
+- Touching any file outside `Sources/Play/Local/ReadingPane.swift`.

--- a/docs/issues/editor-accessibility-sidebar-counts.md
+++ b/docs/issues/editor-accessibility-sidebar-counts.md
@@ -6,6 +6,11 @@
 **Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
 **Lane:** Mailboxes — `Sources/Chrome/`
 
+**Status: ✅ merged (PR #244).** Kept as the record; do not reopen. One
+note vs. this spec: the merged implementation used plain strings for the
+"items" unit (the repo has not adopted `String(localized:)`), matching the
+sidebar's existing style.
+
 ## Problem
 
 The mailbox sidebar announces row titles but not item counts, so VoiceOver

--- a/docs/issues/editor-compose-accessibility.md
+++ b/docs/issues/editor-compose-accessibility.md
@@ -20,16 +20,19 @@ tracker; each child is one lane, one worktree, one PR.
 All five are independent — no child consumes another's file, state, or
 selection. They can run in five worktrees at once.
 
-| Child | Issue | Lane | Gate (short) |
-|-------|-------|------|----------------|
-| [A-1 Compose toolbar + diagnostics](editor-accessibility-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | every Compose toolbar control and diagnostics row announces |
-| [A-2 Reading pane header](editor-accessibility-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | header announces title, status, role |
-| [A-3 Preview toolbar](editor-accessibility-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | URL / reload / open-in-browser labeled |
-| [A-4 Editor toolbar](editor-accessibility-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | URL / connect / restart / nav labeled |
-| [A-5 Mailbox sidebar counts](editor-accessibility-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | Pages + trunk rows announce counts from the stored graph |
+| Child | Issue | Lane | Status | Gate (short) |
+|-------|-------|------|--------|----------------|
+| [A-1 Compose toolbar + diagnostics](editor-accessibility-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | ⬜ partial — labels landed, delta remains | Language picker label + hints + diagnostics rows |
+| [A-2 Reading pane header](editor-accessibility-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | ⬜ not covered | header announces title + caption as one element |
+| [A-3 Preview toolbar](editor-accessibility-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | ⬜ not covered | URL / reload / open-in-browser labeled |
+| [A-4 Editor toolbar](editor-accessibility-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | ⬜ not covered | URL / connect / restart / nav / phase labeled |
+| [A-5 Mailbox sidebar counts](editor-accessibility-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | ✅ merged (PR #244) | Pages + trunk rows announce counts from the stored graph |
 
-Filed 2026-08-21 as #239–#243 (milestone 10). Close this tracker when all
-five land.
+Filed 2026-08-21 as #239–#243 (milestone 10). **Status as of 2026-08-21:**
+#243 landed (merged in PR #244); #239 is partially covered by the polish
+batch (#209/#210) — the specs and cards were recut to the remaining delta
+and marked accordingly; #240/#241/#242 are untouched and pickable as-is.
+Close this tracker when all five land.
 
 ## Shared nice-to-haves (not assigned — later)
 
@@ -49,8 +52,9 @@ five land.
 ## Gate (whole)
 
 With all five children landed, VoiceOver (⌘F5) can navigate the Compose
-window, both companions, and the sidebar without visual assistance: every
-toolbar control announces, a diagnostics row announces "Error on line 12: …",
-the reading header announces "title, status, role", and the Pages / trunk rows
-announce item counts that update when the graph rebuilds.
+window, both companions, and the sidebar without visual assistance: the
+Language picker announces the current language and every toolbar control
+announces a hint, a diagnostics row announces "Error on line 12: …", the
+reading header announces title + caption as one element, and the Pages / trunk
+rows announce item counts that update when the graph rebuilds (landed, #243).
 `SKIP_EMBED_BORIS=1 make build` + `make test` green.


### PR DESCRIPTION
## Why

The a11y polish batch (#209/#210) landed while the milestone-10 accessibility children (#239–#242) were still open — and it partially implemented **#239** (four toolbar labels) and fully shipped the **#243** sidebar counts via #244. The child specs and cards still described the pre-polish state, so anyone picking one up would find stale "verified current state" sections and ~half of #239 already done.

This PR recuts the A11Y specs, cards, and tracker against main's actual state (`6ddffd7`) so each remaining issue is a truthful, delta-only work item.

## What changed

**Child specs (#239–#242)** — each rewritten against verified main source:

| Issue | Status on main | Recut to |
|-------|----------------|----------|
| [#239](https://github.com/drawmeanelephant/solipsist/issues/239) Compose toolbar + diagnostics | ⬜ partial (4 toolbar labels landed) | Delta-only: Language picker label w/ current language + hint, hints on Front Matter / Render Options / Save, diagnostics-row combine via a unit-testable `ComposeDiagnostic.accessibilityLabel` |
| [#240](https://github.com/drawmeanelephant/solipsist/issues/240) Reading pane header | ⬜ not covered | Combine title + caption into one announcement; keep the landed served-badge label/traits |
| [#241](https://github.com/drawmeanelephant/solipsist/issues/241) Preview toolbar | ⬜ not covered | URL / Reload / Open-in-Browser labels + `.isButton` traits; label-only |
| [#242](https://github.com/drawmeanelephant/solipsist/issues/242) Editor toolbar | ⬜ not covered | URL / Connect / Restart / Back-Forward labels + phase indicator label incl. enumerate-all-phases |

Systemic corrections applied to all four:
- **No un-runnable UI tests promised** — views are not in the test target; only #239 has an honest unit seam (`ComposeDiagnostic` is compiled into ContractTests).
- **Plain-string style** — the earlier drafts told workers to introduce `String(localized:)`; the repo hasn't adopted it, so the recut matches the files' existing style and defers localization to tracker nice-to-haves.

**Tracker #236 + board** — status column added (A11Y-5 ✅ merged PR #244, A11Y-1 ⬜️ partial, A11Y-2/3/4 ⬜ untouched); card gates and both READMEs brought in sync; A11Y-5 spec/card marked "merged — do not reopen".

## Prior art

- Dispatch comments posted on #239–#242 reference the branch specs (now live): they link `blob/docs/a11y-spec-recut/...`, which this merge resolves onto `main`.
- Follows the milestone-10 docs pattern from PR #245.

Markdown only — no code, no build, no behavior change.

Generated with Codebuff 🤖
Co-Authored-By: Codebuff <noreply@codebuff.com>