### PR TITLE
feat(a11y): label the Preview toolbar controls (URL, Reload, Open in Browser) (#241)

### DIFF
--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -117,12 +117,15 @@ struct PreviewWindow: View {
                 TextField("http://127.0.0.1:8080/__boris/", text: $urlText)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit(submit)
+                    .accessibilityLabel("Preview URL")
 
                 Button {
                     model.reload()
                 } label: {
                     Image(systemName: "arrow.clockwise")
                 }
+                .accessibilityLabel("Reload")
+                .accessibilityAddTraits(.isButton)
                 .help("Reload")
                 .disabled(!model.canReload)
 
@@ -131,6 +134,8 @@ struct PreviewWindow: View {
                 } label: {
                     Image(systemName: "safari")
                 }
+                .accessibilityLabel("Open in Browser")
+                .accessibilityAddTraits(.isButton)
                 .help("Open in Browser")
                 .disabled(!model.canOpenInBrowser)
             }


### PR DESCRIPTION
## A11Y-3 (#241): Preview toolbar — label the controls

The Preview window's toolbar controls carried only `.help()` tooltips, which VoiceOver does not read as a name. This adds explicit accessibility labels and `.isButton` traits so VoiceOver announces each control by name, per the recut spec (now on `main` via #246).

### What changed

**`Sources/Companions/Preview/PreviewWindow.swift`** (+5 lines) — exactly the spec's delta:
- URL field → `.accessibilityLabel("Preview URL")`
- Reload → `.accessibilityLabel("Reload")` + `.accessibilityAddTraits(.isButton)`
- Open in Browser → `.accessibilityLabel("Open in Browser")` + `.accessibilityAddTraits(.isButton)`

The `.help()` tooltips are kept for hover text; no layout, icons, or behavior changed.

### Verification

- `make build` — BUILD SUCCEEDED
- `make test` — green
- `make lint` — 0 violations
- **Live AX probe** (running app, Preview window opened via ⌘⇧P):
  - `AXTextField desc="Preview URL"` — the URL field is now a labeled text field
  - `AXButton desc="Reload"` with `help="Reload"` — tooltip intact
  - `AXButton desc="Open in Browser"` with `help="Open in Browser"` — tooltip intact

Closes #241
