### PR TITLE
docs: close A11Y tracker — all five children landed (#239-#243)

### DIFF
--- a/docs/cards/A11Y-editor-toolbar.md
+++ b/docs/cards/A11Y-editor-toolbar.md
@@ -8,8 +8,7 @@ branch suggestion `feat/a11y-editor-toolbar`.
 
 Spec: [`docs/issues/editor-accessibility-editor-toolbar.md`](../issues/editor-accessibility-editor-toolbar.md).
 
-**Status: ⬜ not covered.** Toolbar controls carry only `.help()` or nothing;
-nav + phase were refactored into subviews but stayed unlabeled.
+**Status: ✅ merged (PR #252).** Kept as the record; do not reopen.
 
 ## Owns
 

--- a/docs/cards/A11Y-preview-toolbar.md
+++ b/docs/cards/A11Y-preview-toolbar.md
@@ -8,8 +8,7 @@ branch suggestion `feat/a11y-preview-toolbar`.
 
 Spec: [`docs/issues/editor-accessibility-preview-toolbar.md`](../issues/editor-accessibility-preview-toolbar.md).
 
-**Status: ⬜ not covered.** No accessibility attributes on any toolbar control
-(only `.help()` tooltips).
+**Status: ✅ merged (PR #251).** Kept as the record; do not reopen.
 
 ## Owns
 

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -162,8 +162,8 @@ entry). Do not pick.
 
 VoiceOver across the editor surfaces, cut into five disjoint lanes from
 tracker [#236](https://github.com/drawmeanelephant/solipsist/issues/236).
-Each card is one worktree, one PR against `main`; the remaining two are
-independent and can run at once (#243, #239, #240 merged). Specs live in
+Each card is one worktree, one PR against `main`; all five are now
+merged. Specs live in
 [`docs/issues/`](../issues/README.md) (child-of-#236 drafts); the cards
 below are the session briefs.
 
@@ -172,15 +172,14 @@ below are the session briefs.
 | [A11Y tracker](../issues/editor-compose-accessibility.md) | [#236](https://github.com/drawmeanelephant/solipsist/issues/236) | design | — | five children land; VoiceOver covers all surfaces |
 | [A11Y-1 Compose toolbar + diagnostics](A11Y-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | A11Y-2..A11Y-5 | ✅ merged (PR #247) |
 | [A11Y-2 Reading pane header](A11Y-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | A11Y-1, A11Y-3..A11Y-5 | ✅ merged (PR #249) |
-| [A11Y-3 Preview toolbar](A11Y-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | A11Y-1, A11Y-2, A11Y-4, A11Y-5 | ⬜ URL / reload / open-in-browser labeled |
-| [A11Y-4 Editor toolbar](A11Y-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | A11Y-1..A11Y-3, A11Y-5 | ⬜ URL / connect / restart / nav / phase labeled |
+| [A11Y-3 Preview toolbar](A11Y-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | A11Y-1, A11Y-2, A11Y-4, A11Y-5 | ✅ merged (PR #251) |
+| [A11Y-4 Editor toolbar](A11Y-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | A11Y-1..A11Y-3, A11Y-5 | ✅ merged (PR #252) |
 | [A11Y-5 Mailbox sidebar counts](A11Y-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | — | ✅ merged (PR #244) |
 
-Filed 2026-08-21 as #239–#243 (milestone 10). **Status:** #243 landed
-(PR #244), #239 landed (PR #247), and #240 landed (PR #249); the remaining
-two are untouched and pickable. Close #236 when all five land. Do not grow
-a card into another card's lane — the Owns / Do-not-touch lists are the
-contract.
+Filed 2026-08-21 as #239–#243 (milestone 10). **All five children landed:**
+#243 (PR #244), #239 (PR #247), #240 (PR #249), #241 (PR #251),
+#242 (PR #252). #236 tracker closed. Do not grow a card into another
+card's lane — the Owns / Do-not-touch lists are the contract.
 
 ## Do not start yet
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -51,9 +51,9 @@ two touch the same lane in the same PR.
 | [Editor UX Polish](editor-companion-ux-polish.md) | [#237](https://github.com/drawmeanelephant/solipsist/issues/237) | `Sources/Companions/Editor/` |
 | [Go to Line (⌘L)](editor-compose-go-to-line.md) | [#238](https://github.com/drawmeanelephant/solipsist/issues/238) | `Sources/Compose/` |
 
-Status (2026-08-21): #243 merged (PR #244); #239 partially covered by the
-polish batch (#209/#210) — its spec + card are recut to the remaining delta;
-#240/#241/#242 untouched and pickable.
+Status (2026-08-21): all five accessibility children merged — #243 (PR
+#244), #239 (PR #247), #240 (PR #249), #241 (PR #251), #242 (PR #252).
+#236 tracker closed.
 
 Do not ask: unifying `compiler` field names, library mode, relaxing
 editor token/CSP, shipping `boris-editor` in the agent-pack.

--- a/docs/issues/editor-accessibility-editor-toolbar.md
+++ b/docs/issues/editor-accessibility-editor-toolbar.md
@@ -5,6 +5,10 @@
 - **Lane:** Editor companion
 - **Owns:** `Sources/Companions/Editor/`
 
+**Status: ✅ merged (PR #252).** Kept as the record; do not reopen. The
+merged implementation matches this spec: plain strings, .help() tooltips
+kept, all controls labeled, phase indicator enumerates all four cases.
+
 ## Problem
 
 The Editor window's toolbar controls are **unlabeled** to assistive

--- a/docs/issues/editor-accessibility-preview-toolbar.md
+++ b/docs/issues/editor-accessibility-preview-toolbar.md
@@ -5,6 +5,10 @@
 - **Lane:** Preview companion
 - **Owns:** `Sources/Companions/Preview/`
 
+**Status: ✅ merged (PR #251).** Kept as the record; do not reopen. The
+merged implementation matches this spec: plain strings, .help() tooltips
+kept, all three controls labeled.
+
 ## Problem
 
 The Preview window's toolbar controls are **unlabeled** to assistive

--- a/docs/issues/editor-compose-accessibility.md
+++ b/docs/issues/editor-compose-accessibility.md
@@ -24,14 +24,13 @@ selection. They can run in five worktrees at once.
 |-------|-------|------|--------|----------------|
 | [A-1 Compose toolbar + diagnostics](editor-accessibility-compose-toolbar.md) | [#239](https://github.com/drawmeanelephant/solipsist/issues/239) | Compose | ✅ merged (PR #247) | Language picker label + hints + diagnostics rows |
 | [A-2 Reading pane header](editor-accessibility-reading-header.md) | [#240](https://github.com/drawmeanelephant/solipsist/issues/240) | Reading | ✅ merged (PR #249) | header announces title + caption as one element |
-| [A-3 Preview toolbar](editor-accessibility-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | ⬜ not covered | URL / reload / open-in-browser labeled |
-| [A-4 Editor toolbar](editor-accessibility-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | ⬜ not covered | URL / connect / restart / nav / phase labeled |
+| [A-3 Preview toolbar](editor-accessibility-preview-toolbar.md) | [#241](https://github.com/drawmeanelephant/solipsist/issues/241) | Preview companion | ✅ merged (PR #251) | URL / reload / open-in-browser labeled |
+| [A-4 Editor toolbar](editor-accessibility-editor-toolbar.md) | [#242](https://github.com/drawmeanelephant/solipsist/issues/242) | Editor companion | ✅ merged (PR #252) | URL / connect / restart / nav / phase labeled |
 | [A-5 Mailbox sidebar counts](editor-accessibility-sidebar-counts.md) | [#243](https://github.com/drawmeanelephant/solipsist/issues/243) | Mailboxes | ✅ merged (PR #244) | Pages + trunk rows announce counts from the stored graph |
 
-Filed 2026-08-21 as #239–#243 (milestone 10). **Status as of 2026-08-21:**
-#243 landed (merged in PR #244), #239 landed (merged in PR #247), and
-#240 landed (merged in PR #249); #241/#242 are untouched and pickable
-as-is. Close this tracker when all five land.
+Filed 2026-08-21 as #239–#243 (milestone 10). **All five children landed:**
+#243 (PR #244), #239 (PR #247), #240 (PR #249), #241 (PR #251),
+#242 (PR #252). Tracker closed.
 
 ## Shared nice-to-haves (not assigned — later)
 


### PR DESCRIPTION
## Close A11Y tracker (#236) — all five children landed

All five accessibility children have been merged. This docs-only PR records that on the board, tracker, and individual card/spec files.

### Children landed

| Child | Issue | PR | Status |
|-------|-------|----|--------|
| A-1 Compose toolbar + diagnostics | #239 | #247 | ✅ |
| A-2 Reading pane header | #240 | #249 | ✅ |
| A-3 Preview toolbar | #241 | #251 | ✅ |
| A-4 Editor toolbar + phase indicator | #242 | #252 | ✅ |
| A-5 Mailbox sidebar counts | #243 | #244 | ✅ |

### Changes (7 docs files)

- **Tracker** — A-3 and A-4 rows → ✅ merged; status note → "All five children landed; tracker closed."
- **Board** — A11Y-3 and A11Y-4 rows → ✅ merged; intro + status updated.
- **Issues README** — status line updated.
- **A11Y-3 + A11Y-4 card + spec** — `Status: ✅ merged` markers added, matching the A11Y-1/A11Y-2/A11Y-5 convention.
