### PR TITLE
docs: mark A11Y-2 (#240) merged in the accessibility tracker + board

### DIFF
--- a/docs/cards/A11Y-reading-header.md
+++ b/docs/cards/A11Y-reading-header.md
@@ -8,8 +8,7 @@ suggestion `feat/a11y-reading-header`.
 
 Spec: [`docs/issues/editor-accessibility-reading-header.md`](../issues/editor-accessibility-reading-header.md).
 
-**Status: ⬜ not covered.** The header still announces as two separate
-elements; only the served badge has a11y work (polish batch — keep it).
+**Status: ✅ merged (PR #249).** Kept as the record; do not reopen.
 
 ## Owns
 

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -162,8 +162,8 @@ entry). Do not pick.
 
 VoiceOver across the editor surfaces, cut into five disjoint lanes from
 tracker [#236](https://github.com/drawmeanelephant/solipsist/issues/236).
-Each card is one worktree, one PR against `main`; the remaining four are
-independent and can run at once (#243 is merged). Specs live in
+Each card is one worktree, one PR against `main`; the remaining two are
+independent and can run at once (#243, #239, #240 merged). Specs live in
 [`docs/issues/`](../issues/README.md) (child-of-#236 drafts); the cards
 below are the session briefs.
 
@@ -171,15 +171,16 @@ below are the session briefs.
 |------|-------|------|----------------|------|
 | [A11Y tracker](../issues/editor-compose-accessibility.md) | [#236](https://github.com/drawmeanelephant/solipsist/issues/236) | design | — | five children land; VoiceOver covers all surfaces |
 | [A11Y-1 Compose toolbar + diagnostics](A11Y-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | A11Y-2..A11Y-5 | ✅ merged (PR #247) |
-| [A11Y-2 Reading pane header](A11Y-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | A11Y-1, A11Y-3..A11Y-5 | ⬜ header announces title + caption as one element |
+| [A11Y-2 Reading pane header](A11Y-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | A11Y-1, A11Y-3..A11Y-5 | ✅ merged (PR #249) |
 | [A11Y-3 Preview toolbar](A11Y-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | A11Y-1, A11Y-2, A11Y-4, A11Y-5 | ⬜ URL / reload / open-in-browser labeled |
 | [A11Y-4 Editor toolbar](A11Y-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | A11Y-1..A11Y-3, A11Y-5 | ⬜ URL / connect / restart / nav / phase labeled |
 | [A11Y-5 Mailbox sidebar counts](A11Y-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | — | ✅ merged (PR #244) |
 
 Filed 2026-08-21 as #239–#243 (milestone 10). **Status:** #243 landed
-(PR #244) and #239 landed (PR #247); the remaining three are untouched and
-pickable. Close #236 when all five land. Do not grow a card into another
-card's lane — the Owns / Do-not-touch lists are the contract.
+(PR #244), #239 landed (PR #247), and #240 landed (PR #249); the remaining
+two are untouched and pickable. Close #236 when all five land. Do not grow
+a card into another card's lane — the Owns / Do-not-touch lists are the
+contract.
 
 ## Do not start yet
 

--- a/docs/issues/editor-accessibility-reading-header.md
+++ b/docs/issues/editor-accessibility-reading-header.md
@@ -5,7 +5,10 @@
 - **Lane:** Reading
 - **Owns:** `Sources/Play/Local/ReadingPane.swift`
 
-## Problem
+**Status: ✅ merged (PR #249).** Kept as the record; do not reopen. The
+merged implementation matches this spec: title + caption combine into one
+announcement (title first), the served badge keeps its label + traits, and
+the action buttons stay separate.
 
 The Reading pane header announces its title and its status caption as **two
 separate accessibility elements**. A VoiceOver user swiping through the header

--- a/docs/issues/editor-compose-accessibility.md
+++ b/docs/issues/editor-compose-accessibility.md
@@ -23,15 +23,15 @@ selection. They can run in five worktrees at once.
 | Child | Issue | Lane | Status | Gate (short) |
 |-------|-------|------|--------|----------------|
 | [A-1 Compose toolbar + diagnostics](editor-accessibility-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | ✅ merged (PR #247) | Language picker label + hints + diagnostics rows |
-| [A-2 Reading pane header](editor-accessibility-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | ⬜ not covered | header announces title + caption as one element |
+| [A-2 Reading pane header](editor-accessibility-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | ✅ merged (PR #249) | header announces title + caption as one element |
 | [A-3 Preview toolbar](editor-accessibility-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | ⬜ not covered | URL / reload / open-in-browser labeled |
 | [A-4 Editor toolbar](editor-accessibility-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | ⬜ not covered | URL / connect / restart / nav / phase labeled |
 | [A-5 Mailbox sidebar counts](editor-accessibility-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | ✅ merged (PR #244) | Pages + trunk rows announce counts from the stored graph |
 
 Filed 2026-08-21 as #239–#243 (milestone 10). **Status as of 2026-08-21:**
-#243 landed (merged in PR #244) and #239 landed (merged in PR #247);
-#240/#241/#242 are untouched and pickable as-is. Close this tracker when
-all five land.
+#243 landed (merged in PR #244), #239 landed (merged in PR #247), and
+#240 landed (merged in PR #249); #241/#242 are untouched and pickable
+as-is. Close this tracker when all five land.
 
 ## Shared nice-to-haves (not assigned — later)
 


### PR DESCRIPTION
## Mark A11Y-2 (#240) merged in the accessibility tracker + board

PR #249 landed the Reading pane header combine (title + caption as one VoiceOver announcement), which auto-closed #240. This docs-only PR records that on the board.

### Changes (4 docs files)

- **Tracker** (`docs/issues/editor-compose-accessibility.md`) — A-2 row → `✅ merged (PR #249)`; status note now "…#243 (PR #244), #239 (PR #247), and #240 (PR #249) landed; #241/#242 untouched and pickable."
- **Board** (`docs/cards/README.md`) — A11Y-2 row → `✅ merged (PR #249)`; intro + status updated (2 of 5 remain, pickable).
- **A11Y-2 card + spec** — `Status: ✅ merged (PR #249). Kept as the record; do not reopen.` matching the A11Y-1/A11Y-5 convention, with a note that the merged implementation matches the spec.

Docs only — no code touched.
