### PR TITLE
feat(a11y): label the Editor toolbar controls + enumerate phase indicator (#242)

### DIFF
--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -182,6 +182,8 @@ struct EditorWindow: View {
                 } label: {
                     Label("Restart Host", systemImage: "arrow.counterclockwise")
                 }
+                .accessibilityLabel("Restart")
+                .accessibilityAddTraits(.isButton)
                 .help("Restart boris-editor")
                 .disabled(!session.canRestart)
 
@@ -190,6 +192,8 @@ struct EditorWindow: View {
                 } label: {
                     Image(systemName: "safari")
                 }
+                .accessibilityLabel("Open in Browser")
+                .accessibilityAddTraits(.isButton)
                 .help("Open in Browser")
                 .disabled(!model.canOpenInBrowser)
             }
@@ -198,8 +202,11 @@ struct EditorWindow: View {
                 TextField("BORIS_EDITOR_URL=http://127.0.0.1:49152/#token=…", text: $urlText)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit(submit)
+                    .accessibilityLabel("Editor URL")
 
                 Button("Connect", action: submit)
+                    .accessibilityLabel("Connect")
+                    .accessibilityAddTraits(.isButton)
             }
 
             if let rejection = model.rejection {
@@ -239,6 +246,8 @@ private struct EditorNavButtons: View {
             } label: {
                 Image(systemName: "chevron.left")
             }
+            .accessibilityLabel("Back")
+            .accessibilityAddTraits(.isButton)
             .help("Back")
             .disabled(!model.canGoBack)
 
@@ -247,6 +256,8 @@ private struct EditorNavButtons: View {
             } label: {
                 Image(systemName: "chevron.right")
             }
+            .accessibilityLabel("Forward")
+            .accessibilityAddTraits(.isButton)
             .help("Forward")
             .disabled(!model.canGoForward)
 
@@ -255,6 +266,8 @@ private struct EditorNavButtons: View {
             } label: {
                 Image(systemName: "arrow.clockwise")
             }
+            .accessibilityLabel("Reload")
+            .accessibilityAddTraits(.isButton)
             .help("Reload")
             .disabled(!model.canReload)
         }
@@ -275,6 +288,9 @@ private struct EditorPhaseIndicator: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityPhaseLabel)
+        .accessibilityAddTraits(.isStaticText)
     }
 
     @ViewBuilder
@@ -304,6 +320,22 @@ private struct EditorPhaseIndicator: View {
             return "Connected · \(url.host ?? "loopback")"
         case .failed(let message):
             return message
+        }
+    }
+
+    /// A11Y-4 (#242): a VoiceOver-readable label for every phase value the
+    /// indicator can render. Enumerates all four `Phase` cases so a new one
+    /// won't ship unlabeled.
+    private var accessibilityPhaseLabel: String {
+        switch phase {
+        case .idle:
+            return "Engine idle"
+        case .starting:
+            return "Engine starting"
+        case .connected:
+            return "Engine running"
+        case .failed:
+            return "Engine error"
         }
     }
 }


### PR DESCRIPTION
## A11Y-4 (#242): Editor toolbar — label the controls + phase indicator

The Editor window's toolbar controls carried only `.help()` tooltips (which VoiceOver does not read as a name) or nothing at all. This adds explicit accessibility labels and `.isButton` traits to every toolbar control, and gives the `EditorPhaseIndicator` a combined accessibility element whose label enumerates every `Phase` case, per the recut spec (now on `main` via #246).

### What changed

**`Sources/Companions/Editor/EditorWindow.swift`** (+32 lines) — exactly the spec's delta:
- URL field → `.accessibilityLabel("Editor URL")`
- Connect → `.accessibilityLabel("Connect")` + `.isButton`
- Restart → `.accessibilityLabel("Restart")` + `.isButton`
- Back / Forward / Reload (in `EditorNavButtons`) → labels + `.isButton`
- Open in Browser → `.accessibilityLabel("Open in Browser")` + `.isButton`
- Phase indicator (`EditorPhaseIndicator`) → `.accessibilityElement(children: .combine)` + label that **enumerates all four** `Phase` cases: `.idle` → "Engine idle", `.starting` → "Engine starting", `.connected` → "Engine running", `.failed` → "Engine error" + `.isStaticText`

All `.help()` tooltips kept; plain strings; no layout/behavior changes.

### Verification

- `make build` — BUILD SUCCEEDED
- `make test` — green
- `make lint` — 0 violations
- **Live AX probe** (running app, Editor window opened via View → Editor):
  - `AXTextField desc="Editor URL"`
  - `AXButton desc="Connect"` / `"Restart"` / `"Back"` / `"Forward"` / `"Reload"` / `"Open in Browser"` (tooltips intact)
  - `AXStaticText value="Engine running"` — the phase indicator (`.connected` case) reads its label, not an unlabeled graphic

The phase label switches on all four `Phase` cases, so every phase ships labeled (idle/starting/connected/failed) — the spec's enumerate-all-phases edge case.

Closes #242
