### PR TITLE
feat(a11y): combine Reading pane header title + caption into one announcement (#240)

### DIFF
--- a/Sources/Play/Local/ReadingPane.swift
+++ b/Sources/Play/Local/ReadingPane.swift
@@ -79,6 +79,8 @@ struct ReadingPane: View {
                     .textSelection(.enabled)
                     .help(headerCaption(for: page))
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(page.title), \(headerCaption(for: page))")
 
             Spacer(minLength: 12)
 


### PR DESCRIPTION
## A11Y-2 (#240): Reading pane header — one announcement

Combines the Reading pane header's title + caption into a single VoiceOver element, per the recut spec (now on `main` via #246).

### What changed

**`Sources/Play/Local/ReadingPane.swift`** (+2 lines) — on the header's title+caption `VStack`:

```swift
.accessibilityElement(children: .combine)
.accessibilityLabel("\(page.title), \(headerCaption(for: page))")
```

The explicit label makes the announcement order deterministic (title first, then caption) regardless of how the served badge sits in the layout.

### What's preserved

- **Served badge** — untouched: keeps `.accessibilityLabel("Served")` + `.isStaticText`, sits outside the combined `VStack` as its own element.
- **Action buttons** (Preview / Edit Page / Compose) — remain separate siblings.
- No other Reading-pane element touched.

### Verification

- `make build` — BUILD SUCCEEDED
- `make test` — 388 tests, 0 failures
- `make lint` — 0 violations
- **Live AX probe** (running app, dogfood source, trunk page selected): header announces as **one element** — *"Agent Field Notes, agents/index.md · published · Trunk"* — title then caption, single stop; buttons stay separate.

Closes #240
