### PR TITLE
M18: Compose Find bar (#225) + Line gutter (#226)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -125,6 +125,8 @@ targets:
       - path: Sources/Compose/MarkupRenderService.swift
       - path: Sources/Compose/ComposePageResolver.swift
       - path: Sources/Compose/OliverRenderService.swift
+      - path: Sources/Compose/ComposeLineGutter.swift
+      - path: Sources/Compose/ComposeTextView.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.drawmeanelephant.solipsist.contracttests

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -50,6 +50,7 @@ struct ComposeEditorView: View {
                     jumpToCharacter: jumpToCharacter,
                     completion: cookCompletion
                 )
+                .id(document.fileURL)
                 .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)
                 if showPreview {
                     ComposePreviewView(

--- a/Sources/Compose/ComposeLineGutter.swift
+++ b/Sources/Compose/ComposeLineGutter.swift
@@ -1,0 +1,251 @@
+import AppKit
+
+/// Line numbers gutter for the compose editor (#226).
+///
+/// Lightweight `NSView` overlay that lives as a subview of the `NSTextView`
+/// (so it scrolls vertically with the buffer but stays fixed horizontally
+/// because `widthTracksTextView` disables horizontal scrolling). It draws
+/// monospaced 13pt numbers in `secondaryLabelColor`, highlights the current
+/// line, and shows a thin separator. Width is at least 36pt (3–4 digits for
+/// ~9999 lines).
+final class ComposeLineGutter: NSView {
+    weak var textView: NSTextView?
+
+    /// Fixed minimum width; grows only if line count needs more digits.
+    var gutterWidth: CGFloat {
+        guard let textView else { return 36 }
+        let lines = max(1, lineCount(in: textView.string))
+        let digits = max(3, "\(lines)".count)
+        let charWidth: CGFloat = 7.8 // ~13pt ui-monospace average
+        let computed = CGFloat(digits) * charWidth + 12
+        return max(36, computed)
+    }
+
+    private let baseFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    private let boldFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold)
+
+    override var isOpaque: Bool { false }
+
+    // swiftlint:disable:next function_body_length
+    override func draw(_ dirtyRect: NSRect) {
+        guard let textView,
+              let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer
+        else { return }
+
+        // Background
+        NSColor.textBackgroundColor.setFill()
+        dirtyRect.fill()
+
+        // Separator at right edge
+        NSColor.separatorColor.setStroke()
+        let sep = NSBezierPath()
+        sep.move(to: NSPoint(x: bounds.width - 0.5, y: bounds.minY))
+        sep.line(to: NSPoint(x: bounds.width - 0.5, y: bounds.maxY))
+        sep.lineWidth = 0.5
+        sep.stroke()
+
+        let text = textView.string as NSString
+        let currentLine = currentLineNumber(in: textView)
+
+        // Visible optimization: only draw lines whose y is in visible rect.
+        // For gutter-as-subview-of-textView, visibleRect is the portion of the
+        // gutter actually exposed by the clipView. Use textView's layout to
+        // compute each logical line's y.
+        var lineNumber = 1
+        var hasDrawn = false
+
+        // Enumerate logical lines (by \n, handling \r\n via NSString enumeration)
+        text.enumerateSubstrings(
+            in: NSRange(location: 0, length: text.length),
+            options: [.byLines, .substringNotRequired]
+        ) { _, range, _, _ in
+            self.drawNumber(
+                lineNumber,
+                atCharacterRange: range,
+                layoutManager: layoutManager,
+                textView: textView,
+                isCurrent: lineNumber == currentLine
+            )
+            hasDrawn = true
+            lineNumber += 1
+        }
+
+        // Empty buffer: show line 1
+        if !hasDrawn {
+            drawNumber(
+                1,
+                atCharacterRange: NSRange(location: 0, length: 0),
+                layoutManager: layoutManager,
+                textView: textView,
+                isCurrent: currentLine == 1
+            )
+            lineNumber = 2
+        }
+
+        // Trailing empty line (text ends with \n creates an extra logical line)
+        if text.length > 0, text.character(at: text.length - 1) == 10 { // \n
+            let range = NSRange(location: text.length, length: 0)
+            drawNumber(
+                lineNumber,
+                atCharacterRange: range,
+                layoutManager: layoutManager,
+                textView: textView,
+                isCurrent: lineNumber == currentLine
+            )
+            lineNumber += 1
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func lineCount(in text: String) -> Int {
+        if text.isEmpty { return 1 }
+        let nsText = text as NSString
+        var lines = 0
+        nsText.enumerateSubstrings(
+            in: NSRange(location: 0, length: nsText.length),
+            options: [.byLines, .substringNotRequired]
+        ) { _, _, _, _ in lines += 1 }
+        if nsText.length > 0, nsText.character(at: nsText.length - 1) == 10 {
+            lines += 1
+        }
+        return max(1, lines)
+    }
+
+    private func currentLineNumber(in textView: NSTextView) -> Int {
+        let selected = textView.selectedRange().location
+        let text = textView.string as NSString
+        if text.length == 0 { return 1 }
+        var line = 1
+        var found = 1
+        text.enumerateSubstrings(
+            in: NSRange(location: 0, length: text.length),
+            options: [.byLines, .substringNotRequired]
+        ) { _, range, _, stop in
+            if NSLocationInRange(selected, range) || selected == range.upperBound {
+                found = line
+                stop.pointee = true
+            }
+            // Also handle trailing empty line: selection at end == last line
+            line += 1
+        }
+        // If selection is at very end past last line's range (trailing \n case)
+        if selected == text.length, text.character(at: text.length - 1) == 10 {
+            // That is the trailing empty line
+            var count = 0
+            text.enumerateSubstrings(
+                in: NSRange(location: 0, length: text.length),
+                options: [.byLines, .substringNotRequired]
+            ) { _, _, _, _ in count += 1 }
+            return count + 1
+        }
+        return found
+    }
+
+    private func drawNumber(
+        _ number: Int,
+        atCharacterRange range: NSRange,
+        layoutManager: NSLayoutManager,
+        textView: NSTextView,
+        isCurrent: Bool
+    ) {
+        // Resolve y for this character range via layoutManager
+        let glyphIndex: Int
+        if range.length == 0, range.location > 0 {
+            glyphIndex = layoutManager.glyphIndexForCharacter(at: max(0, range.location - 1))
+        } else if range.location < (textView.string as NSString).length {
+            glyphIndex = layoutManager.glyphIndexForCharacter(at: range.location)
+        } else if (textView.string as NSString).length > 0 {
+            glyphIndex = layoutManager.glyphIndexForCharacter(at: (textView.string as NSString).length - 1)
+        } else {
+            glyphIndex = 0
+        }
+        var lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+        // lineRect is in textContainer coordinates; offset by inset to get textView coords
+        var yInTextView = lineRect.minY + textView.textContainerInset.height
+        // For trailing empty line, place it one lineHeight below last fragment
+        if range.location == (textView.string as NSString).length, range.length == 0,
+           (textView.string as NSString).length > 0 {
+            yInTextView = lineRect.maxY + textView.textContainerInset.height
+            lineRect = NSRect(
+                x: 0,
+                y: yInTextView - textView.textContainerInset.height,
+                width: 0,
+                height: lineRect.height
+            )
+        }
+
+        // Gutter's coordinate system is the textView's coordinate system (since gutter is subview of textView at (0,0)).
+        // So yInGutter == yInTextView
+        let gutterYPos = yInTextView
+        let lineHeight = layoutManager.defaultLineHeight(for: baseFont)
+        // Cull offscreen numbers (gutter's visibleRect is clipped by scrollView)
+        let visible = visibleRect
+        if gutterYPos + lineHeight < visible.minY || gutterYPos > visible.maxY + visible.height {
+            // Still draw if within dirtyRect's expansion — keep cheap cull conservative
+            if gutterYPos + lineHeight < bounds.minY || gutterYPos > bounds.maxY {
+                return
+            }
+        }
+
+        // Highlight current line background
+        if isCurrent {
+            NSColor.selectedContentBackgroundColor.withAlphaComponent(0.12).setFill()
+            let bgRect = NSRect(x: 0, y: gutterYPos, width: bounds.width, height: lineHeight)
+            bgRect.fill()
+        }
+
+        let numberString = "\(number)" as NSString
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: isCurrent ? boldFont : baseFont,
+            .foregroundColor: isCurrent ? NSColor.labelColor : NSColor.secondaryLabelColor,
+        ]
+        let size = numberString.size(withAttributes: attrs)
+        // Right-aligned inside gutter, with 6pt right padding before separator
+        let drawX = bounds.width - size.width - 6
+        let drawY = gutterYPos + (lineHeight - size.height) / 2
+        numberString.draw(at: NSPoint(x: drawX, y: drawY), withAttributes: attrs)
+    }
+
+    // Click to select line (nice-to-have)
+    override func mouseDown(with event: NSEvent) {
+        guard let textView,
+              let layoutManager = textView.layoutManager
+        else { super.mouseDown(with: event); return }
+        let location = convert(event.locationInWindow, from: nil)
+        // Find nearest line number by y
+        let text = textView.string as NSString
+        var bestRange: NSRange?
+        var bestYDistance = CGFloat.greatestFiniteMagnitude
+        text.enumerateSubstrings(
+            in: NSRange(location: 0, length: text.length),
+            options: [.byLines, .substringNotRequired]
+        ) { _, range, _, _ in
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: range.location)
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+            let gutterY = lineRect.minY + textView.textContainerInset.height
+            let distance = abs(location.y - (gutterY + lineRect.height / 2))
+            if distance < bestYDistance {
+                bestYDistance = distance
+                bestRange = range
+            }
+        }
+        if let bestRange {
+            // Select the line's character range (without trailing \n)
+            let lineRange = (text as NSString).lineRange(for: bestRange)
+            // Trim trailing newline for selection, but include content
+            let selectLength = NSMaxRange(lineRange) > text.length ? text.length - lineRange.location : lineRange.length
+            // If line ends with \n, exclude it from selection to mimic Xcode
+            var length = selectLength
+            if length > 0, text.character(at: lineRange.location + length - 1) == 10 {
+                length -= 1
+            }
+            let selectRange = NSRange(location: lineRange.location, length: length)
+            textView.setSelectedRange(selectRange)
+            textView.window?.makeFirstResponder(textView)
+        } else {
+            super.mouseDown(with: event)
+        }
+    }
+}

--- a/Sources/Compose/ComposeLineGutter.swift
+++ b/Sources/Compose/ComposeLineGutter.swift
@@ -165,8 +165,9 @@ final class ComposeLineGutter: NSView {
         // lineRect is in textContainer coordinates; offset by inset to get textView coords
         var yInTextView = lineRect.minY + textView.textContainerInset.height
         // For trailing empty line, place it one lineHeight below last fragment
-        if range.location == (textView.string as NSString).length, range.length == 0,
-           (textView.string as NSString).length > 0 {
+        let isTrailingEmpty = range.location == (textView.string as NSString).length
+            && range.length == 0 && (textView.string as NSString).length > 0
+        if isTrailingEmpty {
             yInTextView = lineRect.maxY + textView.textContainerInset.height
             lineRect = NSRect(
                 x: 0,
@@ -208,11 +209,13 @@ final class ComposeLineGutter: NSView {
         numberString.draw(at: NSPoint(x: drawX, y: drawY), withAttributes: attrs)
     }
 
-    // Click to select line (nice-to-have)
+    /// Click to select line (nice-to-have)
     override func mouseDown(with event: NSEvent) {
         guard let textView,
               let layoutManager = textView.layoutManager
-        else { super.mouseDown(with: event); return }
+        else { super.mouseDown(with: event)
+            return
+        }
         let location = convert(event.locationInWindow, from: nil)
         // Find nearest line number by y
         let text = textView.string as NSString

--- a/Sources/Compose/ComposeTextView.swift
+++ b/Sources/Compose/ComposeTextView.swift
@@ -1,9 +1,15 @@
 import AppKit
 import SwiftUI
 
-/// NSTextView host with live heuristic highlighting. The text storage is
-/// re-painted after every edit; the buffer in `ComposeDocument` stays the
-/// single source of truth.
+/// NSTextView host with live heuristic highlighting and native Find bar.
+/// The text storage is re-painted after every edit; the buffer in
+/// `ComposeDocument` stays the single source of truth.
+///
+/// Find & Replace (#225) uses the system find bar (`usesFindBar = true`,
+/// `isIncrementalSearchingEnabled = true`) hosted in the enclosing
+/// `NSScrollView` (which conforms to `NSTextFinderBarContainer`). This gives
+/// ⌘F / ⌘⌥F / ⌘G / ⇧⌘G, wrap-around, case-insensitive and regex toggles for
+/// free — no custom UI.
 struct ComposeTextView: NSViewRepresentable {
     @Bindable var document: ComposeDocument
     /// Click-to-line target (LATER-3.1); nil = no pending jump.
@@ -16,7 +22,15 @@ struct ComposeTextView: NSViewRepresentable {
         Coordinator(document: document, completion: completion)
     }
 
-    func makeNSView(context: Context) -> NSTextView {
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.findBarPosition = .aboveContent
+
         let textView = NSTextView()
         textView.delegate = context.coordinator
         textView.isRichText = false
@@ -28,8 +42,21 @@ struct ComposeTextView: NSViewRepresentable {
         textView.font = baseFont
         textView.textContainerInset = NSSize(width: 10, height: 10)
         textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
         textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: scrollView.contentSize.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        // #225 Find & Replace: system find bar + incremental search.
+        textView.usesFindBar = true
+        textView.usesFindPanel = false
+        textView.isIncrementalSearchingEnabled = true
+
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+        context.coordinator.scrollView = scrollView
 
         context.coordinator.applyHighlight(
             textView,
@@ -37,13 +64,29 @@ struct ComposeTextView: NSViewRepresentable {
             language: document.language,
             force: true
         )
-        return textView
+        return scrollView
     }
 
-    func updateNSView(_ textView: NSTextView, context: Context) {
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
         context.coordinator.document = document
         context.coordinator.completion = completion
+        context.coordinator.textView = textView
+        context.coordinator.scrollView = scrollView
+
+        // Page switch (#225 edge): the buffer was replaced wholesale. Hide the
+        // find bar so it does not survive across pages. The SwiftUI `.id`
+        // recreation in `ComposeEditorView` is the primary reset; this is the
+        // fallback when the view is reused.
         if textView.string != document.text {
+            // Best-effort hide via NSTextFinderBarContainer. NSScrollView
+            // conforms to it in AppKit, even though the header only exposes
+            // `findBarPosition`; the `findBarVisible` selector is available
+            // at runtime.
+            if scrollView.responds(to: Selector(("setFindBarVisible:"))) {
+                // swiftlint:disable:next no_direct_perform_selector
+                scrollView.perform(Selector(("setFindBarVisible:")), with: NSNumber(value: false))
+            }
             textView.string = document.text
             context.coordinator.applyHighlight(textView, text: document.text, language: document.language, force: true)
         } else {
@@ -62,6 +105,8 @@ struct ComposeTextView: NSViewRepresentable {
         /// Cooklang completion vocabulary, updated on view syncs so a
         /// freshly-built `.boris/` index reaches the popup without a reload.
         var completion: ComposeCookCompletion = .empty
+        weak var textView: NSTextView?
+        weak var scrollView: NSScrollView?
         private var isApplying = false
         /// Last click-to-line offset we applied, so re-syncs do not re-jump.
         private var lastJumpedCharacter: Int?

--- a/Sources/Compose/ComposeTextView.swift
+++ b/Sources/Compose/ComposeTextView.swift
@@ -54,6 +54,19 @@ struct ComposeTextView: NSViewRepresentable {
         textView.usesFindPanel = false
         textView.isIncrementalSearchingEnabled = true
 
+        // #226 Line numbers gutter: lightweight overlay as subview of the
+        // textView so it scrolls vertically with the buffer but stays fixed
+        // horizontally (widthTracksTextView disables horizontal scroll).
+        let gutter = ComposeLineGutter()
+        gutter.textView = textView
+        gutter.frame = NSRect(x: 0, y: 0, width: 36, height: textView.bounds.height)
+        gutter.autoresizingMask = [.height]
+        gutter.wantsLayer = true
+        // Reserve 36pt for the gutter + keep 10pt original inset as gap.
+        textView.textContainer?.lineFragmentPadding = 36
+        textView.addSubview(gutter)
+        context.coordinator.gutter = gutter
+
         scrollView.documentView = textView
         context.coordinator.textView = textView
         context.coordinator.scrollView = scrollView
@@ -64,6 +77,9 @@ struct ComposeTextView: NSViewRepresentable {
             language: document.language,
             force: true
         )
+        // Gutter width tracks line count; update after initial paint.
+        context.coordinator.updateGutterWidth()
+        gutter.needsDisplay = true
         return scrollView
     }
 
@@ -73,6 +89,12 @@ struct ComposeTextView: NSViewRepresentable {
         context.coordinator.completion = completion
         context.coordinator.textView = textView
         context.coordinator.scrollView = scrollView
+        // Re-bind gutter if view was recreated (SwiftUI .id)
+        if let gutter = context.coordinator.gutter, gutter.superview !== textView {
+            gutter.textView = textView
+            gutter.frame = NSRect(x: 0, y: 0, width: gutter.frame.width, height: textView.bounds.height)
+            textView.addSubview(gutter)
+        }
 
         // Page switch (#225 edge): the buffer was replaced wholesale. Hide the
         // find bar so it does not survive across pages. The SwiftUI `.id`
@@ -93,6 +115,14 @@ struct ComposeTextView: NSViewRepresentable {
             context.coordinator.applyHighlight(textView, text: document.text, language: document.language)
         }
         context.coordinator.jump(to: jumpToCharacter, in: textView)
+        context.coordinator.updateGutterWidth()
+        // Keep gutter height in sync with textView content height
+        if let gutter = context.coordinator.gutter {
+            var f = gutter.frame
+            f.size.height = max(textView.bounds.height, scrollView.contentSize.height)
+            gutter.frame = f
+            gutter.needsDisplay = true
+        }
     }
 
     private var baseFont: NSFont {
@@ -107,6 +137,7 @@ struct ComposeTextView: NSViewRepresentable {
         var completion: ComposeCookCompletion = .empty
         weak var textView: NSTextView?
         weak var scrollView: NSScrollView?
+        weak var gutter: ComposeLineGutter?
         private var isApplying = false
         /// Last click-to-line offset we applied, so re-syncs do not re-jump.
         private var lastJumpedCharacter: Int?
@@ -134,6 +165,33 @@ struct ComposeTextView: NSViewRepresentable {
             document.text = newText
             repaintChanged(oldText: oldText, newText: newText, textView: textView, language: document.language)
             maybeOpenCompletion(in: textView, previousText: oldText)
+            updateGutterWidth()
+            gutter?.needsDisplay = true
+            // Keep gutter height in sync with textView's content height
+            if let gutter {
+                var f = gutter.frame
+                f.size.height = max(textView.bounds.height, scrollView?.contentSize.height ?? 0)
+                gutter.frame = f
+            }
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            gutter?.needsDisplay = true
+        }
+
+        /// Update gutter width and text container padding when line count grows
+        /// beyond 4 digits. Minimum 36pt.
+        func updateGutterWidth() {
+            guard let gutter, let textView else { return }
+            let newWidth = gutter.gutterWidth
+            if abs(gutter.frame.width - newWidth) > 0.5 {
+                var f = gutter.frame
+                f.size.width = newWidth
+                gutter.frame = f
+                textView.textContainer?.lineFragmentPadding = newWidth
+                textView.needsLayout = true
+                gutter.needsDisplay = true
+            }
         }
 
         /// LATER-3.4: when the author types a Cooklang token marker (`@`,

--- a/Sources/Compose/ComposeTextView.swift
+++ b/Sources/Compose/ComposeTextView.swift
@@ -106,7 +106,6 @@ struct ComposeTextView: NSViewRepresentable {
             // `findBarPosition`; the `findBarVisible` selector is available
             // at runtime.
             if scrollView.responds(to: Selector(("setFindBarVisible:"))) {
-                // swiftlint:disable:next no_direct_perform_selector
                 scrollView.perform(Selector(("setFindBarVisible:")), with: NSNumber(value: false))
             }
             textView.string = document.text
@@ -118,9 +117,9 @@ struct ComposeTextView: NSViewRepresentable {
         context.coordinator.updateGutterWidth()
         // Keep gutter height in sync with textView content height
         if let gutter = context.coordinator.gutter {
-            var f = gutter.frame
-            f.size.height = max(textView.bounds.height, scrollView.contentSize.height)
-            gutter.frame = f
+            var gutterFrame = gutter.frame
+            gutterFrame.size.height = max(textView.bounds.height, scrollView.contentSize.height)
+            gutter.frame = gutterFrame
             gutter.needsDisplay = true
         }
     }
@@ -169,9 +168,9 @@ struct ComposeTextView: NSViewRepresentable {
             gutter?.needsDisplay = true
             // Keep gutter height in sync with textView's content height
             if let gutter {
-                var f = gutter.frame
-                f.size.height = max(textView.bounds.height, scrollView?.contentSize.height ?? 0)
-                gutter.frame = f
+                var gutterFrame = gutter.frame
+                gutterFrame.size.height = max(textView.bounds.height, scrollView?.contentSize.height ?? 0)
+                gutter.frame = gutterFrame
             }
         }
 
@@ -185,9 +184,9 @@ struct ComposeTextView: NSViewRepresentable {
             guard let gutter, let textView else { return }
             let newWidth = gutter.gutterWidth
             if abs(gutter.frame.width - newWidth) > 0.5 {
-                var f = gutter.frame
-                f.size.width = newWidth
-                gutter.frame = f
+                var gutterFrame = gutter.frame
+                gutterFrame.size.width = newWidth
+                gutter.frame = gutterFrame
                 textView.textContainer?.lineFragmentPadding = newWidth
                 textView.needsLayout = true
                 gutter.needsDisplay = true

--- a/Tests/ContractTests/ComposeFindBarTests.swift
+++ b/Tests/ContractTests/ComposeFindBarTests.swift
@@ -1,0 +1,49 @@
+import AppKit
+import XCTest
+
+/// #225 Find & Replace: the native find bar contract.
+/// The editor must expose the system find bar (⌘F / ⌘⌥F / ⌘G) with
+/// incremental search, hosted in the enclosing NSScrollView.
+@MainActor
+final class ComposeFindBarTests: XCTestCase {
+    func testFindBarUsesBarNotPanel() {
+        let textView = NSTextView()
+        textView.usesFindBar = true
+        textView.usesFindPanel = false
+        textView.isIncrementalSearchingEnabled = true
+        XCTAssertTrue(textView.usesFindBar, "⌘F must show the find bar")
+        XCTAssertFalse(textView.usesFindPanel, "find panel must be off")
+        XCTAssertTrue(textView.isIncrementalSearchingEnabled, "incremental search must be enabled")
+    }
+
+    func testFindBarConfigurationMatchesComposeTextView() {
+        // Replicate what ComposeTextView.makeNSView does, and verify the
+        // scrollView is a valid findBarContainer.
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.borderType = .noBorder
+        let textView = NSTextView()
+        textView.usesFindBar = true
+        textView.usesFindPanel = false
+        textView.isIncrementalSearchingEnabled = true
+        scrollView.documentView = textView
+        guard let documentView = scrollView.documentView as? NSTextView else {
+            return XCTFail("scrollView must host an NSTextView")
+        }
+        XCTAssertTrue(documentView.usesFindBar)
+        XCTAssertTrue(documentView.isIncrementalSearchingEnabled)
+        // NSScrollView conforms to NSTextFinderBarContainer at runtime even
+        // though the header only exposes findBarPosition.
+        XCTAssertTrue(scrollView.responds(to: Selector(("findBarView"))))
+    }
+
+    func testFindBarMustBeScopedToBuffer() {
+        // The find bar is scoped to the NSTextView's string, not the preview.
+        // A trivial sanity: searching does not cross into a separate view.
+        let textView = NSTextView()
+        textView.string = "hello hello world"
+        textView.usesFindBar = true
+        XCTAssertEqual(textView.string, "hello hello world")
+        XCTAssertTrue(textView.string.contains("hello"))
+    }
+}

--- a/Tests/ContractTests/ComposeGutterTests.swift
+++ b/Tests/ContractTests/ComposeGutterTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import XCTest
+
+/// #226 Line numbers gutter contract.
+@MainActor
+final class ComposeGutterTests: XCTestCase {
+    func testEmptyBufferShowsOneLine() {
+        let gutter = ComposeLineGutter()
+        let textView = NSTextView()
+        textView.string = ""
+        gutter.textView = textView
+        // Empty buffer line count is 1, digits = 3 => width 36 min
+        XCTAssertEqual(gutter.gutterWidth, 36, "empty buffer must show line 1 with min width")
+    }
+
+    func testGutterWidthGrowsWithDigits() {
+        let gutter = ComposeLineGutter()
+        let textView = NSTextView()
+        // 1 line => 36
+        textView.string = "one line"
+        gutter.textView = textView
+        XCTAssertEqual(gutter.gutterWidth, 36)
+        // 999 lines => 3 digits => 36
+        textView.string = String(repeating: "a\n", count: 998) + "a"
+        XCTAssertEqual(gutter.gutterWidth, 36)
+        // 10000 lines => 5 digits => wider than 36
+        textView.string = String(repeating: "a\n", count: 9999) + "a"
+        XCTAssertGreaterThan(gutter.gutterWidth, 36, "5-digit line numbers need wider gutter")
+    }
+
+    func testGutterIsSubviewOfTextView() {
+        // Directly verify the contract: gutter lives as subview of NSTextView
+        // and reserves lineFragmentPadding. We replicate what ComposeTextView does.
+        let textView = NSTextView()
+        textView.string = "first\nsecond\nthird"
+        let gutter = ComposeLineGutter()
+        gutter.textView = textView
+        gutter.frame = NSRect(x: 0, y: 0, width: 36, height: textView.bounds.height)
+        textView.addSubview(gutter)
+        textView.textContainer?.lineFragmentPadding = gutter.gutterWidth
+        XCTAssertTrue(textView.subviews.contains(where: { $0 is ComposeLineGutter }))
+        XCTAssertEqual(gutter.textView, textView)
+        XCTAssertEqual(textView.textContainer?.lineFragmentPadding, gutter.gutterWidth)
+    }
+
+    func testGutterHighlightsCurrentLine() {
+        let textView = NSTextView()
+        textView.string = "one\ntwo\nthree"
+        // Place cursor on line 2 (after first \n)
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+        XCTAssertEqual(textView.selectedRange().location, 4)
+        let gutter = ComposeLineGutter()
+        gutter.textView = textView
+        // Verify gutter can be asked to display without crashing
+        gutter.displayIfNeeded()
+        // Move to line 3 and ensure selection updated
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        XCTAssertEqual(textView.selectedRange().location, 8)
+        XCTAssertNotNil(gutter.textView)
+        // Coordinator would mark gutter dirty on selection change
+        gutter.setNeedsDisplay(gutter.bounds)
+        XCTAssertNotNil(gutter.textView)
+    }
+
+    func testSyncAfterTextChange() {
+        let textView = NSTextView()
+        textView.string = "a\nb"
+        let gutter = ComposeLineGutter()
+        gutter.textView = textView
+        gutter.frame = NSRect(x: 0, y: 0, width: 36, height: textView.bounds.height)
+        textView.addSubview(gutter)
+        textView.textContainer?.lineFragmentPadding = gutter.gutterWidth
+        let initialWidth = gutter.gutterWidth
+        // Insert many lines to force width growth
+        textView.string = String(repeating: "x\n", count: 10000) + "end"
+        // Recompute width via new string
+        let newWidth = gutter.gutterWidth
+        XCTAssertGreaterThan(newWidth, initialWidth)
+        // Simulate coordinator update
+        textView.textContainer?.lineFragmentPadding = newWidth
+        XCTAssertEqual(textView.textContainer?.lineFragmentPadding, newWidth)
+    }
+}


### PR DESCRIPTION
Stack: #225 Find & Replace (⌘F/⌘G/⌘⌥F) + #226 Line numbers gutter.

**#225** `Sources/Compose/ComposeTextView.swift:53` — host in `NSScrollView` with `usesFindBar` + incremental search, wrap-around/case/regex via `NSTextFinder`, page-switch hides bar (`.id(document.fileURL)` + fallback `setFindBarVisible:`). Tests `ComposeFindBarTests` (3).

**#226** `Sources/Compose/ComposeLineGutter.swift:11` — lightweight `NSView` subview of `NSTextView` (vertical scroll, fixed horizontal), 13pt `ui-monospace` `secondaryLabelColor`, current line bold+tint+separator, min 36pt (grows for 5+ digits), live on `textDidChange`/`selection`, click-to-select, trailing-\n + empty + CRLF handled. `ComposeTextView.swift:59` reserves `lineFragmentPadding`. Tests `ComposeGutterTests` (5).

Milestone: https://github.com/drawmeanelephant/solipsist/milestone/10 (M18 Editor Polish, 31%)
Build: `SKIP_EMBED_BORIS=1 make build` ok, `make test` 391/391.

Branch clean on top of `origin/main` (4aa6289). Original work branch `m18-225-find-bar` retains full history.
Closes #225, closes #226