### PR TITLE
compose: formatting toolbar + preview options popover (#263)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -134,6 +134,8 @@ targets:
       - path: Sources/Compose/ComposeLineGutter.swift
       - path: Sources/Compose/ComposeTabIndent.swift
       - path: Sources/Compose/ComposeTextView.swift
+      - path: Sources/Compose/ComposeFormat.swift
+      - path: Sources/Compose/ComposeFormatToolbar.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.drawmeanelephant.solipsist.contracttests

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -38,6 +38,9 @@ struct ComposeEditorView: View {
     /// LATER-3.3: leading pane editing the closed front-matter key set.
     @State private var showFrontmatter = false
     @State private var previewOptions = MarkupRenderOptions()
+    /// #263: toolbar-to-text-view seam for formatting verbs.
+    @State private var formatApplier = ComposeFormatApplier()
+    @State private var showPreviewOptions = false
 
     private var autosaveName: String {
         "ComposeSplit-\(document.language.rawValue)"
@@ -61,7 +64,8 @@ struct ComposeEditorView: View {
                     document: document,
                     jumpToCharacter: jumpToCharacter,
                     completion: cookCompletion,
-                    jumpToLine: goToLineTarget
+                    jumpToLine: goToLineTarget,
+                    formatApplier: formatApplier
                 )
                 .id(document.fileURL)
                 .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)
@@ -157,10 +161,11 @@ struct ComposeEditorView: View {
             .accessibilityLabel("Language, currently \(document.language.displayName)")
             .accessibilityHint("Select the authoring frontend")
 
-            Text(document.language.conformanceNote)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
+            // #263: formatting up front; hidden for Cooklang (recipes are
+            // not prose).
+            if document.language.supportsFormatting {
+                ComposeFormatToolbar(applier: formatApplier)
+            }
 
             Spacer()
 
@@ -182,14 +187,17 @@ struct ComposeEditorView: View {
             .accessibilityHint("Show or hide the front matter editor.")
             .accessibilityAddTraits(showFrontmatter ? .isSelected : [])
 
-            Menu {
-                previewOptionsContent
+            Button {
+                showPreviewOptions = true
             } label: {
-                Label("Render Options", systemImage: "slider.horizontal.3")
+                Label("Preview Options", systemImage: "slider.horizontal.3")
             }
             .help("Oliver ParseOptions — every extension is off by default.")
-            .accessibilityLabel("Render Options")
+            .accessibilityLabel("Preview Options")
             .accessibilityHint("Configure Oliver's parse extensions.")
+            .popover(isPresented: $showPreviewOptions, arrowEdge: .bottom) {
+                previewOptionsPopover
+            }
 
             Button {
                 // #231: never write here. The host's save flow wraps the
@@ -207,6 +215,25 @@ struct ComposeEditorView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
+    }
+
+    /// #263: today's Render Options content verbatim (values and defaults
+    /// unchanged — all-off stays the Oliver contract default), plus a
+    /// reset-to-defaults button and the conformance note as footnote.
+    private var previewOptionsPopover: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            previewOptionsContent
+            Divider()
+            Button("Reset to Defaults") {
+                previewOptions = MarkupRenderOptions()
+            }
+            .help("Restore every option to its off-by-default value")
+            Text(document.language.conformanceNote)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .frame(width: 280, alignment: .leading)
     }
 
     /// Author-facing extension surface, mirroring Oliver's `ParseOptions`:

--- a/Sources/Compose/ComposeFormat.swift
+++ b/Sources/Compose/ComposeFormat.swift
@@ -1,0 +1,346 @@
+import Foundation
+
+/// #263: formatting verbs for the compose toolbar. Each verb compiles to a
+/// pure buffer transform derived from Oliver's documented Markdown / Textile
+/// syntax — no grammar invention, no parse. Boris/Oliver own semantics; this
+/// only types markers faster than the author would.
+enum ComposeFormat {
+    case bold
+    case italic
+    case strikethrough
+    /// Level 1–3: ATX `#` runs in Markdown, `hN.` labels in Textile.
+    case heading(level: Int)
+    case link
+    case codeSpan
+    case bulletList
+    case numberedList
+    case quote
+
+    /// Heading levels offered in the toolbar menu.
+    static let headingLevels = [1, 2, 3]
+
+    /// Undo-stack action name for one toolbar press.
+    var actionName: String {
+        switch self {
+        case .bold: return "Bold"
+        case .italic: return "Italic"
+        case .strikethrough: return "Strikethrough"
+        case .heading(let level): return "Heading \(level)"
+        case .link: return "Link"
+        case .codeSpan: return "Code"
+        case .bulletList: return "Bulleted List"
+        case .numberedList: return "Numbered List"
+        case .quote: return "Block Quote"
+        }
+    }
+
+    /// Applies the format to a buffer at a UTF-16 selection. Returns nil
+    /// when the language has no marker table for the verb (Cooklang).
+    static func apply(
+        _ format: ComposeFormat,
+        to text: String,
+        selectedRange rawSelection: NSRange,
+        language: ComposeLanguage
+    ) -> ComposeFormatEdit? {
+        guard language.supportsFormatting else { return nil }
+        let nsString = text as NSString
+        let selection = clamp(rawSelection, length: nsString.length)
+        switch format {
+        case .bold, .italic, .strikethrough, .codeSpan:
+            return wrapped(format, selection: selection, nsString: nsString, language: language)
+        case .link:
+            return linked(selection: selection, nsString: nsString, language: language)
+        case .heading, .bulletList, .numberedList, .quote:
+            return prefixed(format, selection: selection, nsString: nsString, language: language)
+        }
+    }
+}
+
+extension ComposeLanguage {
+    /// Cooklang recipes are not prose; the formatting row hides itself.
+    var supportsFormatting: Bool {
+        self != .cooklang
+    }
+}
+
+/// The outcome of a formatting transform (#263): which span of the original
+/// buffer changes, what replaces it, and where the selection lands in the
+/// resulting buffer. All offsets are UTF-16 (NSRange units).
+struct ComposeFormatEdit {
+    let replacedRange: NSRange
+    let replacement: String
+    let selection: NSRange
+}
+
+// MARK: - Transforms
+
+private extension ComposeFormat {
+    static func clamp(_ range: NSRange, length: Int) -> NSRange {
+        let location = min(max(range.location, 0), length)
+        let end = min(max(range.location + range.length, location), length)
+        return NSRange(location: location, length: end - location)
+    }
+
+    // MARK: Inline wraps
+
+    /// Marker pairs per (verb, language), mirroring Oliver's documented
+    /// surface. Nil = the pair does not exist for that frontend.
+    static func inlinePair(
+        _ format: ComposeFormat,
+        language: ComposeLanguage
+    ) -> (open: String, close: String)? {
+        switch (format, language) {
+        case (.bold, .markdown): return ("**", "**")
+        case (.italic, .markdown): return ("*", "*")
+        case (.strikethrough, .markdown): return ("~~", "~~")
+        case (.codeSpan, .markdown): return ("`", "`")
+        case (.bold, .textile): return ("*", "*")
+        case (.italic, .textile): return ("_", "_")
+        case (.strikethrough, .textile): return ("-", "-")
+        case (.codeSpan, .textile): return ("@", "@")
+        default: return nil
+        }
+    }
+
+    /// Wrap: with a selection, enclose it and keep the enclosed text selected;
+    /// with an empty selection, insert the marker pair and place the cursor
+    /// inside.
+    static func wrapped(
+        _ format: ComposeFormat,
+        selection: NSRange,
+        nsString: NSString,
+        language: ComposeLanguage
+    ) -> ComposeFormatEdit? {
+        guard let pair = inlinePair(format, language: language) else { return nil }
+        let selected = nsString.substring(with: selection)
+        let replacement = pair.open + selected + pair.close
+        let openLength = (pair.open as NSString).length
+        return ComposeFormatEdit(
+            replacedRange: selection,
+            replacement: replacement,
+            selection: NSRange(location: selection.location + openLength, length: selected.count)
+        )
+    }
+
+    /// Link: `[text](url)` (Markdown) or `"text":url` (Textile) with the
+    /// text kept selected for typing over; an empty selection inserts the
+    /// placeholder word selected.
+    static func linked(
+        selection: NSRange,
+        nsString: NSString,
+        language: ComposeLanguage
+    ) -> ComposeFormatEdit? {
+        let selected = nsString.substring(with: selection)
+        let placeholder = selected.isEmpty ? "text" : selected
+        let replacement: String
+        switch language {
+        case .markdown: replacement = "[\(placeholder)](url)"
+        case .textile: replacement = "\"\(placeholder)\":url"
+        case .cooklang: return nil
+        }
+        let lead = ((language == .markdown) ? "[" : "\"") as NSString
+        return ComposeFormatEdit(
+            replacedRange: selection,
+            replacement: replacement,
+            selection: NSRange(
+                location: selection.location + lead.length,
+                length: (placeholder as NSString).length
+            )
+        )
+    }
+
+    // MARK: Line prefixes
+
+    /// One per-line prefix application: replace `range` (usually an empty
+    /// span at the line start) with `text`.
+    struct LineEdit {
+        let range: NSRange
+        let text: String
+    }
+
+    /// Expand the selection to whole lines and prefix each one.
+    static func prefixed(
+        _ format: ComposeFormat,
+        selection: NSRange,
+        nsString: NSString,
+        language: ComposeLanguage
+    ) -> ComposeFormatEdit? {
+        let expanded = nsString.lineRange(for: selection)
+        var edits: [LineEdit] = []
+
+        if expanded.length == 0 {
+            // Empty buffer (or clamped-to-end zero selection): insert the
+            // prefix and leave the cursor after it.
+            if let edit = lineEdit(
+                format, line: expanded, counter: 1, nsString: nsString, language: language
+            ) {
+                edits.append(edit)
+            }
+        } else {
+            appendEdits(
+                format, into: &edits, span: expanded, nsString: nsString, language: language
+            )
+        }
+
+        guard !edits.isEmpty, let replacement = assemble(edits, over: expanded, in: nsString)
+        else { return nil }
+        return ComposeFormatEdit(
+            replacedRange: expanded,
+            replacement: replacement,
+            selection: mappedSelection(selection, edits: edits)
+        )
+    }
+
+    /// Walks the lines of `span`, appending one edit per affected line.
+    static func appendEdits(
+        _ format: ComposeFormat,
+        into edits: inout [LineEdit],
+        span: NSRange,
+        nsString: NSString,
+        language: ComposeLanguage
+    ) {
+        let end = span.location + span.length
+        var position = span.location
+        var counter = 1
+        while position < end {
+            let newline = nsString.range(
+                of: "\n",
+                options: [],
+                range: NSRange(location: position, length: end - position)
+            )
+            let lineContentEnd = newline.location == NSNotFound ? end : newline.location
+            if let edit = lineEdit(
+                format, line: NSRange(location: position, length: lineContentEnd - position),
+                counter: counter, nsString: nsString, language: language
+            ) {
+                edits.append(edit)
+            }
+            counter += 1
+            if newline.location == NSNotFound { break }
+            position = newline.location + 1
+        }
+    }
+
+    /// Prefix for a line: lists and quotes prepend; headings replace an
+    /// existing same-family heading label so levels do not stack.
+    static func lineEdit(
+        _ format: ComposeFormat,
+        line: NSRange,
+        counter: Int,
+        nsString: NSString,
+        language: ComposeLanguage
+    ) -> LineEdit? {
+        let lineStart = line.location
+        let prefix: String
+        switch format {
+        case .heading(let level):
+            prefix = language == .markdown
+                ? String(repeating: "#", count: level) + " "
+                : "h\(level). "
+        case .bulletList:
+            prefix = language == .markdown ? "- " : "* "
+        case .numberedList:
+            prefix = language == .markdown ? "\(counter). " : "# "
+        case .quote:
+            prefix = language == .markdown ? "> " : "bq. "
+        default:
+            return nil
+        }
+
+        // Headings replace an existing heading label instead of stacking.
+        if case .heading = format {
+            let existingEnd = existingHeadingLabelEnd(line, nsString: nsString, language: language)
+            if let existingEnd {
+                return LineEdit(
+                    range: NSRange(location: lineStart, length: existingEnd - lineStart),
+                    text: prefix
+                )
+            }
+        }
+
+        return LineEdit(
+            range: NSRange(location: lineStart, length: 0),
+            text: prefix
+        )
+    }
+
+    /// End offset of a heading label at the line start (`#…␣` in Markdown,
+    /// `hN.`/`hN.␣` in Textile), or nil when the line does not open with one.
+    static func existingHeadingLabelEnd(
+        _ line: NSRange,
+        nsString: NSString,
+        language: ComposeLanguage
+    ) -> Int? {
+        func character(_ index: Int) -> unichar {
+            index < NSMaxRange(line) ? nsString.character(at: index) : 0
+        }
+        if language == .markdown {
+            var index = line.location
+            var hashes = 0
+            while character(index) == 35 { // "#"
+                hashes += 1
+                index += 1
+            }
+            guard hashes >= 1, hashes <= 6, character(index) == 32 else { return nil } // "␣"
+            return index + 1
+        }
+        guard line.length >= 3,
+              character(line.location) == 104, // "h"
+              character(line.location + 1) >= 49, // "1"
+              character(line.location + 1) <= 54, // "6"
+              character(line.location + 2) == 46 // "."
+        else { return nil }
+        return character(line.location + 3) == 32 ? line.location + 4 : line.location + 3 // "␣"
+    }
+
+    /// Rebuild the expanded span: original content with each prefix spliced
+    /// in at its line start.
+    static func assemble(
+        _ edits: [LineEdit],
+        over expanded: NSRange,
+        in nsString: NSString
+    ) -> String? {
+        let end = NSMaxRange(expanded)
+        var pieces: [String] = []
+        var cursor = expanded.location
+        for edit in edits {
+            if edit.range.location > cursor {
+                pieces.append(
+                    nsString.substring(
+                        with: NSRange(location: cursor, length: edit.range.location - cursor)
+                    )
+                )
+            }
+            pieces.append(edit.text)
+            cursor = max(cursor, NSMaxRange(edit.range))
+        }
+        if cursor < end {
+            pieces.append(nsString.substring(with: NSRange(location: cursor, length: end - cursor)))
+        }
+        return pieces.joined()
+    }
+
+    /// Carets land after the inserted prefix; ranges stay mapped onto the
+    /// same text, so a prefix inserted at the range's own line start does
+    /// not push the range forward.
+    static func mappedSelection(_ selection: NSRange, edits: [LineEdit]) -> NSRange {
+        let caretsIncludeAtOffset = selection.length == 0
+
+        func shifted(_ offset: Int) -> Int {
+            var delta = 0
+            for edit in edits {
+                let counts = caretsIncludeAtOffset
+                    ? edit.range.location <= offset
+                    : edit.range.location < offset
+                if counts {
+                    delta += (edit.text as NSString).length - edit.range.length
+                }
+            }
+            return offset + delta
+        }
+
+        let newStart = shifted(selection.location)
+        let newEnd = shifted(selection.location + selection.length)
+        return NSRange(location: newStart, length: newEnd - newStart)
+    }
+}

--- a/Sources/Compose/ComposeFormatToolbar.swift
+++ b/Sources/Compose/ComposeFormatToolbar.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// Seam between the SwiftUI toolbar and the AppKit text-view coordinator
+/// (#263). The hosted view registers its applier; toolbar buttons publish.
+@MainActor
+final class ComposeFormatApplier: ObservableObject {
+    /// Registered by the hosted text view; weakly captures its coordinator.
+    var handler: ((ComposeFormat) -> Void)?
+
+    func send(_ format: ComposeFormat) {
+        handler?(format)
+    }
+}
+
+/// The formatting row (#263): Bold · Italic · Strikethrough · Heading ·
+/// Link · Code · Bullet · Numbered · Quote, hidden entirely for Cooklang.
+struct ComposeFormatToolbar: View {
+    let applier: ComposeFormatApplier
+
+    var body: some View {
+        HStack(spacing: 2) {
+            wrapButton(.bold, icon: "bold", name: "Bold", hint: "Wrap the selection in bold markers")
+            wrapButton(
+                .italic, icon: "italic", name: "Italic",
+                hint: "Wrap the selection in italic markers"
+            )
+            wrapButton(
+                .strikethrough, icon: "strikethrough", name: "Strikethrough",
+                hint: "Wrap the selection in strikethrough markers"
+            )
+
+            Menu {
+                ForEach(ComposeFormat.headingLevels, id: \.self) { level in
+                    Button("Heading \(level)") {
+                        applier.send(.heading(level: level))
+                    }
+                }
+            } label: {
+                Text("H")
+                    .frame(minWidth: 14)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help("Heading level")
+            .accessibilityLabel("Heading")
+            .accessibilityHint("Apply a heading level to the selected lines")
+
+            wrapButton(.link, icon: "link", name: "Link", hint: "Turn the selection into a link")
+            wrapButton(
+                .codeSpan, icon: "chevron.left.forwardslash.chevron.right", name: "Code span",
+                hint: "Wrap the selection in inline code markers"
+            )
+            wrapButton(
+                .bulletList, icon: "list.bullet", name: "Bulleted list",
+                hint: "Prefix every selected line with a bullet marker"
+            )
+            wrapButton(
+                .numberedList, icon: "list.numbered", name: "Numbered list",
+                hint: "Prefix every selected line with an ordered-list marker"
+            )
+            wrapButton(
+                .quote, icon: "text.quote", name: "Block quote",
+                hint: "Prefix every selected line with a quote marker"
+            )
+        }
+        .buttonStyle(.borderless)
+    }
+
+    private func wrapButton(
+        _ format: ComposeFormat,
+        icon: String,
+        name: String,
+        hint: String
+    ) -> some View {
+        Button {
+            applier.send(format)
+        } label: {
+            Image(systemName: icon)
+        }
+        .help(name)
+        .accessibilityLabel(name)
+        .accessibilityHint(hint)
+    }
+}

--- a/Sources/Compose/ComposeTextView.swift
+++ b/Sources/Compose/ComposeTextView.swift
@@ -19,6 +19,9 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
     var completion: ComposeCookCompletion = .empty
     /// #238: Go to Line — 1-based line number to jump to; nil = no pending jump.
     var jumpToLine: Int?
+    /// #263: toolbar-to-coordinator seam; the editor view owns the bus and
+    /// the coordinator registers its applier on it.
+    var formatApplier: ComposeFormatApplier?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(document: document, completion: completion)
@@ -56,16 +59,7 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
         textView.usesFindPanel = false
         textView.isIncrementalSearchingEnabled = true
 
-        // #226 Line numbers gutter: lightweight overlay as subview of the
-        // textView so it scrolls vertically with the buffer but stays fixed
-        // horizontally (widthTracksTextView disables horizontal scroll).
-        let gutter = ComposeLineGutter()
-        gutter.textView = textView
-        gutter.frame = NSRect(x: 0, y: 0, width: 36, height: textView.bounds.height)
-        gutter.autoresizingMask = [.height]
-        gutter.wantsLayer = true
-        // Reserve 36pt for the gutter + keep 10pt original inset as gap.
-        textView.textContainer?.lineFragmentPadding = 36
+        let gutter = makeGutter(for: textView)
         textView.addSubview(gutter)
         context.coordinator.gutter = gutter
 
@@ -73,6 +67,7 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
         context.coordinator.textView = textView
         context.coordinator.hostedTextView = textView
         context.coordinator.scrollView = scrollView
+        registerFormatApplier(context.coordinator)
 
         context.coordinator.applyHighlight(
             textView,
@@ -87,12 +82,27 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
         return scrollView
     }
 
+    /// #226 Line numbers gutter: lightweight overlay as subview of the
+    /// textView so it scrolls vertically with the buffer but stays fixed
+    /// horizontally (widthTracksTextView disables horizontal scroll).
+    private func makeGutter(for textView: NSTextView) -> ComposeLineGutter {
+        let gutter = ComposeLineGutter()
+        gutter.textView = textView
+        gutter.frame = NSRect(x: 0, y: 0, width: 36, height: textView.bounds.height)
+        gutter.autoresizingMask = [.height]
+        gutter.wantsLayer = true
+        // Reserve 36pt for the gutter + keep 10pt original inset as gap.
+        textView.textContainer?.lineFragmentPadding = 36
+        return gutter
+    }
+
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? NSTextView else { return }
         context.coordinator.document = document
         context.coordinator.completion = completion
         context.coordinator.textView = textView
         context.coordinator.scrollView = scrollView
+        registerFormatApplier(context.coordinator)
         // Re-bind gutter if view was recreated (SwiftUI .id)
         if let gutter = context.coordinator.gutter, gutter.superview !== textView {
             gutter.textView = textView
@@ -134,6 +144,15 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
 
     private var baseFont: NSFont {
         NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    }
+
+    /// #263: point the toolbar bus at this coordinator (weakly — the bus is
+    /// owned by the SwiftUI view and outlives view rebuilds).
+    private func registerFormatApplier(_ coordinator: Coordinator) {
+        guard let formatApplier else { return }
+        formatApplier.handler = { [weak coordinator] format in
+            coordinator?.apply(format)
+        }
     }
 
     @MainActor
@@ -339,6 +358,35 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
             let range = NSRange(location: targetLocation, length: 0)
             textView.setSelectedRange(range)
             textView.scrollRangeToVisible(range)
+        }
+
+        /// #263: applies a toolbar format at the current selection. The
+        /// mutation flows through `shouldChangeText` / `didChangeText` so the
+        /// undo stack records one group per press and the ordinary
+        /// `textDidChange` delegate path (buffer sync + repaint) runs
+        /// unchanged.
+        func apply(_ format: ComposeFormat) {
+            guard let textView, document.language.supportsFormatting else { return }
+            guard
+                let edit = ComposeFormat.apply(
+                    format,
+                    to: textView.string,
+                    selectedRange: textView.selectedRange(),
+                    language: document.language
+                )
+            else { return }
+            let undoManager = textView.undoManager
+            undoManager?.beginUndoGrouping()
+            defer { undoManager?.endUndoGrouping() }
+            undoManager?.setActionName(format.actionName)
+            if textView.shouldChangeText(in: edit.replacedRange, replacementString: edit.replacement) {
+                textView.textStorage?.replaceCharacters(
+                    in: edit.replacedRange,
+                    with: edit.replacement
+                )
+                textView.didChangeText()
+                textView.setSelectedRange(edit.selection)
+            }
         }
 
         private var baseFont: NSFont {

--- a/Tests/ContractTests/ComposeFormatToolbarTests.swift
+++ b/Tests/ContractTests/ComposeFormatToolbarTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+
+/// #263 — Compose formatting toolbar transforms.
+///
+/// Every toolbar verb compiles to a pure buffer transform derived from
+/// Oliver's documented Markdown / Textile syntax. These tests pin the
+/// marker tables and the selection semantics; no AppKit views involved.
+final class ComposeFormatToolbarTests: XCTestCase {
+    // MARK: - Harness
+
+    /// Applies a format and returns the resulting buffer plus selection.
+    private func run(
+        _ format: ComposeFormat,
+        on text: String,
+        location: Int,
+        length: Int = 0,
+        language: ComposeLanguage = .markdown
+    ) -> (result: String, selection: NSRange)? {
+        guard
+            let edit = ComposeFormat.apply(
+                format, to: text,
+                selectedRange: NSRange(location: location, length: length),
+                language: language
+            )
+        else { return nil }
+        let buffer = NSMutableString(string: text)
+        buffer.replaceCharacters(in: edit.replacedRange, with: edit.replacement)
+        return (buffer as String, edit.selection)
+    }
+
+    // MARK: - Wraps
+
+    func testBoldWrapsSelection() throws {
+        let outcome = try XCTUnwrap(run(.bold, on: "say hello now", location: 4, length: 5))
+        XCTAssertEqual(outcome.result, "say **hello** now")
+        XCTAssertEqual(outcome.selection, NSRange(location: 6, length: 5), "the wrapped word stays selected")
+    }
+
+    func testItalicEmptySelectionPlacesCursorInside() throws {
+        let outcome = try XCTUnwrap(run(.italic, on: "word ", location: 5))
+        XCTAssertEqual(outcome.result, "word **")
+        XCTAssertEqual(outcome.selection, NSRange(location: 6, length: 0), "cursor sits inside the marker pair")
+    }
+
+    func testMarkdownStrikethroughUsesTildes() throws {
+        let outcome = try XCTUnwrap(run(.strikethrough, on: "gone", location: 0, length: 4))
+        XCTAssertEqual(outcome.result, "~~gone~~")
+    }
+
+    func testCodeSpanWrapsWithBackticks() throws {
+        let outcome = try XCTUnwrap(run(.codeSpan, on: "x = 1", location: 0, length: 5))
+        XCTAssertEqual(outcome.result, "`x = 1`")
+    }
+
+    // MARK: - Link
+
+    func testLinkKeepsTextSelected() throws {
+        let outcome = try XCTUnwrap(run(.link, on: "read docs", location: 5, length: 4))
+        XCTAssertEqual(outcome.result, "read [docs](url)")
+        XCTAssertEqual(outcome.selection, NSRange(location: 6, length: 4), "text stays selected for typing over")
+    }
+
+    func testLinkEmptySelectionInsertsPlaceholderSelected() throws {
+        let outcome = try XCTUnwrap(run(.link, on: "", location: 0))
+        XCTAssertEqual(outcome.result, "[text](url)")
+        XCTAssertEqual(outcome.selection, NSRange(location: 1, length: 4))
+    }
+
+    func testTextileLinkUsesQuotedColonForm() throws {
+        let outcome = try XCTUnwrap(run(.link, on: "see this", location: 4, length: 4, language: .textile))
+        XCTAssertEqual(outcome.result, "see \"this\":url")
+        XCTAssertEqual(outcome.selection, NSRange(location: 5, length: 4))
+    }
+
+    // MARK: - Line prefixes
+
+    func testHeadingPrefixesEachSelectedLine() throws {
+        let outcome = try XCTUnwrap(
+            run(.heading(level: 2), on: "one\ntwo\nthree", location: 0, length: 7)
+        )
+        XCTAssertEqual(outcome.result, "## one\n## two\nthree")
+        XCTAssertEqual(outcome.selection.location, 0, "selection maps onto the edited lines")
+        XCTAssertEqual(outcome.selection.length, "## one\n## two".count)
+    }
+
+    func testHeadingReplacesExistingLevelInsteadOfStacking() throws {
+        let outcome = try XCTUnwrap(run(.heading(level: 3), on: "# title", location: 3))
+        XCTAssertEqual(outcome.result, "### title")
+    }
+
+    func testTextileHeadingReplacesLabel() throws {
+        let outcome = try XCTUnwrap(
+            run(.heading(level: 2), on: "h1. old", location: 4, language: .textile)
+        )
+        XCTAssertEqual(outcome.result, "h2. old")
+    }
+
+    func testNumberedListIncrementsPerLine() throws {
+        let outcome = try XCTUnwrap(run(.numberedList, on: "a\nb\nc", location: 0, length: 5))
+        XCTAssertEqual(outcome.result, "1. a\n2. b\n3. c")
+    }
+
+    func testTextileNumberedUsesHashPerLine() throws {
+        let outcome = try XCTUnwrap(
+            run(.numberedList, on: "a\nb", location: 0, length: 3, language: .textile)
+        )
+        XCTAssertEqual(outcome.result, "# a\n# b")
+    }
+
+    func testBulletPrefixesOnlySelectedLines() throws {
+        let outcome = try XCTUnwrap(run(.bulletList, on: "keep\nmine\nkeep", location: 5, length: 4))
+        XCTAssertEqual(outcome.result, "keep\n- mine\nkeep")
+    }
+
+    func testQuotePrefixesEverySelectedLine() throws {
+        let outcome = try XCTUnwrap(run(.quote, on: "deep\nthoughts", location: 0, length: 12))
+        XCTAssertEqual(outcome.result, "> deep\n> thoughts")
+    }
+
+    func testEmptyBufferListInsertsWithCursorAfterPrefix() throws {
+        let outcome = try XCTUnwrap(run(.bulletList, on: "", location: 0))
+        XCTAssertEqual(outcome.result, "- ")
+        XCTAssertEqual(outcome.selection, NSRange(location: 2, length: 0))
+    }
+
+    func testCursorAtLineStartLandsAfterInsertedPrefix() throws {
+        let outcome = try XCTUnwrap(run(.bulletList, on: "item", location: 0))
+        XCTAssertEqual(outcome.result, "- item")
+        XCTAssertEqual(outcome.selection, NSRange(location: 2, length: 0))
+    }
+
+    // MARK: - Language tables
+
+    func testTextileMarkersDiffer() throws {
+        let bold = try XCTUnwrap(run(.bold, on: "hi", location: 0, length: 2, language: .textile))
+        XCTAssertEqual(bold.result, "*hi*")
+        let italic = try XCTUnwrap(run(.italic, on: "hi", location: 0, length: 2, language: .textile))
+        XCTAssertEqual(italic.result, "_hi_")
+        let strike = try XCTUnwrap(run(.strikethrough, on: "hi", location: 0, length: 2, language: .textile))
+        XCTAssertEqual(strike.result, "-hi-")
+        let code = try XCTUnwrap(run(.codeSpan, on: "hi", location: 0, length: 2, language: .textile))
+        XCTAssertEqual(code.result, "@hi@")
+    }
+
+    func testCooklangHasNoFormats() {
+        XCTAssertFalse(ComposeLanguage.cooklang.supportsFormatting)
+        XCTAssertNil(ComposeFormat.apply(.bold, to: "sugar", selectedRange: NSRange(location: 0, length: 5), language: .cooklang))
+        XCTAssertTrue(ComposeLanguage.markdown.supportsFormatting)
+        XCTAssertTrue(ComposeLanguage.textile.supportsFormatting)
+    }
+
+    func testStaleSelectionBeyondBufferIsClamped() throws {
+        let outcome = try XCTUnwrap(run(.bold, on: "tiny", location: 900, length: 900))
+        XCTAssertEqual(outcome.result, "tiny****")
+        XCTAssertEqual(outcome.selection, NSRange(location: 6, length: 0))
+    }
+
+    // MARK: - Preview options reset (#263 popover)
+
+    func testPreviewOptionsResetRestoresDefaults() {
+        var mutated = MarkupRenderOptions()
+        mutated.wikilinks = true
+        mutated.taskLists = true
+        mutated.frontmatter = .toml
+        mutated.rawHTML = .rejected
+        mutated.profile = .xhtml
+        XCTAssertNotEqual(mutated, MarkupRenderOptions())
+
+        // What the Reset button assigns.
+        let reset = MarkupRenderOptions()
+        XCTAssertEqual(reset.profile, .html)
+        XCTAssertEqual(reset.rawHTML, .allowed)
+        XCTAssertEqual(reset.frontmatter, .none)
+        for enabled in [
+            reset.wikilinks, reset.callouts, reset.smartypants, reset.footnotes,
+            reset.definitionLists, reset.headingAttributes, reset.strikethrough,
+            reset.headingIDs, reset.taskLists,
+        ] {
+            XCTAssertFalse(enabled, "every Markdown extension stays off by default")
+        }
+    }
+}


### PR DESCRIPTION
Closes #263 (child of tracker #262).

## What

- **Formatting toolbar** between the language picker and Preview: Bold · Italic · Strikethrough · Heading menu (H1–H3) · Link · Code span · Bullet list · Numbered list · Quote. Per-language marker tables mirror Oliver's documented syntax; the row hides entirely for Cooklang.
- **Insert-at-selection seam**: `ComposeTextView.Coordinator.apply(_:)` computes a pure `ComposeFormatEdit` and applies it via `shouldChangeText` → storage replace → `didChangeText`, so undo records one group per press and the existing `textDidChange` repaint path runs unchanged.
- **Toolbar recut**: conformance note leaves the toolbar into the new **"Preview Options…" popover**; option values/defaults unchanged (all-off stays the Oliver contract), plus Reset-to-defaults.
- VoiceOver label + hint on every new button.

## Tests

New `ComposeFormatToolbarTests` (pure transforms, no AppKit): wrap semantics, cursor-inside on empty selection, per-line prefixes with numbered increments (Markdown `1. 2. 3.` / Textile `#`), heading level replacement instead of stacking, link placeholder selection, Textile marker table divergence, Cooklang has no formats, stale-selection clamping, preview-options defaults pin.

`SKIP_EMBED_BORIS=1 make build`, `make test`, `make lint` all green.

## Must-not-land honored

No WYSIWYG, no grammar invention beyond Oliver's documented surface, no option-default changes, no persistence of options, save flow (#231) untouched.