### PR TITLE
editor: humanized companion chrome round 2 (#267)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -116,6 +116,7 @@ targets:
       - path: Sources/Companions/CompanionID.swift
       - path: Sources/Companions/Editor/EditorURL.swift
       - path: Sources/Companions/Editor/EditorSession.swift
+      - path: Sources/Companions/Editor/EditorCopy.swift
       - path: Sources/Companions/Editor/EditorServerFactory.swift
       - path: Sources/Companions/Preview/PreviewURL.swift
       - path: Sources/Compose/ComposeLanguage.swift

--- a/Sources/Companions/Editor/EditorCopy.swift
+++ b/Sources/Companions/Editor/EditorCopy.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// #267: human idle-state copy for the editor companion chrome. Leads with
+/// what to do; manual connect is mentioned only as the last-resort sentence
+/// (#237 collapsed that field behind Manual Connect).
+enum EditorIdleCopy {
+    static let lead = "Choose File → Edit Page, or press Restart Host below."
+    static let lastResort = "Manual Connect stays available below as a last resort."
+
+    static var description: String {
+        lead + " " + lastResort
+    }
+}
+
+/// #267: human phase copy for the editor chrome — display-only mapping;
+/// the session's `Phase` enum is untouched. Enumerates all five cases (the
+/// A11Y-4 pattern) so a new case cannot compile without a label.
+enum EditorPhaseCopy {
+    static func label(for phase: EditorSession.Phase) -> String {
+        switch phase {
+        case .idle:
+            return "Not connected"
+        case .starting:
+            return "Connecting…"
+        case .connected:
+            return "Ready"
+        case .reconnecting(let attempt):
+            return "Connection lost — retrying (\(attempt) of \(EditorAutoReconnect.maxAttempts))"
+        case .failed(let message):
+            return message
+        }
+    }
+
+    /// VoiceOver label for every phase value the indicator can render.
+    static func accessibilityLabel(for phase: EditorSession.Phase) -> String {
+        switch phase {
+        case .idle:
+            return "Not connected"
+        case .starting:
+            return "Connecting"
+        case .connected:
+            return "Ready"
+        case .reconnecting(let attempt):
+            return "Connection lost — retrying, attempt \(attempt) of \(EditorAutoReconnect.maxAttempts)"
+        case .failed:
+            return "Connection failed"
+        }
+    }
+}

--- a/Sources/Companions/Editor/EditorWebView.swift
+++ b/Sources/Companions/Editor/EditorWebView.swift
@@ -12,8 +12,6 @@ final class EditorWebModel: NSObject {
     private(set) var currentURL: URL?
     private(set) var rejection: String?
     private(set) var isLoading = false
-    private(set) var canGoBack = false
-    private(set) var canGoForward = false
 
     @ObservationIgnored
     private var observations: [NSKeyValueObservation] = []
@@ -56,18 +54,6 @@ final class EditorWebModel: NSObject {
         }
     }
 
-    func goBack() {
-        if webView.canGoBack {
-            webView.goBack()
-        }
-    }
-
-    func goForward() {
-        if webView.canGoForward {
-            webView.goForward()
-        }
-    }
-
     func openInBrowser() {
         guard let url = currentURL, Self.isLoopback(url) else { return }
         NSWorkspace.shared.open(url)
@@ -80,16 +66,6 @@ final class EditorWebModel: NSObject {
             webView.observe(\.isLoading, options: [.initial, .new]) { [weak self] _, change in
                 MainActor.assumeIsolated {
                     self?.isLoading = change.newValue ?? false
-                }
-            },
-            webView.observe(\.canGoBack, options: [.initial, .new]) { [weak self] _, change in
-                MainActor.assumeIsolated {
-                    self?.canGoBack = change.newValue ?? false
-                }
-            },
-            webView.observe(\.canGoForward, options: [.initial, .new]) { [weak self] _, change in
-                MainActor.assumeIsolated {
-                    self?.canGoForward = change.newValue ?? false
                 }
             },
         ]

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -116,7 +116,9 @@ struct EditorWindow: View { // swiftlint:disable:this type_body_length
                         .foregroundStyle(.secondary)
                 } else {
                     Text("The Boris editor connects when the host process is running.")
-                    Text("File → Edit Page opens the editor, or paste a BORIS_EDITOR_URL line to connect manually.")
+                    // #267: lead with the action; manual connect is the
+                    // last-resort sentence, matching #237's collapsed field.
+                    Text(EditorIdleCopy.description)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -217,9 +219,11 @@ struct EditorWindow: View { // swiftlint:disable:this type_body_length
 
     private var toolbar: some View {
         VStack(alignment: .leading, spacing: 6) {
-            // Row 1: Nav + phase indicator + actions (always visible)
+            // Row 1: phase indicator + actions (always visible). #267:
+            // Back/Forward removed — the shell loads one tokenized SPA URL
+            // per session and never navigates cross-page by design.
             HStack(spacing: 8) {
-                EditorNavButtons(model: model)
+                ReloadButton(model: model)
 
                 if model.isLoading {
                     ProgressView()
@@ -264,14 +268,14 @@ struct EditorWindow: View { // swiftlint:disable:this type_body_length
             }
 
             // #232: one-shot confirmation after an automatic reconnect.
-            if let notice = session.transientNotice {
-                Text(notice)
+            if session.transientNotice != nil {
+                Label("Reconnected", systemImage: "checkmark.circle.fill")
                     .font(.caption)
                     .foregroundStyle(.green)
             }
 
             if let rejection = model.rejection {
-                Text(rejection)
+                Label(rejection, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.red)
             }
@@ -360,42 +364,22 @@ struct EditorWindow: View { // swiftlint:disable:this type_body_length
     }
 }
 
-private struct EditorNavButtons: View {
+/// #267: the only navigation control left — Reload. Back/Forward are gone:
+/// the web view never navigates cross-page by design, and dead controls
+/// read as broken.
+private struct ReloadButton: View {
     let model: EditorWebModel
 
     var body: some View {
-        HStack(spacing: 2) {
-            Button {
-                model.goBack()
-            } label: {
-                Image(systemName: "chevron.left")
-            }
-            .accessibilityLabel("Back")
-            .accessibilityAddTraits(.isButton)
-            .help("Back")
-            .disabled(!model.canGoBack)
-
-            Button {
-                model.goForward()
-            } label: {
-                Image(systemName: "chevron.right")
-            }
-            .accessibilityLabel("Forward")
-            .accessibilityAddTraits(.isButton)
-            .help("Forward")
-            .disabled(!model.canGoForward)
-
-            Button {
-                model.reload()
-            } label: {
-                Image(systemName: "arrow.clockwise")
-            }
-            .accessibilityLabel("Reload")
-            .accessibilityAddTraits(.isButton)
-            .help("Reload")
-            .disabled(!model.canReload)
+        Button {
+            model.reload()
+        } label: {
+            Image(systemName: "arrow.clockwise")
         }
-        .buttonStyle(.borderless)
+        .accessibilityLabel("Reload")
+        .accessibilityAddTraits(.isButton)
+        .help("Reload")
+        .disabled(!model.canReload)
     }
 }
 
@@ -406,14 +390,14 @@ private struct EditorPhaseIndicator: View {
     var body: some View {
         HStack(spacing: 5) {
             phaseIcon
-            Text(phaseLabel)
+            Text(EditorPhaseCopy.label(for: phase))
                 .font(.caption)
                 .foregroundStyle(isFailure ? Color.red : Color.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityPhaseLabel)
+        .accessibilityLabel(EditorPhaseCopy.accessibilityLabel(for: phase))
         .accessibilityAddTraits(.isStaticText)
     }
 
@@ -431,39 +415,6 @@ private struct EditorPhaseIndicator: View {
         case .failed:
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
-        }
-    }
-
-    private var phaseLabel: String {
-        switch phase {
-        case .idle:
-            return "Not connected"
-        case .starting:
-            return "Starting boris-editor…"
-        case .connected(let url):
-            return "Connected · \(url.host ?? "loopback")"
-        case .reconnecting(let attempt):
-            return "Reconnecting · attempt \(attempt) of \(EditorAutoReconnect.maxAttempts)"
-        case .failed(let message):
-            return message
-        }
-    }
-
-    /// A11Y-4 (#242): a VoiceOver-readable label for every phase value the
-    /// indicator can render. Enumerates all five `Phase` cases so a new one
-    /// won't ship unlabeled.
-    private var accessibilityPhaseLabel: String {
-        switch phase {
-        case .idle:
-            return "Engine idle"
-        case .starting:
-            return "Engine starting"
-        case .connected:
-            return "Engine running"
-        case .reconnecting:
-            return "Engine reconnecting"
-        case .failed:
-            return "Engine error"
         }
     }
 }

--- a/Tests/ContractTests/EditorChromeCopyTests.swift
+++ b/Tests/ContractTests/EditorChromeCopyTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+/// #267 — Editor companion humanized chrome, round 2. Pins the display-only
+/// copy mappings; the session's `Phase` enum and reconnect policy (#232)
+/// are untouched.
+final class EditorChromeCopyTests: XCTestCase {
+    private let url = URL(string: "http://127.0.0.1:49152/#token=x")!
+
+    func testPhaseLabelHumanWording() {
+        XCTAssertEqual(EditorPhaseCopy.label(for: .idle), "Not connected")
+        XCTAssertEqual(EditorPhaseCopy.label(for: .starting), "Connecting…")
+        XCTAssertEqual(EditorPhaseCopy.label(for: .connected(url)), "Ready")
+        XCTAssertEqual(
+            EditorPhaseCopy.label(for: .reconnecting(attempt: 2)),
+            "Connection lost — retrying (2 of \(EditorAutoReconnect.maxAttempts))"
+        )
+        XCTAssertEqual(EditorPhaseCopy.label(for: .failed("host exited")), "host exited")
+    }
+
+    func testPhaseAccessibilityLabelsEnumerateAllCases() {
+        // The A11Y-4 pattern: every case carries a non-empty VoiceOver label.
+        let phases: [EditorSession.Phase] = [
+            .idle,
+            .starting,
+            .connected(url),
+            .reconnecting(attempt: 1),
+            .failed("boom"),
+        ]
+        for phase in phases {
+            XCTAssertFalse(EditorPhaseCopy.accessibilityLabel(for: phase).isEmpty)
+        }
+        // No more engine-speak in the accessible chrome.
+        XCTAssertFalse(EditorPhaseCopy.accessibilityLabel(for: .starting).contains("Engine"))
+    }
+
+    func testIdleCopyLeadsWithAction() {
+        let description = EditorIdleCopy.description
+        XCTAssertTrue(description.contains("File → Edit Page"), "the action leads the copy")
+        guard
+            let leadRange = description.range(of: EditorIdleCopy.lead),
+            let lastResortRange = description.range(of: "last resort")
+        else {
+            return XCTFail("idle copy must contain both the lead action and the last-resort sentence")
+        }
+        XCTAssertLessThan(
+            leadRange.lowerBound, lastResortRange.lowerBound,
+            "manual-connect mention must come after the action"
+        )
+    }
+}


### PR DESCRIPTION
Closes #267 (child of tracker #262). Independent lane — builds on #237/#232, amends neither.

## What

- **Human phase copy** (`EditorPhaseCopy`, display-only; `Phase` enum untouched): idle → "Not connected", starting → "Connecting…", connected → "Ready", reconnecting → "Connection lost — retrying (N of 3)", failed → raw message + existing guidance. VoiceOver labels updated to match, keeping the enumerated-all-cases pattern.
- **Back/Forward removed**, Reload kept: the shell loads one tokenized SPA URL per session and never navigates cross-page. The now-dead `canGoBack`/`canGoForward` KVO mirrors and model passthroughs are dropped with them.
- **Idle copy rewritten**: leads with the action ("Choose File → Edit Page, or press Restart Host below."); Manual Connect mentioned only as the last-resort sentence.
- Reconnect notice renders as a checkmark-prefixed **"Reconnected"** line; rejection keeps red + gains a standard error icon.

## Tests

`EditorChromeCopyTests`: every `Phase` case maps to the new copy (compiler-complete switch), accessibility labels enumerate all cases with no engine-speak, idle copy leads with the action before any manual-connect mention.

`SKIP_EMBED_BORIS=1 make build`, `make test`, `make lint` green; `EditorSessionReconnectTests` untouched and green (no session/policy change).