### PR TITLE
feat(a11y): Compose toolbar hints + diagnostics-row announcement (#239)

### DIFF
--- a/Sources/Compose/ComposeDiagnostic.swift
+++ b/Sources/Compose/ComposeDiagnostic.swift
@@ -24,3 +24,17 @@ struct ComposeDiagnostic: Identifiable, Equatable {
         self.characterIndex = characterIndex
     }
 }
+
+extension ComposeDiagnostic {
+    /// VoiceOver label for a diagnostics row (A11Y-1 #239): severity first,
+    /// then the line when present, then the message — e.g. "Error on line
+    /// 12: unexpected token" / "Warning: missing closing fence". No line →
+    /// no "on line" clause.
+    var accessibilityLabel: String {
+        let severity = self.severity == .error ? "Error" : "Warning"
+        if let line {
+            return "\(severity) on line \(line): \(message)"
+        }
+        return "\(severity): \(message)"
+    }
+}

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -116,6 +116,8 @@ struct ComposeEditorView: View {
             .pickerStyle(.menu)
             .fixedSize()
             .help("Authoring frontend (Oliver's \(document.language.oliverFrontend))")
+            .accessibilityLabel("Language, currently \(document.language.displayName)")
+            .accessibilityHint("Select the authoring frontend")
 
             Text(document.language.conformanceNote)
                 .font(.caption)
@@ -139,6 +141,7 @@ struct ComposeEditorView: View {
             .toggleStyle(.button)
             .help("Edit the front-matter block (closed key set)")
             .accessibilityLabel("Front Matter")
+            .accessibilityHint("Show or hide the front matter editor.")
             .accessibilityAddTraits(showFrontmatter ? .isSelected : [])
 
             Menu {
@@ -148,6 +151,7 @@ struct ComposeEditorView: View {
             }
             .help("Oliver ParseOptions — every extension is off by default.")
             .accessibilityLabel("Render Options")
+            .accessibilityHint("Configure Oliver's parse extensions.")
 
             Button {
                 do {
@@ -164,6 +168,7 @@ struct ComposeEditorView: View {
             .keyboardShortcut("s", modifiers: .command)
             .help("Save (⌘S)")
             .accessibilityLabel("Save")
+            .accessibilityHint("Write the buffer to disk (⌘S).")
             .disabled(!document.isDirty)
 
             if let saveError {
@@ -232,6 +237,8 @@ private struct ComposeDiagnosticsPane: View {
             .contentShape(Rectangle())
             .onTapGesture { onSelect(diagnostic) }
             .help("Jump to this diagnostic")
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(diagnostic.accessibilityLabel)
         }
     }
 }

--- a/Tests/ContractTests/ComposeDiagnosticAccessibilityTests.swift
+++ b/Tests/ContractTests/ComposeDiagnosticAccessibilityTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+/// A11Y-1 #239: the diagnostics-row VoiceOver label. Pinned here because
+/// `ComposeDiagnostic` is compiled into ContractTests (Foundation-only);
+/// the view wiring (`.accessibilityElement(children: .combine)` + this
+/// label) is manual-verified.
+final class ComposeDiagnosticAccessibilityTests: XCTestCase {
+    func testErrorWithLine() {
+        let diagnostic = ComposeDiagnostic(severity: .error, message: "unexpected token", line: 12)
+        XCTAssertEqual(diagnostic.accessibilityLabel, "Error on line 12: unexpected token")
+    }
+
+    func testWarningWithLine() {
+        let diagnostic = ComposeDiagnostic(severity: .warning, message: "missing closing fence", line: 3)
+        XCTAssertEqual(diagnostic.accessibilityLabel, "Warning on line 3: missing closing fence")
+    }
+
+    func testErrorWithoutLineOmitsLineClause() {
+        let diagnostic = ComposeDiagnostic(severity: .error, message: "render failed")
+        XCTAssertEqual(diagnostic.accessibilityLabel, "Error: render failed")
+    }
+
+    func testWarningWithoutLineOmitsLineClause() {
+        let diagnostic = ComposeDiagnostic(severity: .warning, message: "unknown syntax")
+        XCTAssertEqual(diagnostic.accessibilityLabel, "Warning: unknown syntax")
+    }
+
+    func testLabelKeepsMessageWhitespace() {
+        let diagnostic = ComposeDiagnostic(severity: .error, message: "unclosed `{` (no `}` on the line)", line: 1)
+        XCTAssertEqual(diagnostic.accessibilityLabel, "Error on line 1: unclosed `{` (no `}` on the line)")
+    }
+}


### PR DESCRIPTION
## Why

Closes #239 (A11Y-1, child of tracker #236). The a11y polish batch (#209/#210) already labeled Preview / Front Matter / Render Options / Save; this PR is the recut **delta** from the A11Y-1 spec ([`docs/issues/editor-accessibility-compose-toolbar.md`](https://github.com/drawmeanelephant/solipsist/blob/main/docs/issues/editor-accessibility-compose-toolbar.md)): the Language picker is still unlabeled, three controls lack hints, and diagnostics rows read as a bare `HStack`.

## What

**`Sources/Compose/ComposeEditorView.swift`**
- **Language picker** — `.accessibilityLabel("Language, currently \(document.language.displayName)")` + `.accessibilityHint("Select the authoring frontend")`. The label is bound to the document, so it announces the *current* language and follows a switch.
- **Hints** on Front Matter ("Show or hide the front matter editor."), Render Options ("Configure Oliver's parse extensions."), Save ("Write the buffer to disk (⌘S).") — parity with the Preview toggle's existing hint.
- **Diagnostics rows** — `.accessibilityElement(children: .combine)` + `.accessibilityLabel(diagnostic.accessibilityLabel)` so each row is one VoiceOver announcement.

**`Sources/Compose/ComposeDiagnostic.swift`** — pure `accessibilityLabel` helper (Foundation-only, so it compiles into ContractTests): `"Error on line 12: unexpected token"` / `"Warning: missing closing fence"`; no line → `"Error: message"`.

**`Tests/ContractTests/ComposeDiagnosticAccessibilityTests.swift`** (new) — 5 tests pinning the label: severity + line + message; no-line variants for both severities; message-whitespace preservation. This is the one honest unit seam (the view wiring is manual-verified).

## Verification

- `make test` — **388 tests, 0 failures**, including the 5 new `ComposeDiagnosticAccessibilityTests`.
- `make build` — **BUILD SUCCEEDED**; `make lint` — **0 violations**.
- **Live AX probe** (running app, dogfood source, Compose window): every toolbar control announced its label + help; the picker announced `Language, currently Markdown` and, after a real language switch via the menu, **updated live to `Language, currently Cooklang`**; with the buffer set to the probed trigger (unclosed `{` in a heading, which the embedded oliver reports), the diagnostics pane row exposed as **one element announcing "Warning on line 1: unclosed `{` (no `}` on the line)"** — severity + line + message, tooltip intact.

Plain strings matching the file's existing style — `String(localized:)` deferred to tracker nice-to-haves per the spec.

Generated with Codebuff 🤖
Co-Authored-By: Codebuff <noreply@codebuff.com>