### PR TITLE
editor: auto-reconnect when boris-editor crashes (#232)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -115,6 +115,8 @@ targets:
       - path: Sources/Workspace/GitHub
       - path: Sources/Companions/CompanionID.swift
       - path: Sources/Companions/Editor/EditorURL.swift
+      - path: Sources/Companions/Editor/EditorSession.swift
+      - path: Sources/Companions/Editor/EditorServerFactory.swift
       - path: Sources/Companions/Preview/PreviewURL.swift
       - path: Sources/Compose/ComposeLanguage.swift
       - path: Sources/Compose/ComposeDocument.swift

--- a/Sources/Companions/Editor/EditorServerFactory.swift
+++ b/Sources/Companions/Editor/EditorServerFactory.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Why the production host factory refused to build a host. These are
+/// permanent configuration errors — never crash-reconnect candidates (#232).
+enum EditorHostLaunchError: LocalizedError {
+    case editorBinaryNotFound
+
+    var errorDescription: String? {
+        switch self {
+        case .editorBinaryNotFound:
+            return "boris-editor binary not found. Set SOLIPSIST_BORIS_EDITOR_BIN or build the editor host."
+        }
+    }
+}
+
+/// Production wiring for `EditorSession`'s host seam: locates the
+/// `boris-editor` binary and starts the real subprocess (A14).
+enum EditorServerFactory {
+    /// Builds the live host. A missing binary throws a permanent
+    /// configuration error — the session never crash-reconnects those (#232).
+    static func launch(engine: BorisEngine, workingDirectory: URL) throws -> any EditorHost {
+        guard let editorBinary = findEditorBinary(relativeTo: engine.binaryURL) else {
+            throw EditorHostLaunchError.editorBinaryNotFound
+        }
+        return try engine.editorStart(
+            editorBinary: editorBinary,
+            workingDirectory: workingDirectory,
+            port: 0
+        )
+    }
+
+    static func findEditorBinary(relativeTo engineBinary: URL) -> URL? {
+        if let custom = UserDefaults.standard.string(forKey: "customBorisEditorBinaryPath"), !custom.isEmpty {
+            let url = URL(fileURLWithPath: custom)
+            if FileManager.default.isExecutableFile(atPath: url.path) { return url }
+        }
+
+        let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_EDITOR_BIN"]
+        if let env, !env.isEmpty, FileManager.default.isExecutableFile(atPath: env) {
+            return URL(fileURLWithPath: env)
+        }
+
+        let sibling = engineBinary.deletingLastPathComponent().appendingPathComponent("boris-editor")
+        if FileManager.default.isExecutableFile(atPath: sibling.path) {
+            return sibling
+        }
+
+        let bundled = Bundle.main.url(forResource: "boris-editor", withExtension: nil)
+        if let bundled, FileManager.default.isExecutableFile(atPath: bundled.path) {
+            return bundled
+        }
+
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let devCandidates = [
+            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris-editor",
+            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/bin/boris-editor",
+            "../boris-agent-kit/bin/boris-editor",
+            "editor/zig-out/bin/boris-editor",
+            "../boris/editor/zig-out/bin/boris-editor",
+        ]
+        for relative in devCandidates {
+            let url = cwd.appendingPathComponent(relative).standardizedFileURL
+            if FileManager.default.isExecutableFile(atPath: url.path) { return url }
+        }
+
+        return nil
+    }
+}

--- a/Sources/Companions/Editor/EditorSession.swift
+++ b/Sources/Companions/Editor/EditorSession.swift
@@ -1,8 +1,61 @@
 import Foundation
 import Observation
 
+/// What `EditorSession` drives across the subprocess boundary. Production
+/// vends `EditorServer` from `BorisEngine.editorStart` (A14); the seam lets
+/// reconnect behavior be exercised without spawning binaries.
+protocol EditorHost: AnyObject {
+    var onConnect: ((URL) -> Void)? { get set }
+    var onExit: ((EditorExit) -> Void)? { get set }
+    var editorURL: URL? { get }
+    var isRunning: Bool { get }
+    func stop()
+}
+
+extension EditorServer: EditorHost {}
+
+/// Auto-reconnect policy for spontaneous `boris-editor` crashes (#232): up
+/// to three restarts inside a 30s sliding window, backing off 2s × attempt.
+/// Pure so the cap/window arithmetic is unit-testable without a clock.
+enum EditorAutoReconnect {
+    static let maxAttempts = 3
+    static let window: Duration = .seconds(30)
+    static let baseDelay: Duration = .seconds(2)
+
+    enum Decision: Equatable {
+        /// Schedule the next automatic restart; payload is the 1-based
+        /// attempt number (delay = baseDelay × attempt).
+        case retry(attempt: Int)
+        /// Cap reached within the window — manual restart required.
+        case giveUp
+    }
+
+    /// Drops crash instants that aged out of the sliding window.
+    static func prune(_ crashes: [ContinuousClock.Instant], now: ContinuousClock.Instant) -> [ContinuousClock.Instant] {
+        let cutoff = now - window
+        return crashes.filter { $0 >= cutoff }
+    }
+
+    /// Decides what to do given the number of crashes recorded in the
+    /// window, including the one that just happened.
+    static func decision(crashesInWindow count: Int) -> Decision {
+        count > maxAttempts ? .giveUp : .retry(attempt: count)
+    }
+
+    static let windowDescription = "\(window.components.seconds)s"
+}
+
 /// Drives the M6 author companion surface (A14 / #75): owns the `boris-editor`
 /// subprocess host lifetime and hands the tokenized session URL to the editor web view.
+///
+/// When the host dies spontaneously (non-zero exit or signal — never exit 0,
+/// which is the SIGTERM shutdown path), the session restarts it automatically
+/// with backoff, capped at `EditorAutoReconnect.maxAttempts` crashes inside
+/// `EditorAutoReconnect.window`. A successful connect resets the counter and
+/// raises a transient "Editor host restarted" notice (#232). Manual actions
+/// (`restart()`, `stop()`, source switches) cancel any pending auto-restart;
+/// they clear the callbacks before the old process reports its exit, so
+/// `handleExit` only ever sees spontaneous deaths.
 @MainActor
 @Observable
 final class EditorSession {
@@ -10,10 +63,22 @@ final class EditorSession {
         case idle
         case starting
         case connected(URL)
+        /// Spontaneous exit; an automatic restart is pending (attempt N).
+        case reconnecting(attempt: Int)
         case failed(String)
     }
 
+    /// Builds a host. Always invoked on the main actor (`start()`'s context).
+    typealias HostFactory = @MainActor (_ engine: BorisEngine, _ workingDirectory: URL) throws -> any EditorHost
+
     private(set) var phase: Phase = .idle
+
+    /// One-shot confirmation after an automatic reconnect succeeds ("Editor
+    /// host restarted"). Cleared whenever the session leaves `connected`.
+    private(set) var transientNotice: String?
+
+    /// Backoff base for automatic restarts: attempt N waits N × base.
+    let reconnectBaseDelay: Duration
 
     var editorURL: URL? {
         if case .connected(let url) = phase { return url }
@@ -33,23 +98,50 @@ final class EditorSession {
             return "Starting boris-editor…"
         case .connected(let url):
             return "Connected to \(url.host ?? "loopback")"
+        case .reconnecting(let attempt):
+            return "boris-editor exited unexpectedly — restarting automatically (attempt \(attempt) of \(EditorAutoReconnect.maxAttempts))…"
         case .failed(let message):
             return message
         }
     }
 
-    private var server: EditorServer?
+    private let makeHost: HostFactory
+    private var server: (any EditorHost)?
     private var rootPath: String?
     private var timeoutTask: Task<Void, Never>?
     private var lastContentRoot: URL?
     private var lastProjectRoot: URL?
     private var lastEngine: BorisEngine?
+    private var reconnectCrashes: [ContinuousClock.Instant] = []
+    private var reconnectTask: Task<Void, Never>?
 
     var canRestart: Bool {
         lastContentRoot != nil
     }
 
+    init(
+        makeHost: @escaping HostFactory = EditorServerFactory.launch,
+        reconnectBaseDelay: Duration = EditorAutoReconnect.baseDelay
+    ) {
+        self.makeHost = makeHost
+        self.reconnectBaseDelay = reconnectBaseDelay
+    }
+
     func start(contentRoot: URL, projectRoot: URL, engine: BorisEngine?) {
+        startInternal(
+            contentRoot: contentRoot,
+            projectRoot: projectRoot,
+            engine: engine,
+            preservingReconnectState: false
+        )
+    }
+
+    private func startInternal(
+        contentRoot: URL,
+        projectRoot: URL,
+        engine: BorisEngine?,
+        preservingReconnectState preserve: Bool
+    ) {
         lastContentRoot = contentRoot
         lastProjectRoot = projectRoot
         lastEngine = engine
@@ -60,27 +152,24 @@ final class EditorSession {
             }
             return
         }
-        stop()
+        // A fresh lifecycle cancels any pending auto-restart (source switch,
+        // re-selected source); the automatic restart itself must preserve the
+        // counter so crashes accumulate toward the cap (#232).
+        if !preserve {
+            cancelAutoReconnect()
+        }
+        teardown()
         rootPath = root
 
         guard let engine else {
-            phase = .failed("Boris engine not available.")
+            setPhase(.failed("Boris engine not available."))
             return
         }
 
-        guard let editorBinary = findEditorBinary(relativeTo: engine.binaryURL) else {
-            phase = .failed("boris-editor binary not found. Set SOLIPSIST_BORIS_EDITOR_BIN or build the editor host.")
-            return
-        }
-
-        phase = .starting
+        setPhase(.starting)
         scheduleTimeout()
         do {
-            let server = try engine.editorStart(
-                editorBinary: editorBinary,
-                workingDirectory: projectRoot,
-                port: 0
-            )
+            let server = try makeHost(engine, projectRoot)
             self.server = server
             server.onConnect = { [weak self] url in
                 Task { @MainActor in self?.handleConnect(url: url) }
@@ -91,31 +180,60 @@ final class EditorSession {
         } catch {
             timeoutTask?.cancel()
             timeoutTask = nil
-            phase = .failed("Could not start editor host: \(error)")
+            if error is EditorHostLaunchError {
+                // Permanent configuration error — surface verbatim, no
+                // prefix, and never a crash-reconnect candidate (#232).
+                setPhase(.failed(error.localizedDescription))
+            } else {
+                setPhase(.failed("Could not start editor host: \(error)"))
+            }
         }
     }
 
     /// Tears down the current host (if any) and starts a fresh one for the
     /// same content root. A new random token URL is printed by the new host,
     /// so the web view reconnects via the existing `editorURL` observation.
+    ///
+    /// Manual entry point (#232): cancels any pending auto-reconnect and
+    /// resets its crash counter — the gate treats manual restarts as a
+    /// deliberate fresh start.
     func restart() {
+        beginRestart(preservingReconnectState: false)
+    }
+
+    /// Shared restart path. The automatic reconnect passes
+    /// `preservingReconnectState: true` so crash counts accumulate across
+    /// auto-restarts; every other caller resets them. Teardown happens
+    /// unconditionally — a manual restart must bounce even a healthy host,
+    /// and `startInternal`'s idempotent early-return must not short-circuit it.
+    private func beginRestart(preservingReconnectState preserve: Bool) {
         guard let contentRoot = lastContentRoot, let projectRoot = lastProjectRoot else { return }
-        stop()
-        start(contentRoot: contentRoot, projectRoot: projectRoot, engine: lastEngine)
+        if !preserve {
+            cancelAutoReconnect()
+        }
+        teardown()
+        startInternal(
+            contentRoot: contentRoot,
+            projectRoot: projectRoot,
+            engine: lastEngine,
+            preservingReconnectState: preserve
+        )
     }
 
     func fail(_ message: String) {
-        timeoutTask?.cancel()
-        timeoutTask = nil
-        server?.onConnect = nil
-        server?.onExit = nil
-        server?.stop()
-        server = nil
-        rootPath = nil
-        phase = .failed(message)
+        cancelAutoReconnect()
+        teardown()
+        setPhase(.failed(message))
     }
 
     func stop() {
+        cancelAutoReconnect()
+        teardown()
+    }
+
+    /// Tears down the host and returns the session to idle without touching
+    /// auto-reconnect bookkeeping (callers decide whether to reset it).
+    private func teardown() {
         timeoutTask?.cancel()
         timeoutTask = nil
         if let server {
@@ -125,27 +243,64 @@ final class EditorSession {
             self.server = nil
         }
         rootPath = nil
-        phase = .idle
+        setPhase(.idle)
     }
 
     private func handleConnect(url: URL) {
         timeoutTask?.cancel()
         timeoutTask = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        // Direct assignment, not setPhase(_:): a notice raised by this very
+        // connect must survive landing in the connected phase.
         phase = .connected(url)
+        if !reconnectCrashes.isEmpty {
+            transientNotice = "Editor host restarted"
+        }
+        reconnectCrashes.removeAll()
     }
 
     private func handleExit(_ exit: EditorExit) {
+        // Only spontaneous exits reach this callback: stop()/fail()/teardown
+        // nil the callbacks before the old process can report, so a manual
+        // Restart Host, Stop, window close, or source switch never lands here.
         guard server != nil else { return }
         server = nil
         timeoutTask?.cancel()
         timeoutTask = nil
         rootPath = nil
-        if exit.exitCode == 0 {
-            phase = .idle
-        } else {
+
+        // Exit 0 is a clean shutdown (SIGTERM via stop()), never a crash (#232).
+        guard exit.exitCode != 0 || exit.signalled else {
+            setPhase(.idle)
+            return
+        }
+
+        let now = ContinuousClock.now
+        reconnectCrashes.append(now)
+        reconnectCrashes = EditorAutoReconnect.prune(reconnectCrashes, now: now)
+
+        switch EditorAutoReconnect.decision(crashesInWindow: reconnectCrashes.count) {
+        case .retry(let attempt):
+            setPhase(.reconnecting(attempt: attempt))
+            scheduleAutoReconnect(after: reconnectBaseDelay * attempt)
+        case .giveUp:
             let tail = exit.stderrTail.trimmingCharacters(in: .whitespacesAndNewlines)
             let suffix = tail.isEmpty ? "" : " — \(tail.suffix(200))"
-            phase = .failed("Editor host exited (\(exit.exitCode))\(suffix)")
+            setPhase(
+                .failed(
+                    "Editor host crashed \(EditorAutoReconnect.maxAttempts) times within \(EditorAutoReconnect.windowDescription). Manual restart required.\(suffix)"
+                )
+            )
+        }
+    }
+
+    private func scheduleAutoReconnect(after delay: Duration) {
+        reconnectTask = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            self.beginRestart(preservingReconnectState: true)
         }
     }
 
@@ -163,43 +318,21 @@ final class EditorSession {
         server = nil
         timeoutTask = nil
         rootPath = nil
-        phase = .failed("Editor host did not report a token URL within 15s.")
+        setPhase(.failed("Editor host did not report a token URL within 15s."))
     }
 
-    private func findEditorBinary(relativeTo engineBinary: URL) -> URL? {
-        if let custom = UserDefaults.standard.string(forKey: "customBorisEditorBinaryPath"), !custom.isEmpty {
-            let url = URL(fileURLWithPath: custom)
-            if FileManager.default.isExecutableFile(atPath: url.path) { return url }
-        }
+    /// Phase transitions leave the connected state, so any transient
+    /// "Editor host restarted" notice dies with it.
+    private func setPhase(_ newPhase: Phase) {
+        if case .connected = newPhase {} else { transientNotice = nil }
+        phase = newPhase
+    }
 
-        let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_EDITOR_BIN"]
-        if let env, !env.isEmpty, FileManager.default.isExecutableFile(atPath: env) {
-            return URL(fileURLWithPath: env)
-        }
-
-        let sibling = engineBinary.deletingLastPathComponent().appendingPathComponent("boris-editor")
-        if FileManager.default.isExecutableFile(atPath: sibling.path) {
-            return sibling
-        }
-
-        let bundled = Bundle.main.url(forResource: "boris-editor", withExtension: nil)
-        if let bundled, FileManager.default.isExecutableFile(atPath: bundled.path) {
-            return bundled
-        }
-
-        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        let devCandidates = [
-            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/boris-editor",
-            "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/bin/boris-editor",
-            "../boris-agent-kit/bin/boris-editor",
-            "editor/zig-out/bin/boris-editor",
-            "../boris/editor/zig-out/bin/boris-editor",
-        ]
-        for relative in devCandidates {
-            let url = cwd.appendingPathComponent(relative).standardizedFileURL
-            if FileManager.default.isExecutableFile(atPath: url.path) { return url }
-        }
-
-        return nil
+    /// Cancels a pending automatic restart and clears its crash counter.
+    /// Manual actions and successful connections come through here.
+    private func cancelAutoReconnect() {
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        reconnectCrashes.removeAll()
     }
 }

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -209,6 +209,13 @@ struct EditorWindow: View {
                     .accessibilityAddTraits(.isButton)
             }
 
+            // #232: one-shot confirmation after an automatic reconnect.
+            if let notice = session.transientNotice {
+                Text(notice)
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+
             if let rejection = model.rejection {
                 Text(rejection)
                     .font(.caption)
@@ -298,7 +305,7 @@ private struct EditorPhaseIndicator: View {
         switch phase {
         case .idle:
             Image(systemName: "circle.dotted")
-        case .starting:
+        case .starting, .reconnecting:
             ProgressView()
                 .controlSize(.small)
         case .connected:
@@ -318,13 +325,15 @@ private struct EditorPhaseIndicator: View {
             return "Starting boris-editor…"
         case .connected(let url):
             return "Connected · \(url.host ?? "loopback")"
+        case .reconnecting(let attempt):
+            return "Reconnecting · attempt \(attempt) of \(EditorAutoReconnect.maxAttempts)"
         case .failed(let message):
             return message
         }
     }
 
     /// A11Y-4 (#242): a VoiceOver-readable label for every phase value the
-    /// indicator can render. Enumerates all four `Phase` cases so a new one
+    /// indicator can render. Enumerates all five `Phase` cases so a new one
     /// won't ship unlabeled.
     private var accessibilityPhaseLabel: String {
         switch phase {
@@ -334,6 +343,8 @@ private struct EditorPhaseIndicator: View {
             return "Engine starting"
         case .connected:
             return "Engine running"
+        case .reconnecting:
+            return "Engine reconnecting"
         case .failed:
             return "Engine error"
         }

--- a/Tests/ContractTests/EditorSessionReconnectTests.swift
+++ b/Tests/ContractTests/EditorSessionReconnectTests.swift
@@ -1,0 +1,341 @@
+import XCTest
+
+/// #232: auto-reconnect when the `boris-editor` host crashes spontaneously.
+/// Drives the real `EditorSession` state machine against an in-memory host,
+/// so no binaries are spawned; the injected millisecond backoff keeps every
+/// scenario well under a second.
+@MainActor
+final class EditorSessionReconnectTests: XCTestCase {
+    // MARK: Harness
+
+    private let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("EditorSessionReconnectTests-content")
+    private let project = FileManager.default.temporaryDirectory
+        .appendingPathComponent("EditorSessionReconnectTests-project")
+    private let tokenA = URL(string: "http://127.0.0.1:49152/#token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")!
+    private let tokenB = URL(string: "http://127.0.0.1:49153/#token=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")!
+
+    private func makeEngine() throws -> BorisEngine {
+        try BorisEngine(binaryURL: URL(fileURLWithPath: "/nonexistent/boris"))
+    }
+
+    /// In-memory stand-in for `EditorServer`. Tests fire `connect` / `crash`
+    /// by hand, exactly like the process callbacks would arrive.
+    private final class FakeHost: EditorHost {
+        var onConnect: ((URL) -> Void)?
+        var onExit: ((EditorExit) -> Void)?
+
+        private(set) var editorURL: URL?
+        private(set) var stopCount = 0
+        var isRunning = true
+
+        func connect(url: URL) {
+            editorURL = url
+            isRunning = true
+            onConnect?(url)
+        }
+
+        func crash(exitCode: Int32, signalled: Bool = false) {
+            isRunning = false
+            onExit?(EditorExit(exitCode: exitCode, signalled: signalled, stderrTail: ""))
+        }
+
+        func stop() {
+            stopCount += 1
+            isRunning = false
+        }
+    }
+
+    private final class HostRecorder {
+        private(set) var hosts: [FakeHost] = []
+
+        var last: FakeHost? { hosts.last }
+
+        func factory(engine: BorisEngine, workingDirectory: URL) throws -> any EditorHost {
+            let host = FakeHost()
+            hosts.append(host)
+            return host
+        }
+    }
+
+    /// Backoff small enough that auto-restarts land inside the test, large
+    /// enough that `.reconnecting` stays observable between ticks.
+    private let baseDelay = Duration.milliseconds(100)
+
+    private func makeSession(_ recorder: HostRecorder) -> EditorSession {
+        EditorSession(
+            makeHost: { engine, workDir in try recorder.factory(engine: engine, workingDirectory: workDir) },
+            reconnectBaseDelay: baseDelay
+        )
+    }
+
+    private func connectedURL(of session: EditorSession) -> URL? {
+        if case .connected(let url) = session.phase { return url }
+        return nil
+    }
+
+    private func reconnectingAttempt(of session: EditorSession) -> Int? {
+        if case .reconnecting(let attempt) = session.phase { return attempt }
+        return nil
+    }
+
+    /// Lets enqueued MainActor tasks (`handleConnect` / `handleExit`) run.
+    private func settle(milliseconds: Int = 10) async {
+        try? await Task.sleep(for: .milliseconds(milliseconds))
+    }
+
+    private func waitForHosts(_ recorder: HostRecorder, _ count: Int) async throws {
+        var waited = 0
+        while recorder.hosts.count < count {
+            guard waited < 2000 else {
+                XCTFail("timed out waiting for \(count) hosts (have \(recorder.hosts.count))")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+            waited += 10
+        }
+    }
+
+    private func waitForConnected(_ session: EditorSession, _ url: URL) async throws {
+        var waited = 0
+        while connectedURL(of: session) != url {
+            guard waited < 2000 else {
+                XCTFail("timed out waiting for connected phase (\(session.phase))")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+            waited += 10
+        }
+    }
+
+    /// start → host 1 reports its token URL.
+    private func startAndConnect(_ session: EditorSession, _ recorder: HostRecorder) async throws {
+        session.start(contentRoot: root, projectRoot: project, engine: try makeEngine())
+        try await waitForHosts(recorder, 1)
+        recorder.last?.connect(url: tokenA)
+        try await waitForConnected(session, tokenA)
+        XCTAssertNil(session.transientNotice)
+    }
+
+    // MARK: Auto-reconnect fires
+
+    func testAutoReconnectFiresOnNonZeroExit() async throws {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+        defer { session.stop() }
+
+        try await startAndConnect(session, recorder)
+
+        recorder.hosts[0].crash(exitCode: 1)
+        await settle()
+        XCTAssertEqual(reconnectingAttempt(of: session), 1)
+        XCTAssertFalse(session.isFailure)
+
+        try await waitForHosts(recorder, 2)
+        XCTAssertEqual(
+            recorder.hosts[0].stopCount, 0,
+            "a crashed process is already dead; teardown must not SIGTERM it again"
+        )
+
+        recorder.hosts[1].connect(url: tokenB)
+        try await waitForConnected(session, tokenB)
+        XCTAssertEqual(session.transientNotice, "Editor host restarted")
+    }
+
+    func testAutoReconnectDoesNotFireOnCleanExit() async throws {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+        defer { session.stop() }
+
+        try await startAndConnect(session, recorder)
+
+        recorder.hosts[0].crash(exitCode: 0)
+        await settle(milliseconds: 120)
+        XCTAssertEqual(session.phase, .idle)
+        XCTAssertNil(session.transientNotice)
+        XCTAssertEqual(recorder.hosts.count, 1, "exit 0 must never trigger a reconnect")
+    }
+
+    func testAutoReconnectDoesNotFireWhenStartFails() {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+        defer { session.stop() }
+
+        // No engine: permanent configuration error, not a crash (#232).
+        session.start(contentRoot: root, projectRoot: project, engine: nil)
+        XCTAssertEqual(session.phase, .failed("Boris engine not available."))
+        XCTAssertTrue(recorder.hosts.isEmpty)
+    }
+
+    func testSignalledExitCountsAsCrash() async throws {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+        defer { session.stop() }
+
+        try await startAndConnect(session, recorder)
+
+        recorder.hosts[0].crash(exitCode: 0, signalled: true)
+        try await waitForHosts(recorder, 2)
+        XCTAssertEqual(reconnectingAttempt(of: session), nil, "restart may already have fired")
+        XCTAssertFalse(session.isFailure, "a signalled death must be treated as a crash, not a clean exit")
+    }
+
+    // MARK: Cap and reset
+
+    func testAutoReconnectStopsAfterMaxAttempts() async throws {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+        defer { session.stop() }
+
+        try await startAndConnect(session, recorder)
+
+        for attempt in 1 ... EditorAutoReconnect.maxAttempts {
+            recorder.last?.crash(exitCode: 1)
+            await settle()
+            XCTAssertEqual(reconnectingAttempt(of: session), attempt, "crash \(attempt)")
+            try await waitForHosts(recorder, 1 + attempt)
+        }
+        // The third restart is underway; nothing has connected since.
+        XCTAssertEqual(session.phase, .starting)
+
+        // Fourth crash within the window: cap reached, manual restart required.
+        recorder.last?.crash(exitCode: 1)
+        await settle()
+        guard case .failed(let message) = session.phase else {
+            return XCTFail("expected failed phase, got \(session.phase)")
+        }
+        XCTAssertTrue(message.contains("Manual restart required"), message)
+        XCTAssertTrue(message.contains("3 times"), message)
+
+        await settle(milliseconds: 120)
+        XCTAssertEqual(recorder.hosts.count, 4, "no fifth host may spawn after the cap")
+        XCTAssertTrue(session.isFailure)
+    }
+
+    func testAutoReconnectResetsOnSuccess() async throws {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+        defer { session.stop() }
+
+        try await startAndConnect(session, recorder)
+
+        // First crash-and-recover cycle.
+        recorder.hosts[0].crash(exitCode: 1)
+        try await waitForHosts(recorder, 2)
+        recorder.hosts[1].connect(url: tokenB)
+        try await waitForConnected(session, tokenB)
+        XCTAssertEqual(session.transientNotice, "Editor host restarted")
+
+        // A later crash counts from scratch again.
+        recorder.hosts[1].crash(exitCode: 1)
+        await settle()
+        XCTAssertEqual(reconnectingAttempt(of: session), 1, "a successful connect must reset the counter")
+        XCTAssertNil(session.transientNotice, "leaving connected clears the notice")
+    }
+
+    func testManualRestartResetsAttemptCounter() async throws {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+        defer { session.stop() }
+
+        try await startAndConnect(session, recorder)
+
+        recorder.hosts[0].crash(exitCode: 1)
+        try await waitForHosts(recorder, 2)
+
+        session.restart()
+        try await waitForHosts(recorder, 3)
+        XCTAssertEqual(recorder.hosts[1].stopCount, 1)
+
+        // The manual restart wiped the earlier crash from the books.
+        recorder.hosts[2].crash(exitCode: 1)
+        await settle()
+        XCTAssertEqual(reconnectingAttempt(of: session), 1)
+    }
+
+    // MARK: Manual teardown wins
+
+    func testAutoReconnectDoesNotFireOnWindowClose() async throws {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+
+        try await startAndConnect(session, recorder)
+
+        recorder.hosts[0].crash(exitCode: 1)
+        await settle() // phase flips to .reconnecting; the backoff task is pending
+        XCTAssertEqual(reconnectingAttempt(of: session), 1)
+
+        // Window close (.onDisappear → stop()) must cancel the pending task.
+        session.stop()
+
+        await settle(milliseconds: 150)
+        XCTAssertEqual(session.phase, .idle)
+        XCTAssertEqual(recorder.hosts.count, 1, "closing the window must never spawn another host")
+        XCTAssertNil(session.transientNotice)
+    }
+
+    func testStopBeforeExitArrivesSwallowsTheExit() async throws {
+        let recorder = HostRecorder()
+        let session = makeSession(recorder)
+        defer { session.stop() }
+
+        try await startAndConnect(session, recorder)
+
+        // The exit callback is enqueued, then a manual stop() runs first:
+        // callbacks nil'd and server cleared before handleExit executes, so
+        // the dying host can never schedule a reconnect behind our back.
+        recorder.hosts[0].crash(exitCode: 1)
+        session.stop()
+
+        await settle(milliseconds: 150)
+        XCTAssertEqual(session.phase, .idle)
+        XCTAssertEqual(recorder.hosts.count, 1)
+    }
+
+    // MARK: Source switch while pending
+
+    func testSourceSwitchCancelsPendingReconnect() async throws {
+        let recorder = HostRecorder()
+        // Long backoff so the switch reliably lands while a restart is pending.
+        let session = EditorSession(
+            makeHost: { engine, workDir in try recorder.factory(engine: engine, workingDirectory: workDir) },
+            reconnectBaseDelay: .milliseconds(500)
+        )
+        defer { session.stop() }
+
+        try await startAndConnect(session, recorder)
+
+        recorder.hosts[0].crash(exitCode: 1)
+        await settle()
+        XCTAssertEqual(reconnectingAttempt(of: session), 1)
+
+        // The user picks a different source: .task(id:) re-runs start() with
+        // new roots, which tears down and cancels the pending auto-restart.
+        let otherRoot = root.appendingPathComponent("other")
+        session.start(contentRoot: otherRoot, projectRoot: project, engine: try makeEngine())
+        try await waitForHosts(recorder, 2)
+        XCTAssertEqual(session.phase, .starting)
+
+        await settle(milliseconds: 600)
+        XCTAssertEqual(recorder.hosts.count, 2, "the cancelled backoff task must not add hosts")
+    }
+
+    // MARK: Policy arithmetic (pure)
+
+    func testPolicyRetriesGrowThenGiveUp() {
+        XCTAssertEqual(EditorAutoReconnect.decision(crashesInWindow: 1), .retry(attempt: 1))
+        XCTAssertEqual(EditorAutoReconnect.decision(crashesInWindow: 2), .retry(attempt: 2))
+        XCTAssertEqual(EditorAutoReconnect.decision(crashesInWindow: 3), .retry(attempt: 3))
+        XCTAssertEqual(EditorAutoReconnect.decision(crashesInWindow: 4), .giveUp)
+    }
+
+    func testPolicyPrunesCrashesOutsideWindow() {
+        let now = ContinuousClock.now
+        let fresh = now - Duration.seconds(5)
+        let boundary = now - EditorAutoReconnect.window
+        let stale = now - Duration.seconds(45)
+        XCTAssertEqual(EditorAutoReconnect.prune([stale], now: now), [])
+        XCTAssertEqual(EditorAutoReconnect.prune([fresh], now: now), [fresh])
+        XCTAssertEqual(EditorAutoReconnect.prune([boundary], now: now), [boundary])
+    }
+}


### PR DESCRIPTION
Closes #232. Card: docs/issues/editor-companion-reconnect.md.

## What changed

A spontaneous `boris-editor` death no longer strands the Editor companion
on a static "Editor host exited (N)" error: `EditorSession` now restarts
the host automatically with backoff, and the toolbar says so.

| Piece | File | Notes |
|---|---|---|
| Policy | `EditorAutoReconnect` in `EditorSession.swift` | Pure, unit-tested: up to 3 restarts inside a 30s sliding window (`ContinuousClock` instants, pruned per crash), delay = base × attempt (2s/4s/6s). |
| Host seam | `EditorHost` protocol + `EditorServerFactory.swift` (new) | Production vends the real `EditorServer` via `BorisEngine.editorStart` (A14); binary discovery moved behind the factory so reconnect behavior is testable without binaries on PATH. Missing binary stays a permanent error, surfaced verbatim — never a reconnect candidate. |
| Session state machine | `Sources/Companions/Editor/EditorSession.swift` | New `.reconnecting(attempt:)` phase; transient `"Editor host restarted"` notice raised when a post-crash connect succeeds (cleared on any phase change away from connected). Manual actions (`restart()`, `stop()`, source switches) cancel the pending task; manual restart also resets the counter. The automatic path preserves it so crashes accumulate toward the cap. |
| UI | `EditorWindow.swift` | Phase indicator gains the `.reconnecting` case (spinner + "Reconnecting · attempt N of 3" + VoiceOver label — the A11Y-4 exhaustive-switch comment did its job); green one-shot notice row under the URL field. |

Must-not list honored: exit code 0 (SIGTERM shutdown), window close
(`onDisappear` → `stop()` nils callbacks first), start failures, and
missing engine/editor binaries never auto-reconnect. Source switch while
pending cancels the stale task — a later switch's fresh `start()` records
the new roots, so nothing targets the old source.

## Tests (`EditorSessionReconnectTests`, 12)

Fires on non-zero exit · clean exit never reconnects · signalled death is
a crash · start failure is not · cap after 3 crashes → manual state, no
fifth host · counter resets on success and on manual restart · window
close cancels pending · stop-before-exit swallows the in-flight callback ·
source switch cancels pending · policy retry/give-up table · window prune.
All against an injected fake host with a 100ms backoff — no binaries, no
multi-second sleeps.

## Verification

- `SKIP_EMBED_BORIS=1 make build` ✅
- `make test` 434 tests, 0 failures ✅
- `make lint` 0 violations ✅