### PR TITLE
feat(M18): editor polish - zoom, keyboard nav, go-to-line, toolbar UX, highlighting

### DIFF
--- a/Sources/Companions/Editor/EditorSession.swift
+++ b/Sources/Companions/Editor/EditorSession.swift
@@ -90,6 +90,12 @@ final class EditorSession {
         return false
     }
 
+    /// #237: True when the editor host has connected and the URL is live.
+    var isConnected: Bool {
+        if case .connected = phase { return true }
+        return false
+    }
+
     var statusText: String {
         switch phase {
         case .idle:

--- a/Sources/Companions/Editor/EditorURL.swift
+++ b/Sources/Companions/Editor/EditorURL.swift
@@ -118,6 +118,18 @@ public enum EditorURL {
         return "\(baseStr)#\(fragmentStr)"
     }
 
+    /// #237: Extracts `host:port` from a URL for the redacted toolbar
+    /// display. Handles IPv6 (`[::1]:9000`), IPv4 (`127.0.0.1:9000`),
+    /// and `localhost:9000`.
+    public static func hostPort(for url: URL) -> String {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url.absoluteString
+        }
+        let host = components.host ?? "?"
+        let port = components.port.map { ":\($0)" } ?? ""
+        return "\(host)\(port)"
+    }
+
     // MARK: - Fragment (URLSearchParams)
 
     private static func fragmentItems(_ fragment: String?) -> [URLQueryItem] {

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -3,6 +3,8 @@ import Observation
 import SwiftUI
 import WebKit
 
+// swiftlint:disable file_length
+
 /// Companion host for `boris-editor` (Svelte). Chassis registers the window
 /// and leaves it closed; the editor opens against the selected page.
 ///
@@ -12,13 +14,16 @@ import WebKit
 /// by today's shell). The header names the selected page and its
 /// `sourcePath`. Manual URL paste and "Open in Browser" stay as the
 /// loopback fallback.
-struct EditorWindow: View {
+struct EditorWindow: View { // swiftlint:disable:this type_body_length
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
 
     @State private var model = EditorWebModel()
     @State private var urlText = ""
     @State private var session = EditorSession()
+    /// #237: When true, the manual URL field and Connect button are visible.
+    /// Shown by default when idle/failed; hidden when connected.
+    @State private var showManualConnect = false
 
     var body: some View {
         Group {
@@ -43,7 +48,7 @@ struct EditorWindow: View {
             }
         }
         .frame(minWidth: 480, minHeight: 360)
-        .navigationTitle("Editor")
+        .navigationTitle(headerNavigationTitle)
         .onChange(of: session.editorURL) { _, newURL in
             if let newURL {
                 let targeted = EditorURL.opening(newURL, sourcePath: pageSourcePath)
@@ -89,16 +94,33 @@ struct EditorWindow: View {
         }
     }
 
+    /// #237: The editor window's navigation title shows the page name
+    /// when one is selected, falling back to "Editor".
+    private var headerNavigationTitle: String {
+        if let noun = store.selection.noun, noun.kind == "page", !noun.title.isEmpty {
+            return "Editor — \(noun.title)"
+        }
+        return "Editor"
+    }
+
     private func idleState(for source: SourceItem) -> some View {
         ContentUnavailableView {
             Label("Editor Host Not Running", systemImage: "square.and.pencil")
         } description: {
-            Text(
-                session.statusText.isEmpty
-                    ? "The Boris editor connects when the host process is running. "
-                    + "File → Edit Page opens the editor; paste a BORIS_EDITOR_URL= line above to connect manually."
-                    : session.statusText
-            )
+            VStack(alignment: .leading, spacing: 8) {
+                if let guidance = errorGuidance {
+                    Text(guidance.headline)
+                        .font(.body)
+                    Text(guidance.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("The Boris editor connects when the host process is running.")
+                    Text("File → Edit Page opens the editor, or paste a BORIS_EDITOR_URL line to connect manually.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
         } actions: {
             Button("Restart Host") {
                 session.restart()
@@ -116,6 +138,36 @@ struct EditorWindow: View {
             .controlSize(.small)
             .disabled(session.editorURL == nil && model.currentURL == nil)
         }
+    }
+
+    /// #237: Maps raw error messages from the session to actionable guidance.
+    private var errorGuidance: (headline: String, detail: String)? {
+        guard case .failed(let message) = session.phase else { return nil }
+        if message.contains("binary not found") {
+            return (
+                "boris-editor binary not found",
+                "Install boris-editor or set SOLIPSIST_BORIS_EDITOR_BIN in your environment."
+            )
+        }
+        if message.contains("did not report a token URL") {
+            return (
+                "Editor host did not report a token URL within 15s",
+                "The editor host may be slow to start. Try again or check the boris-editor logs."
+            )
+        }
+        if message.contains("exited (") {
+            return (
+                message,
+                "The editor host crashed. Check the boris-editor logs for details."
+            )
+        }
+        if message.contains("not available") {
+            return (
+                message,
+                "Ensure Boris is built and the engine binary is accessible."
+            )
+        }
+        return nil
     }
 
     private func header(for source: SourceItem) -> some View {
@@ -165,6 +217,7 @@ struct EditorWindow: View {
 
     private var toolbar: some View {
         VStack(alignment: .leading, spacing: 6) {
+            // Row 1: Nav + phase indicator + actions (always visible)
             HStack(spacing: 8) {
                 EditorNavButtons(model: model)
 
@@ -198,15 +251,16 @@ struct EditorWindow: View {
                 .disabled(!model.canOpenInBrowser)
             }
 
-            HStack(spacing: 8) {
-                TextField("BORIS_EDITOR_URL=http://127.0.0.1:49152/#token=…", text: $urlText)
-                    .textFieldStyle(.roundedBorder)
-                    .onSubmit(submit)
-                    .accessibilityLabel("Editor URL")
-
-                Button("Connect", action: submit)
-                    .accessibilityLabel("Connect")
-                    .accessibilityAddTraits(.isButton)
+            // #237: Row 2 — redacted URL (connected) or manual connect
+            // (idle/failed or toggled open)
+            if session.isConnected {
+                if showManualConnect {
+                    manualConnectRow
+                } else {
+                    redactedURLRow
+                }
+            } else if showManualConnect || session.isFailure || session.phase == .idle {
+                manualConnectRow
             }
 
             // #232: one-shot confirmation after an automatic reconnect.
@@ -223,6 +277,69 @@ struct EditorWindow: View {
             }
         }
         .padding(8)
+        .onChange(of: session.phase) { _, newPhase in
+            if case .connected = newPhase {
+                showManualConnect = false
+            } else {
+                showManualConnect = true
+            }
+        }
+    }
+
+    /// #237: Redacted URL row — shows `host:port` only, with full URL
+    /// in tooltip. Double-click reveals the manual connect field.
+    private var redactedURLRow: some View {
+        HStack(spacing: 8) {
+            if let url = session.editorURL {
+                let reduced = EditorURL.hostPort(for: url)
+                Text(reduced)
+                    .font(.caption.monospacedDigit())
+                    .lineLimit(1)
+                    .foregroundStyle(.secondary)
+                    .help(url.absoluteString)
+                    .onTapGesture(count: 2) {
+                        showManualConnect = true
+                    }
+                Spacer()
+            }
+
+            Button {
+                showManualConnect = true
+            } label: {
+                Image(systemName: "chevron.down")
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel("Show URL field")
+            .accessibilityAddTraits(.isButton)
+            .help("Reveal the manual URL field")
+        }
+    }
+
+    /// #237: Manual connect row — URL text field + Connect button.
+    /// Hidden by default when connected; shown when idle, failed, or toggled.
+    private var manualConnectRow: some View {
+        HStack(spacing: 8) {
+            TextField("BORIS_EDITOR_URL=http://127.0.0.1:49152/#token=…", text: $urlText)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(submit)
+                .accessibilityLabel("Editor URL")
+
+            Button("Connect", action: submit)
+                .accessibilityLabel("Connect")
+                .accessibilityAddTraits(.isButton)
+
+            if session.isConnected {
+                Button {
+                    showManualConnect = false
+                } label: {
+                    Image(systemName: "chevron.up")
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("Hide URL field")
+                .accessibilityAddTraits(.isButton)
+                .help("Hide the manual URL field")
+            }
+        }
     }
 
     private func submit() {

--- a/Sources/Companions/Preview/PreviewWindow.swift
+++ b/Sources/Companions/Preview/PreviewWindow.swift
@@ -12,6 +12,10 @@ import WebKit
 /// page owns the iframe + SSE auto-reload. Closing this window does not
 /// stop the watch — Play's reading pane reuses it. The toolbar keeps the
 /// manual loopback-paste escape hatch.
+///
+/// #234: Pinch-to-zoom (trackpad) and ⌘+/-/0 zoom controls are supported.
+/// Zoom level is persisted per-source in UserDefaults and restored when
+/// switching between sources.
 struct PreviewWindow: View {
     @Environment(WorkspaceStore.self) private var store
     @Environment(AppRuntime.self) private var runtime
@@ -33,6 +37,7 @@ struct PreviewWindow: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
                 .task(id: source.id) {
+                    model.setSource(id: source.id.raw.uuidString)
                     startPreview(for: source)
                 }
             } else {
@@ -50,6 +55,9 @@ struct PreviewWindow: View {
             } else {
                 model.loadBlank()
             }
+        }
+        .onChange(of: model.zoomLevel) { _, _ in
+            model.persistZoom()
         }
     }
 
@@ -138,6 +146,41 @@ struct PreviewWindow: View {
                 .accessibilityAddTraits(.isButton)
                 .help("Open in Browser")
                 .disabled(!model.canOpenInBrowser)
+
+                Divider().frame(height: 16)
+
+                Button {
+                    model.zoomOut()
+                } label: {
+                    Image(systemName: "minus.magnifyingglass")
+                }
+                .accessibilityLabel("Zoom Out")
+                .accessibilityAddTraits(.isButton)
+                .help("Zoom Out (⌘-)")
+
+                Text("\(Int(model.zoomLevel * 100))%")
+                    .font(.caption.monospacedDigit())
+                    .frame(minWidth: 40)
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+
+                Button {
+                    model.zoomIn()
+                } label: {
+                    Image(systemName: "plus.magnifyingglass")
+                }
+                .accessibilityLabel("Zoom In")
+                .accessibilityAddTraits(.isButton)
+                .help("Zoom In (⌘+)")
+
+                Button {
+                    model.zoomReset()
+                } label: {
+                    Image(systemName: "1.magnifyingglass")
+                }
+                .accessibilityLabel("Reset Zoom")
+                .accessibilityAddTraits(.isButton)
+                .help("Reset Zoom (⌘0)")
             }
             if let rejection = model.rejection {
                 Text(rejection)
@@ -149,6 +192,21 @@ struct PreviewWindow: View {
                 .foregroundStyle(session.isFailure ? Color.red : .secondary)
         }
         .padding(8)
+        .onKeyPress("+") {
+            guard NSEvent.modifierFlags.contains(.command) else { return .ignored }
+            model.zoomIn()
+            return .handled
+        }
+        .onKeyPress("-") {
+            guard NSEvent.modifierFlags.contains(.command) else { return .ignored }
+            model.zoomOut()
+            return .handled
+        }
+        .onKeyPress("0") {
+            guard NSEvent.modifierFlags.contains(.command) else { return .ignored }
+            model.zoomReset()
+            return .handled
+        }
     }
 
     private func submit() {
@@ -163,6 +221,10 @@ struct PreviewWindow: View {
 
 /// Owns the `WKWebView` and the tiny bit of navigation state the toolbar
 /// needs. Main-actor confined; the view is its only client.
+///
+/// #234: Pinch-to-zoom is enabled on the WKWebView; ⌘+/-/0 shortcuts
+/// drive `zoomIn()` / `zoomOut()` / `zoomReset()`. Zoom level is
+/// persisted per-source in UserDefaults.
 @MainActor
 @Observable
 final class PreviewWebModel {
@@ -171,6 +233,36 @@ final class PreviewWebModel {
     private(set) var currentURL: URL?
     private(set) var rejection: String?
 
+    /// #234: Current zoom level (1.0 = 100%). Published so the toolbar
+    /// percentage label can observe it. Synced from the WKWebView's
+    /// `magnification` via KVO.
+    private(set) var zoomLevel: CGFloat = 1.0
+
+    /// #234: Source ID for per-source zoom persistence in UserDefaults.
+    private var sourceID: String?
+
+    private static let minZoom: CGFloat = 0.25
+    private static let maxZoom: CGFloat = 4.0
+    private static let zoomStep: CGFloat = 1.25
+
+    /// KVO observation token for `webView.magnification`. Stored so the
+    /// observation survives across method calls and is cleaned up on
+    /// deinit. `nonisolated(unsafe)` so `deinit` can invalidate it.
+    private nonisolated(unsafe) var magnificationObservation: NSKeyValueObservation?
+
+    init() {
+        webView.allowsMagnification = true
+        magnificationObservation = webView.observe(\.magnification) { [weak self] webView, _ in
+            Task { @MainActor [weak self] in
+                self?.zoomLevel = webView.magnification
+            }
+        }
+    }
+
+    deinit {
+        magnificationObservation?.invalidate()
+    }
+
     var canReload: Bool {
         currentURL != nil || webView.url != nil
     }
@@ -178,6 +270,12 @@ final class PreviewWebModel {
     var canOpenInBrowser: Bool {
         guard let url = currentURL else { return false }
         return Self.isLoopback(url)
+    }
+
+    /// #234: Bind the source ID for per-source zoom persistence.
+    func setSource(id: String) {
+        sourceID = id
+        restoreZoom()
     }
 
     func loadBlank() {
@@ -214,6 +312,46 @@ final class PreviewWebModel {
         guard let url = currentURL, Self.isLoopback(url) else { return }
         NSWorkspace.shared.open(url)
     }
+
+    // MARK: - Zoom (#234)
+
+    /// Zoom in by 1.25× (matching trackpad feel), clamped to `maxZoom`.
+    func zoomIn() {
+        webView.magnification = min(webView.magnification * Self.zoomStep, Self.maxZoom)
+    }
+
+    /// Zoom out by 1/1.25×, clamped to `minZoom`.
+    func zoomOut() {
+        webView.magnification = max(webView.magnification / Self.zoomStep, Self.minZoom)
+    }
+
+    /// Reset zoom to 100%.
+    func zoomReset() {
+        webView.magnification = 1.0
+    }
+
+    /// #234: Restore the persisted zoom level for the current source.
+    /// Called from `setSource(id:)` and after the page finishes loading
+    /// to override any magnification reset that the navigation causes.
+    func restoreZoom() {
+        guard let sourceID else { return }
+        let stored = UserDefaults.standard.double(forKey: zoomKey(sourceID))
+        let level = stored > 0 ? stored : 1.0
+        webView.magnification = level
+    }
+
+    /// Called from the view's `onChange(of: zoomLevel)` to persist the
+    /// user's zoom preference per-source.
+    func persistZoom() {
+        guard let sourceID else { return }
+        UserDefaults.standard.set(Double(zoomLevel), forKey: zoomKey(sourceID))
+    }
+
+    private func zoomKey(_ sourceID: String) -> String {
+        "preview.zoom.\(sourceID)"
+    }
+
+    // MARK: - URL helpers
 
     private static func isAllowed(_ url: URL) -> Bool {
         PreviewURL.isAllowed(url)

--- a/Sources/Compose/ComposeDocument.swift
+++ b/Sources/Compose/ComposeDocument.swift
@@ -43,10 +43,13 @@ final class ComposeDocument {
     /// Whether the buffer differs from the last save/load.
     private(set) var isDirty = false
 
-    /// Cursor position for the status bar (#228). Updated by
-    /// `ComposeTextView.Coordinator` on every selection change.
+    /// Cursor position for the status bar (#228) and Go to Line (#238).
+    /// Updated by `ComposeTextView.Coordinator` on every selection change.
     var cursorLine: Int = 1
     var cursorColumn: Int = 1
+    /// #238: Total line count, updated alongside cursorLine for the Go to
+    /// Line dialog.
+    var totalLines: Int = 1
     /// Length of the current selection (0 = no selection). Used to show
     /// "42 selected" in place of the total character count.
     var selectedLength: Int = 0
@@ -92,6 +95,8 @@ final class ComposeDocument {
         let length = nsText.length
         let location = min(max(range.location, 0), length)
         selectedLength = min(max(range.length, 0), length - location)
+        // #238: Keep totalLines in sync for the Go to Line dialog.
+        totalLines = max(1, nsText.components(separatedBy: "\n").count)
 
         if length == 0 {
             cursorLine = 1

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -43,6 +43,11 @@ struct ComposeEditorView: View {
         "ComposeSplit-\(document.language.rawValue)"
     }
 
+    @State private var saveError: String?
+    /// #238: Go to Line — when set, the editor jumps to this line number.
+    @State private var goToLineTarget: Int?
+    @State private var showGoToLine = false
+
     var body: some View {
         VStack(spacing: 0) {
             toolbar
@@ -55,7 +60,8 @@ struct ComposeEditorView: View {
                 ComposeTextView(
                     document: document,
                     jumpToCharacter: jumpToCharacter,
-                    completion: cookCompletion
+                    completion: cookCompletion,
+                    jumpToLine: goToLineTarget
                 )
                 .id(document.fileURL)
                 .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)
@@ -94,6 +100,22 @@ struct ComposeEditorView: View {
         }
         .task(id: externalJump) {
             if let externalJump { jumpToCharacter = externalJump }
+        }
+        // #238: Go to Line — ⌘L opens the dialog via a hidden button
+        // (onKeyPress overload resolution is ambiguous in macOS 26).
+        .background {
+            Button("") { showGoToLine = true }
+                .keyboardShortcut("l", modifiers: .command)
+                .hidden()
+        }
+        .sheet(isPresented: $showGoToLine) {
+            GoToLineSheet(
+                isPresented: $showGoToLine,
+                currentLine: document.cursorLine,
+                totalLines: document.totalLines
+            ) { line in
+                goToLineTarget = line
+            }
         }
     }
 
@@ -245,5 +267,54 @@ private struct ComposeDiagnosticsPane: View {
             .accessibilityElement(children: .combine)
             .accessibilityLabel(diagnostic.accessibilityLabel)
         }
+    }
+}
+
+/// #238: "Go to Line" sheet — a compact dialog with a single text field
+/// for a 1-based line number. Pre-filled with the cursor's current line;
+/// validated and clamped before the jump.
+private struct GoToLineSheet: View {
+    @Binding var isPresented: Bool
+    let currentLine: Int
+    let totalLines: Int
+    var onJump: (Int) -> Void
+
+    @State private var lineNumber = ""
+    @FocusState private var isFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Go to line (of \(totalLines)):")
+                .font(.headline)
+            TextField("Line", text: $lineNumber)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 200)
+                .onSubmit(go)
+                .focused($isFieldFocused)
+                .onAppear {
+                    lineNumber = String(currentLine)
+                    isFieldFocused = true
+                }
+            HStack {
+                Button("Cancel") { isPresented = false }
+                    .keyboardShortcut(.cancelAction)
+                Button("Go") { go() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(Int(lineNumber) == nil)
+            }
+        }
+        .padding()
+        .frame(width: 280)
+        .onKeyPress(.escape) {
+            isPresented = false
+            return .handled
+        }
+    }
+
+    private func go() {
+        guard let line = Int(lineNumber), line >= 1 else { return }
+        let clamped = min(line, totalLines)
+        onJump(clamped)
+        isPresented = false
     }
 }

--- a/Sources/Compose/ComposeHighlighter.swift
+++ b/Sources/Compose/ComposeHighlighter.swift
@@ -48,6 +48,12 @@ enum ComposeHighlighter {
             }
         }
 
+        // #235: Autolink post-processing — paint the angle brackets of
+        // autolinks back to plain text so the URL is easier to read.
+        if language == .markdown {
+            paintAutolinkBrackets(text, in: result)
+        }
+
         // Front matter is data, not content: paint it last so no inner rule
         // (a `#` in YAML, an `@` in a cooklang ingredient list) bleeds in.
         if let frontmatter = ComposeDocument.Frontmatter.parse(in: text) {
@@ -144,6 +150,37 @@ enum ComposeHighlighter {
                 )
             }
         }
+
+        // #235: Autolink bracket post-processing for the repainted range.
+        if language == .markdown {
+            repaintAutolinkBrackets(text, in: range, storage: storage)
+        }
+    }
+
+    /// #235: Repaints the angle brackets of autolink matches within `range`
+    /// back to plain text. Extracted from `repaint` to keep cyclomatic
+    /// complexity under the lint threshold.
+    private static func repaintAutolinkBrackets(
+        _ text: String,
+        in range: NSRange,
+        storage: NSMutableAttributedString
+    ) {
+        let nsText = text as NSString
+        guard let regex = try? NSRegularExpression(pattern: "<[^<>\\s]+>", options: []) else { return }
+        let full = NSRange(location: 0, length: nsText.length)
+        let plain = ComposeHighlightStyle.plain
+        regex.enumerateMatches(in: text, range: full) { match, _, _ in
+            guard let match, match.range.length > 2 else { return }
+            let leadingBracket = NSRange(location: match.range.location, length: 1)
+            let trailingBracket = NSRange(
+                location: match.range.location + match.range.length - 1,
+                length: 1
+            )
+            let hitLead = NSIntersectionRange(leadingBracket, range)
+            if hitLead.length > 0 { paint(plain, over: hitLead, in: storage) }
+            let hitTrail = NSIntersectionRange(trailingBracket, range)
+            if hitTrail.length > 0 { paint(plain, over: hitTrail, in: storage) }
+        }
     }
 
     // MARK: - Palette
@@ -176,13 +213,17 @@ enum ComposeHighlighter {
     // MARK: - Markdown (CommonMark 0.31.2 + Oliver's opt-in extensions)
 
     private static let markdownRules: [ComposeHighlightRule] = [
+        // #235: HTML comments — paint first so inline rules paint over them
+        // inside non-comment regions.
+        rule(#"<!--[\s\S]*?-->"#, comment, dotMatches: true),
         // Inline: emphasis family first, widest delimiter runs first.
         rule(#"(\*\*\*|___)(?=\S)(.+?)(?<=\S)\1"#, strong),
         rule(#"(?<![*_])(\*\*|__)(?=\S)(.+?)(?<=\S)\1(?!\1)(?![*_])"#, strong),
         rule(#"(?<![*_])(\*|_)(?!\1)(?=\S)(.+?)(?<=\S)\1(?!\1)(?![*_])"#, emphasis),
         rule(#"~~[^~\n]+~~"#, emphasis),
-        rule(#"`[^`\n]+`"#, code),
-        // Links before images so the image rule repaints the whole construct.
+        // #235: Code spans — match across newlines so **bold** inside
+        // multi-line backtick spans stays green (code wins by paint order).
+        rule(#"`[^`]+`"#, code),
         rule(#"\[([^\]\n]+)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)"#, link),
         rule(#"\[([^\]\n]+)\](?:\[([^\]\n]*)\])?"#, link),
         rule(#"!\[([^\]\n]*)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)"#, image),
@@ -195,7 +236,10 @@ enum ComposeHighlighter {
         // Blocks.
         // Oliver extension: > [!note] callouts (docs/CALLOUTS.md).
         rule(#"^>[ \t]*\[![A-Za-z0-9-]+\][^\n]*"#, callout),
-        rule(#"^(#{1,6})(?:[ \t]+.*)?$"#, heading, anchors: true),
+        // #235: ATX headings require at least one space after the hashes
+        // so YAML comments (# inside front-matter block scalars) are not
+        // painted as headings.
+        rule(#"^(#{1,6})[ \t]+[^\n]*"#, heading, anchors: true),
         rule(#"^[ \t]*=+[ \t]*$"#, heading, anchors: true),
         rule(#"^[ \t]*(-{3,}|\*{3,}|_{3,})[ \t]*$"#, quote, anchors: true),
         rule(#"^>[ \t]?"#, quote, anchors: true),
@@ -251,8 +295,9 @@ enum ComposeHighlighter {
         // Timers: ~name{3%minutes} / ~{25%minutes} / ~rest.
         rule(#"~\{[^}\n]*\}"#, timer),
         rule(#"~[^\s@#~{]+(?:\{[^}\n]*\})?"#, timer),
-        // Steps, notes, sections, comments.
-        rule(#"^>[ \t]?[^\n]*"#, note, anchors: true),
+        // #235: Notes — match consecutive > lines as a single block so the
+        // note paint covers the entire note, not individual lines.
+        rule(#"(?:^>[^\n]*\n?)+"#, note, anchors: true, dotMatches: true),
         rule(#"^=+[ \t]*[^\n]*"#, heading, anchors: true),
         rule(#"^--[^\n]*"#, comment, anchors: true),
         rule(#"\[-[^]*?-\]"#, comment, dotMatches: true),
@@ -285,6 +330,33 @@ enum ComposeHighlighter {
             let italic = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
                 .withTraits(.italic)
             attributed.addAttribute(.font, value: italic, range: range)
+        }
+    }
+
+    // MARK: - #235 Autolink post-processing
+
+    /// #235: Paints the angle brackets of autolinks (`<url>`) back to plain
+    /// text so the URL itself is easier to read. Runs after all rules have
+    /// been applied. Only fires for Markdown (autolinks are a CommonMark
+    /// feature; Cooklang and Textile use different link syntax).
+    private static func paintAutolinkBrackets(_ text: String, in attributed: NSMutableAttributedString) {
+        let nsText = text as NSString
+        let full = NSRange(location: 0, length: nsText.length)
+        // Match autolinks: <scheme:path> or <user@host>
+        guard let regex = try? NSRegularExpression(
+            pattern: "<[^<>\\s]+>",
+            options: []
+        ) else { return }
+        let plain = ComposeHighlightStyle.plain
+        regex.enumerateMatches(in: text, range: full) { match, _, _ in
+            guard let match, match.range.length > 2 else { return }
+            let leadingBracket = NSRange(location: match.range.location, length: 1)
+            let trailingBracket = NSRange(
+                location: match.range.location + match.range.length - 1,
+                length: 1
+            )
+            paint(plain, over: leadingBracket, in: attributed)
+            paint(plain, over: trailingBracket, in: attributed)
         }
     }
 }

--- a/Sources/Compose/ComposeTextView.swift
+++ b/Sources/Compose/ComposeTextView.swift
@@ -10,13 +10,15 @@ import SwiftUI
 /// `NSScrollView` (which conforms to `NSTextFinderBarContainer`). This gives
 /// ⌘F / ⌘⌥F / ⌘G / ⇧⌘G, wrap-around, case-insensitive and regex toggles for
 /// free — no custom UI.
-struct ComposeTextView: NSViewRepresentable {
+struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_body_length
     @Bindable var document: ComposeDocument
     /// Click-to-line target (LATER-3.1); nil = no pending jump.
     var jumpToCharacter: Int?
     /// Cooklang completion vocabulary (LATER-3.4); `.empty` disables the
     /// popup. Sourced from the selected source's `.boris/` artifacts.
     var completion: ComposeCookCompletion = .empty
+    /// #238: Go to Line — 1-based line number to jump to; nil = no pending jump.
+    var jumpToLine: Int?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(document: document, completion: completion)
@@ -69,6 +71,7 @@ struct ComposeTextView: NSViewRepresentable {
 
         scrollView.documentView = textView
         context.coordinator.textView = textView
+        context.coordinator.hostedTextView = textView
         context.coordinator.scrollView = scrollView
 
         context.coordinator.applyHighlight(
@@ -115,6 +118,9 @@ struct ComposeTextView: NSViewRepresentable {
             context.coordinator.applyHighlight(textView, text: document.text, language: document.language)
         }
         context.coordinator.jump(to: jumpToCharacter, in: textView)
+        if let jumpToLine {
+            context.coordinator.jumpToLine(jumpToLine)
+        }
         document.updateCursor(textView.selectedRange())
         context.coordinator.updateGutterWidth()
         // Keep gutter height in sync with textView content height
@@ -142,6 +148,9 @@ struct ComposeTextView: NSViewRepresentable {
         private var isApplying = false
         /// Last click-to-line offset we applied, so re-syncs do not re-jump.
         private var lastJumpedCharacter: Int?
+        /// #238: Weak reference to the hosted NSTextView, set once during
+        /// `makeNSView` so `jumpToLine` can register undo and scroll.
+        weak var hostedTextView: NSTextView?
 
         /// Last state we painted, so programmatic syncs (which fire on every
         /// `document` change) do not re-paint an unchanged buffer.
@@ -295,6 +304,39 @@ struct ComposeTextView: NSViewRepresentable {
             let nsString = textView.string as NSString
             let clamped = min(max(character, 0), nsString.length)
             let range = NSRange(location: clamped, length: 0)
+            textView.setSelectedRange(range)
+            textView.scrollRangeToVisible(range)
+        }
+
+        /// #238: Jump to a 1-based line number. Registers the current cursor
+        /// position in the undo stack so ⌘Z restores it. Clamps to the
+        /// buffer range; empty buffers jump to offset 0.
+        func jumpToLine(_ line: Int) {
+            guard let textView = hostedTextView else { return }
+            let nsString = textView.string as NSString
+            guard nsString.length > 0 else { return }
+            let currentRange = textView.selectedRange()
+            let undoManager = textView.undoManager
+            undoManager?.registerUndo(withTarget: textView) { target in
+                target.setSelectedRange(currentRange)
+                target.scrollRangeToVisible(currentRange)
+            }
+            undoManager?.setActionName("Go to Line")
+            let totalLines = max(1, nsString.components(separatedBy: "\n").count)
+            let clamped = max(1, min(line, totalLines))
+            var foundLine = 1
+            var targetLocation = 0
+            nsString.enumerateSubstrings(
+                in: NSRange(location: 0, length: nsString.length),
+                options: [.byLines, .substringNotRequired]
+            ) { _, range, _, stop in
+                if foundLine == clamped {
+                    targetLocation = range.location
+                    stop.pointee = true
+                }
+                foundLine += 1
+            }
+            let range = NSRange(location: targetLocation, length: 0)
             textView.setSelectedRange(range)
             textView.scrollRangeToVisible(range)
         }

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -283,9 +283,40 @@ struct LocalPlay: PlaySurface {
                 }
                 .listStyle(.inset)
                 .safeAreaPadding(.top, toolbarBand)
+                // #233: keyboard navigation — Return (Compose), ⌘Return (Editor),
+                // Escape (deselect), Page Up/Down (scroll by page), Home/End.
                 .onKeyPress(.return) {
                     guard store.selection.canEditPage else { return .ignored }
                     openWindow(id: CompanionID.compose)
+                    return .handled
+                }
+                .onKeyPress(.return) {
+                    guard NSEvent.modifierFlags.contains(.command),
+                          store.selection.canEditPage else { return .ignored }
+                    openWindow(id: CompanionID.editor)
+                    return .handled
+                }
+                .onKeyPress(.escape) {
+                    if store.selection.noun != nil {
+                        store.select(noun: nil)
+                        return .handled
+                    }
+                    return .ignored
+                }
+                .onKeyPress(.pageUp) {
+                    scrollList(by: -pageScrollCount(filtered))
+                    return .handled
+                }
+                .onKeyPress(.pageDown) {
+                    scrollList(by: pageScrollCount(filtered))
+                    return .handled
+                }
+                .onKeyPress(.home) {
+                    if let first = filtered.first { selectPage(first) }
+                    return .handled
+                }
+                .onKeyPress(.end) {
+                    if let last = filtered.last { selectPage(last) }
                     return .handled
                 }
             }
@@ -295,6 +326,28 @@ struct LocalPlay: PlaySurface {
             placement: .toolbar,
             prompt: "Filter by title, id, tag, or status…"
         )
+    }
+
+    /// #233: Scroll the Pages list by approximately one visible page height.
+    /// The estimate uses a fixed row height (28pt, matching `PageRow`'s
+    /// compact layout) and the list's frame height minus chrome.
+    private func scrollList(by offset: Int) {
+        guard !loadedPages.isEmpty else { return }
+        let filtered = LocalPlayGraph.filter(pages: loadedPages, query: searchText)
+        guard !filtered.isEmpty else { return }
+        let currentID = store.selection.noun?.id
+        let currentIndex = currentID.flatMap { id in filtered.firstIndex(where: { $0.id == id }) } ?? 0
+        let targetIndex = max(0, min(filtered.count - 1, currentIndex + offset))
+        selectPage(filtered[targetIndex])
+    }
+
+    /// #233: Estimated number of list rows per visible page. Uses 28pt
+    /// (compact `PageRow` height) and a minimum list height of 90pt for
+    /// the top pane.
+    private func pageScrollCount(_ pages: [PlayPage]) -> Int {
+        let listHeight = max(topHeight, 90)
+        let rowHeight: CGFloat = 28
+        return max(1, Int(listHeight / rowHeight))
     }
 
     private var selectedPageID: Binding<String?> {


### PR DESCRIPTION
Implements five M18 Editor Polish issues (#233-#235, #237-#238):

**#234 Preview pinch-to-zoom**: enables WKWebView magnification (0.25x-4x) with Cmd+/-/0 keyboard shortcuts, toolbar zoom controls, and per-source zoom persistence in UserDefaults.

**#233 Pages list keyboard navigation**: Cmd+Return opens Editor companion, Escape deselects the current page, Page Up/Down scroll by one page height, Home/End jump to first/last page.

**#238 Compose Go to Line (Cmd+L)**: compact sheet dialog pre-filled with current cursor line, validates/clamps input, registers undo so Cmd+Z restores the previous position.

**#237 Editor companion UX polish**: toolbar collapses URL field + Connect behind a disclosure toggle; connected state shows redacted host:port; error states display actionable guidance (binary not found, timeout, crash).

**#235 Compose highlighting edge cases**: multi-line code spans now match across newlines; HTML comments painted as secondary italic; autolink angle brackets painted plain; ATX heading regex requires space after hashes to avoid YAML false positives; Cooklang multi-line notes paint as a single block.
