### PR TITLE
compose: preview renders through sandboxed WKWebView (#230)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -125,6 +125,9 @@ targets:
       - path: Sources/Compose/MarkupRenderService.swift
       - path: Sources/Compose/ComposePageResolver.swift
       - path: Sources/Compose/OliverRenderService.swift
+      - path: Sources/Compose/ComposePreviewDocument.swift
+      - path: Sources/Compose/ComposeThemeCSS.swift
+      - path: Sources/Compose/ComposeWebPreviewHost.swift
       - path: Sources/Compose/ComposeLineGutter.swift
       - path: Sources/Compose/ComposeTabIndent.swift
       - path: Sources/Compose/ComposeTextView.swift

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -14,6 +14,9 @@ struct ComposeEditorView: View {
     @Bindable var document: ComposeDocument
 
     var renderService: any MarkupRenderService = PlaceholderRenderService()
+    /// Theme CSS for the preview pane (#230): the canonical target's theme
+    /// from the source profile, resolved by the host. Nil → fallback style.
+    var themeCSS: String?
     /// Cooklang completion vocabulary (LATER-3.4); `.empty` (default) keeps
     /// the popup off for hosts without a `.boris/` index.
     var cookCompletion: ComposeCookCompletion = .empty
@@ -69,6 +72,7 @@ struct ComposeEditorView: View {
                         language: document.language,
                         options: previewOptions,
                         renderService: renderService,
+                        themeCSS: themeCSS,
                         onDiagnostics: { diagnostics = $0 }
                     )
                     .frame(minWidth: 240, maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Compose/ComposePreview.swift
+++ b/Sources/Compose/ComposePreview.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WebKit
 
 /// The compose element's preview pane. Renders through the injected
 /// `MarkupRenderService` (Oliver-backed in the app; placeholder standalone),
@@ -8,6 +9,10 @@ struct ComposePreviewView: View {
     let language: ComposeLanguage
     let options: MarkupRenderOptions
     let renderService: any MarkupRenderService
+    /// Theme CSS resolved from the source's profile / `themes/` directory
+    /// (#230). Nil → the fallback stylesheet. The host resolves it; this
+    /// view never touches the workspace.
+    var themeCSS: String?
     /// Receives the mapped diagnostics after each render (LATER-3.1). The
     /// editor owns the problems pane; the preview only renders HTML.
     var onDiagnostics: ([ComposeDiagnostic]) -> Void = { _ in }
@@ -38,7 +43,9 @@ struct ComposePreviewView: View {
                 guard !Task.isCancelled else { return }
                 let rendered = try await renderService.render(source, language: language, options: options)
                 guard !Task.isCancelled else { return }
-                html = rendered.html
+                // Wrap the fragment with the theme CSS here so the web view
+                // receives one self-contained document (#230).
+                html = ComposePreviewDocument.html(fragment: rendered.html, themeCSS: themeCSS)
                 renderError = nil
                 onDiagnostics(rendered.diagnostics)
             } catch is CancellationError {
@@ -60,38 +67,30 @@ private struct PreviewRequest: Equatable {
     let source: String
 }
 
-/// Hosts the rendered fragment. `WKWebView`-free on purpose: the compose
-/// preview is a sandboxed HTML fragment view, not a browser surface.
+/// Hosts the rendered document in a sandboxed `WKWebView` (#230): full CSS,
+/// JavaScript, and media support without an in-process HTML parse. The web
+/// view uses a non-persistent data store (no disk cache) and loads the
+/// self-contained document with `baseURL: nil` — styling needs no file or
+/// network access, and there is no app-side HTTP server (D11). Navigation
+/// policy lives in `ComposePreviewCoordinator`.
 private struct ComposeHTMLPreview: NSViewRepresentable {
     let html: String
 
-    func makeNSView(context: Context) -> NSTextView {
-        let textView = NSTextView()
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.drawsBackground = true
-        textView.backgroundColor = .textBackgroundColor
-        textView.textContainerInset = NSSize(width: 12, height: 12)
-        apply(html, to: textView)
-        return textView
+    func makeCoordinator() -> ComposePreviewCoordinator {
+        ComposePreviewCoordinator()
     }
 
-    func updateNSView(_ textView: NSTextView, context: Context) {
-        apply(html, to: textView)
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        configuration.suppressesIncrementalRendering = true
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        context.coordinator.load(html, in: webView)
+        return webView
     }
 
-    private func apply(_ html: String, to textView: NSTextView) {
-        guard
-            let data = html.data(using: .utf8),
-            let attributed = try? NSAttributedString(
-                data: data,
-                options: [.documentType: NSAttributedString.DocumentType.html],
-                documentAttributes: nil
-            )
-        else {
-            textView.string = html
-            return
-        }
-        textView.textStorage?.setAttributedString(attributed)
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        context.coordinator.reloadIfChanged(html, in: webView)
     }
 }

--- a/Sources/Compose/ComposePreviewDocument.swift
+++ b/Sources/Compose/ComposePreviewDocument.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Assembles the self-contained HTML document the compose preview loads.
+///
+/// The fragment (Oliver's render output) is wrapped with the theme CSS
+/// inlined as a `<style>` element, so styling needs no file or network
+/// access (#230): `loadHTMLString(_:baseURL: nil)` cannot resolve relative
+/// resources from the sandboxed web content process, and the app never
+/// serves HTTP. Relative image/media URLs in the content are therefore out
+/// of scope here — resolving them is the full-site Preview companion's job.
+///
+/// Pure and unit-testable; the WKWebView host only consumes the result.
+enum ComposePreviewDocument {
+    /// Loopback origin reported to tests / policy checks. `loadHTMLString`
+    /// with a nil baseURL surfaces as `about:blank` in the web view.
+    static let aboutBlank = "about:blank"
+
+    /// Minimal readable stylesheet used when no theme CSS resolves.
+    /// Honors the system appearance (`color-scheme` + adaptive `canvas`
+    /// colors) so dark mode stays legible without a theme dark variant.
+    /// Theme CSS is applied verbatim when present — we never rewrite it.
+    static let fallbackCSS = """
+    :root { color-scheme: light dark; }
+    body {
+      margin: 0 auto;
+      max-width: 64rem;
+      padding: 1rem 1.5rem 3rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      line-height: 1.6;
+      color: canvastext;
+      background: canvas;
+    }
+    pre { overflow-x: auto; }
+    code, pre { font-family: ui-monospace, monospace; font-size: 0.95em; }
+    """
+
+    /// Builds the full document for the preview pane.
+    static func html(fragment: String, themeCSS: String?) -> String {
+        let css = themeCSS.flatMap { $0.isEmpty ? nil : sanitize($0) } ?? fallbackCSS
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <meta name="color-scheme" content="light dark">
+        <style>
+        \(css)
+        </style>
+        </head>
+        <body>
+        \(fragment)
+        </body>
+        </html>
+        """
+    }
+
+    /// Neutralizes any `</style…>` inside the injected CSS so a broken or
+    /// hostile stylesheet cannot escape the style element into markup.
+    /// `<\/` is a valid CSS escape inside strings/identifiers and corrupts
+    /// nothing a stylesheet could legitimately contain.
+    static func sanitize(_ css: String) -> String {
+        css.replacingOccurrences(
+            of: "</",
+            with: "<\\/",
+            options: .caseInsensitive,
+            range: css.startIndex..<css.endIndex
+        )
+    }
+}

--- a/Sources/Compose/ComposeThemeCSS.swift
+++ b/Sources/Compose/ComposeThemeCSS.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Resolves the theme stylesheet the compose preview applies (#230): the
+/// canonical HTML target's theme from the publication profile, read from
+/// the workspace's `themes/` directory. The CSS is collected verbatim —
+/// Boris owns theme semantics; we never rewrite it. When nothing resolves
+/// the preview falls back to `ComposePreviewDocument.fallbackCSS`.
+enum ComposeThemeCSS {
+    /// The theme path whose CSS styles the preview: the first public
+    /// target with a non-empty `theme`, else the first target with one.
+    /// Mirrors the Preview companion's "first canonical target" rule.
+    static func preferredThemePath(in targets: [PublicationTarget]?) -> String? {
+        guard let targets, !targets.isEmpty else { return nil }
+        var firstTheme: String?
+        for target in targets {
+            guard let theme = target.theme, !theme.isEmpty else { continue }
+            if target.public == true { return theme }
+            if firstTheme == nil { firstTheme = theme }
+        }
+        return firstTheme
+    }
+
+    /// Concatenated `.css` content under `<workspaceRoot>/<themePath>`
+    /// (recursive, path-sorted so the order is deterministic), or nil when
+    /// the directory is missing / unreadable / has no stylesheets.
+    static func collect(workspaceRoot: URL, themePath: String) -> String? {
+        let themeDir = workspaceRoot.appendingPathComponent(themePath, isDirectory: true)
+        let files = cssFiles(in: themeDir)
+        guard !files.isEmpty else { return nil }
+        let chunks = files.compactMap { url -> String? in
+            guard let css = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+            return css
+        }
+        guard !chunks.isEmpty else { return nil }
+        return chunks.joined(separator: "\n\n")
+    }
+
+    /// Convenience over the profile: preferred theme + collection.
+    static func collect(workspaceRoot: URL, targets: [PublicationTarget]?) -> String? {
+        guard let themePath = preferredThemePath(in: targets) else { return nil }
+        return collect(workspaceRoot: workspaceRoot, themePath: themePath)
+    }
+
+    private static func cssFiles(in directory: URL) -> [URL] {
+        let fileManager = FileManager.default
+        let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )
+        return (enumerator?.allObjects as? [URL])?
+            .filter { $0.pathExtension.lowercased() == "css" }
+            .sorted { $0.path < $1.path } ?? []
+    }
+}

--- a/Sources/Compose/ComposeWebPreviewHost.swift
+++ b/Sources/Compose/ComposeWebPreviewHost.swift
@@ -1,0 +1,80 @@
+import Foundation
+import WebKit
+
+/// Navigation policy for the compose preview web view (#230): exactly one
+/// main-frame navigation is allowed — the load the host initiated. Every
+/// other request (link clicks, sub-frames, programmatic navigation,
+/// back/forward) is cancelled. Pure so the contract is testable without
+/// driving WebKit.
+enum ComposePreviewSandbox {
+    static func allows(initialLoadPending: Bool, isMainFrame: Bool) -> Bool {
+        initialLoadPending && isMainFrame
+    }
+}
+
+/// Owns the load lifecycle for one preview web view: dedupes reloads,
+/// arms the single allowed navigation per load, and enforces the sandbox.
+/// Main-actor confined; the SwiftUI representable is the only client.
+@MainActor
+final class ComposePreviewCoordinator: NSObject {
+    private var lastLoaded: String?
+    private var initialLoadPending = false
+
+    /// Loads the document unless it is already what the view shows (a
+    /// SwiftUI pass re-runs `updateNSView` constantly; reloading would
+    /// flicker and reset scroll on every keystroke).
+    func reloadIfChanged(_ html: String, in webView: WKWebView) {
+        guard html != lastLoaded else { return }
+        load(html, in: webView)
+    }
+
+    func load(_ html: String, in webView: WKWebView) {
+        lastLoaded = html
+        initialLoadPending = true
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+}
+
+extension ComposePreviewCoordinator: WKNavigationDelegate {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        let isMainFrame = navigationAction.targetFrame?.isMainFrame == true
+        let allow = ComposePreviewSandbox.allows(
+            initialLoadPending: initialLoadPending,
+            isMainFrame: isMainFrame
+        )
+        // Consume the grant even if the delegate is skipped for the
+        // initial load — didFinish/didFail close it below as well.
+        if isMainFrame { initialLoadPending = false }
+        decisionHandler(allow ? .allow : .cancel)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        initialLoadPending = false
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        initialLoadPending = false
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        initialLoadPending = false
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        // Target=_blank / window.open never leaves the pane.
+        nil
+    }
+}

--- a/Sources/Compose/ComposeWindow.swift
+++ b/Sources/Compose/ComposeWindow.swift
@@ -27,6 +27,10 @@ struct ComposeWindow: View {
     /// source's `.boris/` artifacts whenever a page is loaded, so a fresh
     /// build reaches the popup without restarting the window.
     @State private var cookCompletion = ComposeCookCompletion.empty
+    /// Preview theme CSS (#230): the canonical HTML target's stylesheet,
+    /// read from the source's `themes/` directory. Resolved per page switch;
+    /// nil → the preview's fallback stylesheet.
+    @State private var themeCSS: String?
 
     var body: some View {
         Group {
@@ -34,6 +38,7 @@ struct ComposeWindow: View {
                 ComposeEditorView(
                     document: document,
                     renderService: OliverRenderService(),
+                    themeCSS: themeCSS,
                     cookCompletion: cookCompletion,
                     onSave: save,
                     externalJump: externalJump
@@ -124,6 +129,7 @@ struct ComposeWindow: View {
             let url = ComposePageResolver.fileURL(contentRoot: contentRoot, sourcePath: node.sourcePath)
             try document.load(from: url)
             cookCompletion = ComposeCookCompletion.load(workspaceRoot: workspaceRoot)
+            themeCSS = resolveThemeCSS(workspaceRoot: workspaceRoot)
             loadError = nil
             saveStatus = nil
             if let jump = runtime.pendingComposeJump, jump.pageID == noun.id {
@@ -152,6 +158,21 @@ struct ComposeWindow: View {
             current += 1
         }
         return found.map { min(max($0, 0), textNSString.length) }
+    }
+
+    /// Theme CSS for the preview (#230): decode the source profile, pick the
+    /// canonical target's theme, collect its stylesheets from `themes/`.
+    /// Anything missing (no profile, no target theme, unreadable folder)
+    /// degrades to nil — the preview falls back to its readable stylesheet.
+    private func resolveThemeCSS(workspaceRoot: URL) -> String? {
+        guard let profileURL = selectedLocalSource?.profileURL() else { return nil }
+        do {
+            let data = try Data(contentsOf: profileURL)
+            let profile = try JSONDecoder().decode(PublicationProfile.self, from: data)
+            return ComposeThemeCSS.collect(workspaceRoot: workspaceRoot, targets: profile.targets)
+        } catch {
+            return nil
+        }
     }
 
     // MARK: - Save → coordinator gate

--- a/Tests/ContractTests/ComposeWebViewPreviewTests.swift
+++ b/Tests/ContractTests/ComposeWebViewPreviewTests.swift
@@ -1,0 +1,181 @@
+import WebKit
+import XCTest
+
+/// #230 — the compose preview renders through a sandboxed WKWebView with
+/// the theme CSS inlined. The document assembly, theme resolution, and
+/// navigation policy are pure and pinned here; one integration test drives
+/// a real web view to prove the sandbox cancels link navigation.
+final class ComposeWebViewPreviewTests: XCTestCase {
+    // MARK: - Document assembly (testPreviewFragmentWrapsHTML)
+
+    func testPreviewFragmentWrapsHTML() {
+        let html = ComposePreviewDocument.html(
+            fragment: "<p>hello <strong>world</strong></p>",
+            themeCSS: "body { color: red; }"
+        )
+        XCTAssertTrue(html.hasPrefix("<!DOCTYPE html>"))
+        XCTAssertTrue(html.contains("<style>"))
+        XCTAssertTrue(html.contains("body { color: red; }"))
+        XCTAssertTrue(html.contains("<body>\n<p>hello <strong>world</strong></p>\n</body>"))
+    }
+
+    func testPreviewThemeCSSFallback() {
+        let withoutTheme = ComposePreviewDocument.html(fragment: "<p>x</p>", themeCSS: nil)
+        let emptyTheme = ComposePreviewDocument.html(fragment: "<p>x</p>", themeCSS: "")
+        for html in [withoutTheme, emptyTheme] {
+            XCTAssertTrue(html.contains(ComposePreviewDocument.fallbackCSS))
+            XCTAssertFalse(html.contains("<style>\n\n</style>"))
+        }
+        // A real theme replaces the fallback entirely.
+        let themed = ComposePreviewDocument.html(fragment: "<p>x</p>", themeCSS: "p { margin: 0; }")
+        XCTAssertFalse(themed.contains(ComposePreviewDocument.fallbackCSS))
+        XCTAssertTrue(themed.contains("p { margin: 0; }"))
+    }
+
+    /// Dark mode (nice-to-have): the document declares its color scheme so
+    /// WebKit follows the system appearance, and the fallback stylesheet
+    /// uses appearance-adaptive colors. Theme CSS is never rewritten.
+    func testFallbackStyleSheetHonorsDarkMode() {
+        let html = ComposePreviewDocument.html(fragment: "<p>x</p>", themeCSS: nil)
+        XCTAssertTrue(html.contains(#"<meta name="color-scheme" content="light dark">"#))
+        XCTAssertTrue(ComposePreviewDocument.fallbackCSS.contains("color-scheme: light dark"))
+        XCTAssertTrue(ComposePreviewDocument.fallbackCSS.contains("canvastext"))
+        XCTAssertTrue(ComposePreviewDocument.fallbackCSS.contains("canvas;"))
+    }
+
+    func testStyleCloseGuardCannotEscape() {
+        let hostile = "a::after { content: \"</style><script>alert(1)</script>\"; }"
+        let html = ComposePreviewDocument.html(fragment: "<p>x</p>", themeCSS: hostile)
+        XCTAssertFalse(html.contains("</style><script>alert(1)</script>"))
+        XCTAssertTrue(html.contains("<script>alert(1)</script>".replacingOccurrences(of: "</", with: "<\\/")))
+    }
+
+    // MARK: - Theme resolution
+
+    func testPreferredThemeTargetSelection() {
+        func target(_ name: String, theme: String?, isPublic: Bool? = nil) -> PublicationTarget {
+            PublicationTarget(name: name, output: "dist/\(name)", public: isPublic, theme: theme)
+        }
+
+        // No targets / no themes → nothing.
+        XCTAssertNil(ComposeThemeCSS.preferredThemePath(in: nil))
+        XCTAssertNil(ComposeThemeCSS.preferredThemePath(in: []))
+        XCTAssertNil(ComposeThemeCSS.preferredThemePath(in: [target("a", theme: nil)]))
+
+        // First public target with a theme wins over earlier private ones.
+        let publicWins = ComposeThemeCSS.preferredThemePath(in: [
+            target("private", theme: "themes/one"),
+            target("public", theme: "themes/two", isPublic: true),
+        ])
+        XCTAssertEqual(publicWins, "themes/two")
+
+        // Without a public flag, the first themed target wins.
+        XCTAssertEqual(
+            ComposeThemeCSS.preferredThemePath(in: [
+                target("first", theme: "themes/first"),
+                target("second", theme: "themes/second"),
+            ]),
+            "themes/first"
+        )
+    }
+
+    func testThemeCSSCollectedFromWorkspaceThemes() throws {
+        let root = try temporaryWorkspace()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let css = try XCTUnwrap(
+            ComposeThemeCSS.collect(workspaceRoot: root, targets: [
+                PublicationTarget(name: "public", output: "dist", public: true, theme: "themes/boris"),
+            ])
+        )
+        XCTAssertTrue(css.contains("/* base */"))
+        XCTAssertTrue(css.contains("/* print */"))
+        // Deterministic order: path-sorted (assets before print.css).
+        let baseRange = try XCTUnwrap(css.range(of: "/* base */"))
+        let printRange = try XCTUnwrap(css.range(of: "/* print */"))
+        XCTAssertLessThan(baseRange.lowerBound, printRange.lowerBound)
+    }
+
+    func testThemeCSSMissingDirectoryFallsBackToNil() {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("compose-theme-missing-\(UUID().uuidString)")
+        XCTAssertNil(
+            ComposeThemeCSS.collect(workspaceRoot: root, targets: [
+                PublicationTarget(name: "t", output: "dist", theme: "themes/nope"),
+            ])
+        )
+        // And no theme at all.
+        XCTAssertNil(ComposeThemeCSS.collect(workspaceRoot: root, targets: nil))
+    }
+
+    // MARK: - Sandbox policy
+
+    func testSandboxAllowsOnlyInitialMainFrameLoad() {
+        XCTAssertTrue(ComposePreviewSandbox.allows(initialLoadPending: true, isMainFrame: true))
+        // Everything after the initial load is cancelled…
+        XCTAssertFalse(ComposePreviewSandbox.allows(initialLoadPending: false, isMainFrame: true))
+        // …and sub-frames are never allowed, even on the first pass.
+        XCTAssertFalse(ComposePreviewSandbox.allows(initialLoadPending: true, isMainFrame: false))
+        XCTAssertFalse(ComposePreviewSandbox.allows(initialLoadPending: false, isMainFrame: false))
+    }
+
+    // MARK: - Integration: a real web view honors the policy
+
+    @MainActor
+    func testWebViewRendersFragmentAndBlocksLinkNavigation() async throws {
+        let document = ComposePreviewDocument.html(
+            fragment: "<p id=\"p\">Hello preview <a id=\"l\" href=\"https://example.invalid/escape\">link</a></p>",
+            themeCSS: "#p { color: navy; }"
+        )
+
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 400, height: 300), configuration: configuration)
+        let coordinator = ComposePreviewCoordinator()
+        webView.navigationDelegate = coordinator
+        coordinator.load(document, in: webView)
+
+        // Rendered: the fragment's text made it into the live DOM.
+        try await waitUntil("fragment to render") {
+            let text = try await webView.evaluateJavaScript("document.body.innerText") as? String
+            return text?.contains("Hello preview") == true
+        }
+
+        // Click the link: the sandbox must cancel the main-frame navigation,
+        // so the location never leaves the about: origin of loadHTMLString.
+        _ = try await webView.evaluateJavaScript("document.getElementById('l').click()")
+        try await Task.sleep(for: .milliseconds(400))
+        let rawLocation = try await webView.evaluateJavaScript("window.location.href")
+        let location = try XCTUnwrap(rawLocation as? String)
+        XCTAssertTrue(location.hasPrefix("about:"), "navigation escaped the pane: \(location)")
+    }
+
+    // MARK: - Helpers
+
+    /// `<root>/themes/boris/assets/css/base.css` + `<root>/themes/boris/print.css`.
+    private func temporaryWorkspace() throws -> URL {
+        let fileManager = FileManager.default
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("compose-theme-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        let assets = root.appendingPathComponent("themes/boris/assets/css", isDirectory: true)
+        try fileManager.createDirectory(at: assets, withIntermediateDirectories: true)
+        try "/* base */".write(to: assets.appendingPathComponent("base.css"), atomically: true, encoding: .utf8)
+        try "/* print */".write(to: root.appendingPathComponent("themes/boris/print.css"), atomically: true, encoding: .utf8)
+        return root
+    }
+
+    @MainActor
+    private func waitUntil(
+        _ description: String,
+        timeout seconds: TimeInterval = 5,
+        _ condition: () async throws -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if try await condition() { return }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        XCTFail("Timed out waiting for \(description)")
+    }
+}


### PR DESCRIPTION
Closes #230. Card: docs/issues/editor-compose-preview-webview.md.

## What changed

The Compose preview pane (`ComposePreviewView` → `ComposeHTMLPreview`) rendered through
`NSAttributedString(data:options:.documentType:html)` on an `NSTextView`: no CSS, no JS, no
media, synchronous main-thread HTML parse. It now hosts a **sandboxed `WKWebView`**.

| Piece | File | Notes |
|---|---|---|
| Document assembly | `Sources/Compose/ComposePreviewDocument.swift` (new) | Wraps Oliver's fragment with the theme CSS inlined as a `<style>` element + `color-scheme` meta. Pure, unit-tested. Neutralizes `</style>` inside injected CSS so a stylesheet cannot escape into markup. |
| Theme CSS | `Sources/Compose/ComposeThemeCSS.swift` (new) | Picks the canonical target's theme from the profile — first public target with a non-empty `theme`, else the first themed target (the Preview companion's rule) — and collects its `.css` files verbatim from `<workspaceRoot>/<theme>/`, path-sorted. Boris owns theme semantics; nothing is rewritten. Nothing resolves → nil. |
| Web view host | `Sources/Compose/ComposeWebPreviewHost.swift` (new) | `ComposePreviewCoordinator` owns load lifecycle; `ComposePreviewSandbox` is the pure policy: exactly one main-frame navigation allowed (the host-initiated one), everything else cancelled — link clicks, sub-frames, programmatic nav, back/forward, `window.open`. |
| SwiftUI layer | `Sources/Compose/ComposePreview.swift` | Same debounced render pipeline (300ms preserved); the representable is now a `WKWebView` with a non-persistent `WKWebsiteDataStore`, loaded via `loadHTMLString(_:baseURL: nil)`. Reload deduped so SwiftUI passes don't flicker/reset scroll per keystroke. |
| Wiring | `ComposeWindow.swift`, `ComposeEditorView.swift` | Window resolves theme CSS per page switch from the source profile; nil degrades to the fallback stylesheet. |

## Design notes

- **No loopback baseURL** (card's resolution of the #230 contradiction): the document is
  self-contained, so styling needs no file or network access and there is no app-side HTTP
  server (D11). Relative media in content stays out of scope here — that's the full-site
  Preview companion's job.
- **Dark mode** (nice-to-have): the document declares `color-scheme` and the fallback uses
  adaptive `canvas`/`canvastext` colors. Theme CSS is never rewritten to fake a dark variant.
- **Scroll-to-top**: dropped per the card (jarring mid-file). A full reload only happens when
  the fragment actually changed.
- Must-not list honored: no shared session with the Preview companion, no app-side server, no
  third-party renderer.

## Tests (`ComposeWebViewPreviewTests`, 9)

Fragment wrap + inlined theme `<style>` · fallback without theme · dark-mode declarations ·
style-close guard · public-target theme pick · path-sorted collection from a temp workspace ·
missing-theme → nil · sandbox policy table · **live WKWebView integration**: renders the
fragment into the DOM and a clicked link stays on the `about:` origin.

## Verification

- `SKIP_EMBED_BORIS=1 make build` ✅
- `make test` 417 tests, 0 failures ✅
- `make lint` 0 violations ✅