### PR TITLE
docs: mark A11Y-1 (#239) merged in the accessibility tracker + board

### DIFF
--- a/docs/cards/A11Y-compose-toolbar.md
+++ b/docs/cards/A11Y-compose-toolbar.md
@@ -8,9 +8,7 @@ suggestion `feat/a11y-compose-toolbar`.
 
 Spec: [`docs/issues/editor-accessibility-compose-toolbar.md`](../issues/editor-accessibility-compose-toolbar.md).
 
-**Status: ⬜ partially covered.** The polish batch (#209/#210) already labeled
-Preview / Front Matter / Render Options / Save. This card is the **delta**:
-Language picker label, three hints, and the diagnostics rows.
+**Status: ✅ merged (PR #247).** Kept as the record; do not reopen.
 
 ## Owns
 

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -170,17 +170,16 @@ below are the session briefs.
 | Card | Issue | Lane | Parallel with | Gate |
 |------|-------|------|----------------|------|
 | [A11Y tracker](../issues/editor-compose-accessibility.md) | [#236](https://github.com/drawmeanelephant/solipsist/issues/236) | design | — | five children land; VoiceOver covers all surfaces |
-| [A11Y-1 Compose toolbar + diagnostics](A11Y-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | A11Y-2..A11Y-5 | ⬜ partial — Language picker label + hints + diagnostics rows |
+| [A11Y-1 Compose toolbar + diagnostics](A11Y-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | A11Y-2..A11Y-5 | ✅ merged (PR #247) |
 | [A11Y-2 Reading pane header](A11Y-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | A11Y-1, A11Y-3..A11Y-5 | ⬜ header announces title + caption as one element |
 | [A11Y-3 Preview toolbar](A11Y-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | A11Y-1, A11Y-2, A11Y-4, A11Y-5 | ⬜ URL / reload / open-in-browser labeled |
 | [A11Y-4 Editor toolbar](A11Y-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | A11Y-1..A11Y-3, A11Y-5 | ⬜ URL / connect / restart / nav / phase labeled |
 | [A11Y-5 Mailbox sidebar counts](A11Y-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | — | ✅ merged (PR #244) |
 
 Filed 2026-08-21 as #239–#243 (milestone 10). **Status:** #243 landed
-(PR #244); #239 is partially covered by the polish batch (#209/#210) — its
-spec and card were recut to the remaining delta; the other three are
-untouched and pickable. Close #236 when all five land. Do not grow a card
-into another card's lane — the Owns / Do-not-touch lists are the contract.
+(PR #244) and #239 landed (PR #247); the remaining three are untouched and
+pickable. Close #236 when all five land. Do not grow a card into another
+card's lane — the Owns / Do-not-touch lists are the contract.
 
 ## Do not start yet
 

--- a/docs/issues/editor-accessibility-compose-toolbar.md
+++ b/docs/issues/editor-accessibility-compose-toolbar.md
@@ -6,6 +6,10 @@
 **Parent:** [#236](https://github.com/drawmeanelephant/solipsist/issues/236) (tracker)
 **Lane:** Compose — `Sources/Compose/`
 
+**Status: ✅ merged (PR #247).** Kept as the record; do not reopen. The
+merged implementation matches this spec, including plain strings (no
+`String(localized:)`).
+
 ## Problem
 
 Compose's toolbar and diagnostics pane are only partly VoiceOver-accessible.

--- a/docs/issues/editor-compose-accessibility.md
+++ b/docs/issues/editor-compose-accessibility.md
@@ -22,17 +22,16 @@ selection. They can run in five worktrees at once.
 
 | Child | Issue | Lane | Status | Gate (short) |
 |-------|-------|------|--------|----------------|
-| [A-1 Compose toolbar + diagnostics](editor-accessibility-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | ⬜ partial — labels landed, delta remains | Language picker label + hints + diagnostics rows |
+| [A-1 Compose toolbar + diagnostics](editor-accessibility-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | ✅ merged (PR #247) | Language picker label + hints + diagnostics rows |
 | [A-2 Reading pane header](editor-accessibility-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | ⬜ not covered | header announces title + caption as one element |
 | [A-3 Preview toolbar](editor-accessibility-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | ⬜ not covered | URL / reload / open-in-browser labeled |
 | [A-4 Editor toolbar](editor-accessibility-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | ⬜ not covered | URL / connect / restart / nav / phase labeled |
 | [A-5 Mailbox sidebar counts](editor-accessibility-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | ✅ merged (PR #244) | Pages + trunk rows announce counts from the stored graph |
 
 Filed 2026-08-21 as #239–#243 (milestone 10). **Status as of 2026-08-21:**
-#243 landed (merged in PR #244); #239 is partially covered by the polish
-batch (#209/#210) — the specs and cards were recut to the remaining delta
-and marked accordingly; #240/#241/#242 are untouched and pickable as-is.
-Close this tracker when all five land.
+#243 landed (merged in PR #244) and #239 landed (merged in PR #247);
+#240/#241/#242 are untouched and pickable as-is. Close this tracker when
+all five land.
 
 ## Shared nice-to-haves (not assigned — later)
 


### PR DESCRIPTION
## Why

#239 (A11Y-1, the Compose toolbar + diagnostics delta) landed via PR #247 and auto-closed. The accessibility tracker (#236), the board, and the A11Y-1 card/spec still read "partial — delta remains", which is now stale.

## What

- **Tracker** `docs/issues/editor-compose-accessibility.md` — A-1 row → `✅ merged (PR #247)`; status note updated to "#243 landed (PR #244) and #239 landed (PR #247); #240/#241/#242 untouched and pickable."
- **Board** `docs/cards/README.md` — A11Y-1 row → `✅ merged (PR #247)`; intro note matches (2 of 5 done, three remain).
- **A11Y-1 card + spec** — "Status: ✅ merged (PR #247). Kept as the record; do not reopen." per the A11Y-5 (#243) convention.

Markdown only — no code, no behavior change. Mirrors the tracker-update pattern applied when #243 merged.

Generated with Codebuff 🤖
Co-Authored-By: Codebuff <noreply@codebuff.com>