### PR TITLE
compose: toolbar save suspends the preview watch (#231)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -118,6 +118,7 @@ targets:
       - path: Sources/Companions/Preview/PreviewURL.swift
       - path: Sources/Compose/ComposeLanguage.swift
       - path: Sources/Compose/ComposeDocument.swift
+      - path: Sources/Compose/ComposeSaveFlow.swift
       - path: Sources/Compose/ComposeHighlighter.swift
       - path: Sources/Compose/ComposeDiagnostic.swift
       - path: Sources/Compose/ComposeFrontmatter.swift

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -20,9 +20,10 @@ struct ComposeEditorView: View {
     /// Cooklang completion vocabulary (LATER-3.4); `.empty` (default) keeps
     /// the popup off for hosts without a `.boris/` index.
     var cookCompletion: ComposeCookCompletion = .empty
-    /// Called after an explicit save actually wrote the buffer. The host
-    /// (ComposeWindow) uses this to flow the save into the coordinator's
-    /// save→validate gate.
+    /// The save verb (#231). The editor never writes the buffer itself:
+    /// Save / ⌘S call this, and the host (ComposeWindow) writes inside the
+    /// coordinator's tree-write window and surfaces errors in its status
+    /// bar.
     var onSave: (() -> Void)?
     /// External line-jump from ProblemsPane (M11 #207): when set, the editor
     /// jumps to this absolute character offset.
@@ -37,7 +38,6 @@ struct ComposeEditorView: View {
     /// LATER-3.3: leading pane editing the closed front-matter key set.
     @State private var showFrontmatter = false
     @State private var previewOptions = MarkupRenderOptions()
-    @State private var saveError: String?
 
     private var autosaveName: String {
         "ComposeSplit-\(document.language.rawValue)"
@@ -170,14 +170,10 @@ struct ComposeEditorView: View {
             .accessibilityHint("Configure Oliver's parse extensions.")
 
             Button {
-                do {
-                    saveError = nil
-                    if try document.save() {
-                        onSave?()
-                    }
-                } catch {
-                    saveError = error.localizedDescription
-                }
+                // #231: never write here. The host's save flow wraps the
+                // write in the coordinator's tree-write window; saving
+                // directly would race the preview watch mid-write.
+                onSave?()
             } label: {
                 Label("Save", systemImage: "square.and.arrow.down")
             }
@@ -186,13 +182,6 @@ struct ComposeEditorView: View {
             .accessibilityLabel("Save")
             .accessibilityHint("Write the buffer to disk (⌘S).")
             .disabled(!document.isDirty)
-
-            if let saveError {
-                Text(saveError)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-                    .lineLimit(1)
-            }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)

--- a/Sources/Compose/ComposeSaveFlow.swift
+++ b/Sources/Compose/ComposeSaveFlow.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// #231: the one save path for Compose. Toolbar Save, ⌘S, and any host
+/// verb funnel through this sequence so the buffer is written **inside**
+/// the preview-watch suspension — never mid-write while boris watches:
+///
+///     beginTreeWrite()   // suspend the watch
+///     document.save()    // write
+///     endTreeWrite()     // resume (deferred: runs on failure too)
+///     noteSave()         // queue validate — only after a real write
+enum ComposeSaveFlow {
+    /// What one save attempt did.
+    enum Outcome: Equatable {
+        /// Wrote and queued validation.
+        case saved
+        /// Buffer was clean or had no URL — nothing written, nothing queued.
+        case notDirty
+        /// The write threw; the watch is resumed and validation is not queued.
+        case failed(String)
+    }
+
+    /// Runs one save inside the tree-write window. `endTreeWrite` is
+    /// deferred, so a throwing write can never leave the watch suspended.
+    static func run(
+        beginTreeWrite: () -> Void,
+        endTreeWrite: () -> Void,
+        noteSave: () -> Void = {},
+        save: () throws -> Bool
+    ) -> Outcome {
+        beginTreeWrite()
+        defer { endTreeWrite() }
+        do {
+            guard try save() else { return .notDirty }
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+        noteSave()
+        return .saved
+    }
+}

--- a/Sources/Compose/ComposeWindow.swift
+++ b/Sources/Compose/ComposeWindow.swift
@@ -177,18 +177,24 @@ struct ComposeWindow: View {
 
     // MARK: - Save → coordinator gate
 
+    /// The single save entry point — toolbar Save, ⌘S, every host verb.
+    /// #231: the write happens inside `ComposeSaveFlow`'s tree-write window,
+    /// so the preview watch can never observe a partially-written file.
     private func save() {
         saveStatus = nil
-        do {
-            // Tree write: suspend the preview watch for the write, like
-            // play's IR build does; resume on the way out.
-            runtime.coordinator.beginTreeWrite()
-            defer { runtime.coordinator.endTreeWrite() }
-            guard try document.save() else { return }
-            runtime.coordinator.noteSave()
+        let outcome = ComposeSaveFlow.run(
+            beginTreeWrite: { runtime.coordinator.beginTreeWrite() },
+            endTreeWrite: { runtime.coordinator.endTreeWrite() },
+            noteSave: { runtime.coordinator.noteSave() },
+            save: { try document.save() }
+        )
+        switch outcome {
+        case .saved:
             saveStatus = "Saved · queued validate"
-        } catch {
-            saveStatus = error.localizedDescription
+        case .notDirty:
+            break
+        case .failed(let message):
+            saveStatus = message
         }
     }
 

--- a/Tests/ContractTests/ComposeSaveFlowTests.swift
+++ b/Tests/ContractTests/ComposeSaveFlowTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+
+/// #231 — Compose toolbar save must suspend the preview watch.
+///
+/// The toolbar Save button never writes the buffer itself: it calls the
+/// host's `onSave`, which runs `ComposeSaveFlow.run` so the write lands
+/// inside `beginTreeWrite()` / `endTreeWrite()` and a clean write queues
+/// validation (`noteSave()`). These tests pin that sequence — the bug was
+/// an unsuspended write racing boris's watch mid-write.
+@MainActor
+final class ComposeSaveFlowTests: XCTestCase {
+    // MARK: - Fixtures
+
+    /// A dirty document backed by a real temp file.
+    private func makeDocument(url: URL) -> ComposeDocument {
+        let doc = ComposeDocument(text: "Hello", fileURL: url)
+        doc.text = "Hello, world."
+        return doc
+    }
+
+    // MARK: - The three gate tests
+
+    func testToolbarSaveWritesInsideTreeWrite() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("compose-flow-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let doc = makeDocument(url: url)
+        var events: [String] = []
+
+        let outcome = ComposeSaveFlow.run(
+            beginTreeWrite: { events.append("begin") },
+            endTreeWrite: { events.append("end") },
+            noteSave: { events.append("noteSave") },
+            save: {
+                events.append("write")
+                return try doc.save()
+            }
+        )
+
+        XCTAssertEqual(outcome, .saved)
+        XCTAssertEqual(events.first, "begin", "the watch must be suspended before the write")
+        XCTAssertEqual(events.last, "end", "the watch must resume after the write")
+        guard let begin = events.firstIndex(of: "begin"),
+              let write = events.firstIndex(of: "write"),
+              let end = events.lastIndex(of: "end")
+        else {
+            return XCTFail("missing begin/write/end in \(events)")
+        }
+        XCTAssertLessThan(begin, write, "expected begin < write < end, got \(events)")
+        XCTAssertLessThan(write, end, "expected begin < write < end, got \(events)")
+    }
+
+    func testToolbarSaveWritesOnce() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("compose-flow-once-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let doc = makeDocument(url: url)
+        var writes = 0
+
+        _ = ComposeSaveFlow.run(
+            beginTreeWrite: {},
+            endTreeWrite: {},
+            noteSave: {},
+            save: {
+                writes += 1
+                return try doc.save()
+            }
+        )
+
+        XCTAssertEqual(writes, 1, "one Save must produce exactly one write")
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "Hello, world.")
+        XCTAssertFalse(doc.isDirty)
+    }
+
+    func testToolbarSaveQueuesValidation() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("compose-flow-queue-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let doc = makeDocument(url: url)
+        var events: [String] = []
+
+        let outcome = ComposeSaveFlow.run(
+            beginTreeWrite: { events.append("begin") },
+            endTreeWrite: { events.append("end") },
+            noteSave: { events.append("noteSave") },
+            save: {
+                events.append("write")
+                return try doc.save()
+            }
+        )
+
+        XCTAssertEqual(outcome, .saved)
+        guard let write = events.firstIndex(of: "write"),
+              let noteSave = events.firstIndex(of: "noteSave")
+        else {
+            return XCTFail("missing write/noteSave in \(events)")
+        }
+        XCTAssertLessThan(write, noteSave, "validation is queued only after the write")
+    }
+
+    // MARK: - Edge cases from the card
+
+    func testFailedWriteResumesWatchAndSkipsValidation() {
+        struct Boom: LocalizedError {
+            var errorDescription: String? { "disk on strike" }
+        }
+        var events: [String] = []
+
+        let outcome = ComposeSaveFlow.run(
+            beginTreeWrite: { events.append("begin") },
+            endTreeWrite: { events.append("end") },
+            noteSave: { events.append("noteSave") },
+            save: {
+                events.append("write")
+                throw Boom()
+            }
+        )
+
+        XCTAssertEqual(outcome, .failed("disk on strike"))
+        XCTAssertFalse(events.contains("noteSave"), "a failed write must not queue validation")
+        XCTAssertEqual(events.last, "end", "deferred endTreeWrite must run even when the write throws")
+    }
+
+    func testCleanBufferWritesNothingAndQueuesNothing() {
+        var events: [String] = []
+
+        let outcome = ComposeSaveFlow.run(
+            beginTreeWrite: { events.append("begin") },
+            endTreeWrite: { events.append("end") },
+            noteSave: { events.append("noteSave") },
+            save: {
+                events.append("write-attempt")
+                return false
+            }
+        )
+
+        XCTAssertEqual(outcome, .notDirty)
+        XCTAssertFalse(events.contains("noteSave"), "no write → no validate queued")
+        XCTAssertEqual(events.last, "end", "the window still opens and closes around the attempt")
+    }
+}


### PR DESCRIPTION
Closes #231. Spec: `docs/issues/editor-compose-toolbar-save-tree-write.md`.

## The bug

The toolbar Save button called `document.save()` **first**, then
`onSave?()` → `ComposeWindow.save()`. So the one real write happened
**outside** the `beginTreeWrite()`/`endTreeWrite()` window — boris's
preview watch could read a partially-written file and rebuild mid-write.
(The second save inside the window was a no-op: `isDirty` was already
false.)

## The fix

- **`ComposeSaveFlow`** (new): the one save sequence —
  `beginTreeWrite()` → write → `endTreeWrite()` (deferred, runs on
  failure) → `noteSave()` only after a real write.
- **Toolbar Save** now calls `onSave?()` only; it never writes the
  buffer itself. Still disabled when clean (`!document.isDirty`).
- **Error surfacing moves**: the editor's inline red `saveError` text is
  gone; `saveStatus` in the status bar (already renders red on failure)
  is the single surface.

## Tests

Six contract tests in `ComposeSaveFlowTests` pin the card's gate:
writes inside the tree-write window, exactly one write per Save,
validation queued after the write, failed writes still resume the watch
and never queue validation, clean buffers write nothing.

Gate: `SKIP_EMBED_BORIS=1 make build` ✅ · `make test` ✅ 422 tests,
0 failures · `make lint` ✅