### PR TITLE
compose: reading comfort — type size ladder, line spacing, gutter toggle (#264)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -135,8 +135,10 @@ targets:
       - path: Sources/Compose/ComposeLineGutter.swift
       - path: Sources/Compose/ComposeTabIndent.swift
       - path: Sources/Compose/ComposeTextView.swift
+      - path: Sources/Compose/ComposeTextCoordinator.swift
       - path: Sources/Compose/ComposeFormat.swift
       - path: Sources/Compose/ComposeFormatToolbar.swift
+      - path: Sources/Compose/ComposeTypography.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.drawmeanelephant.solipsist.contracttests

--- a/Sources/App/AppRuntime.swift
+++ b/Sources/App/AppRuntime.swift
@@ -130,4 +130,8 @@ final class AppRuntime {
     }
 
     var pendingComposeJump: ComposeJumpRequest?
+
+    /// #264: reading-comfort state for the compose buffer — the View-menu
+    /// zoom / gutter commands and the editor window share this instance.
+    var composeTypography = ComposeTypography()
 }

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -199,6 +199,32 @@ struct SolipsistCommands: Commands {
             .keyboardShortcut("c", modifiers: [.command, .shift])
         }
 
+        /// #264: reading comfort for the compose buffer — type ladder and
+        /// gutter toggle, persisted as machine state (UserDefaults).
+        CommandGroup(after: .textFormatting) {
+            Button("Zoom In") {
+                runtime.composeTypography.zoomIn()
+            }
+            .keyboardShortcut("+", modifiers: .command)
+
+            Button("Zoom Out") {
+                runtime.composeTypography.zoomOut()
+            }
+            .keyboardShortcut("-", modifiers: .command)
+
+            Button("Actual Size") {
+                runtime.composeTypography.resetToActualSize()
+            }
+            .keyboardShortcut("0", modifiers: .command)
+
+            Divider()
+
+            Toggle("Line Numbers", isOn: Binding(
+                get: { runtime.composeTypography.showsLineNumbers },
+                set: { runtime.composeTypography.setLineNumbers($0) }
+            ))
+        }
+
         CommandGroup(replacing: .help) {
             Button("Solipsist Help") {
                 openWindow(id: "help")

--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -28,6 +28,9 @@ struct ComposeEditorView: View {
     /// External line-jump from ProblemsPane (M11 #207): when set, the editor
     /// jumps to this absolute character offset.
     var externalJump: Int?
+    /// #264: reading-comfort state (type ladder + gutter toggle). The host
+    /// passes the shared instance so View-menu commands drive this window.
+    var typography: ComposeTypography = .init()
 
     /// Problems from the live preview render (LATER-3.1). Computed from the
     /// render, not injected by the host.
@@ -65,7 +68,11 @@ struct ComposeEditorView: View {
                     jumpToCharacter: jumpToCharacter,
                     completion: cookCompletion,
                     jumpToLine: goToLineTarget,
-                    formatApplier: formatApplier
+                    formatApplier: formatApplier,
+                    // Reading the scalars here registers observation so a
+                    // View-menu zoom re-syncs the AppKit host (#264).
+                    fontSize: typography.size,
+                    showsLineNumbers: typography.showsLineNumbers
                 )
                 .id(document.fileURL)
                 .frame(minWidth: 280, maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Compose/ComposeHighlighter.swift
+++ b/Sources/Compose/ComposeHighlighter.swift
@@ -31,10 +31,19 @@ struct ComposeHighlightRule {
 enum ComposeHighlighter {
     // MARK: - Public API
 
-    static func highlight(_ text: String, language: ComposeLanguage) -> NSAttributedString {
+    /// `fontSize` (#264): the reading-comfort ladder resizes the whole
+    /// paint; defaults keep every existing caller compiling.
+    static func highlight(
+        _ text: String,
+        language: ComposeLanguage,
+        fontSize: CGFloat = 13
+    ) -> NSAttributedString {
         let result = NSMutableAttributedString(
             string: text,
-            attributes: [.font: baseFont, .foregroundColor: NSColor.labelColor]
+            attributes: [
+                .font: font(ofSize: fontSize),
+                .foregroundColor: NSColor.labelColor,
+            ]
         )
 
         for rule in rules(for: language) {
@@ -44,14 +53,14 @@ enum ComposeHighlighter {
             let full = NSRange(location: 0, length: (text as NSString).length)
             regex.enumerateMatches(in: text, range: full) { match, _, _ in
                 guard let match else { return }
-                paint(rule.style, over: match.range, in: result)
+                paint(rule.style, over: match.range, in: result, fontSize: fontSize)
             }
         }
 
         // #235: Autolink post-processing — paint the angle brackets of
         // autolinks back to plain text so the URL is easier to read.
         if language == .markdown {
-            paintAutolinkBrackets(text, in: result)
+            paintAutolinkBrackets(text, in: result, fontSize: fontSize)
         }
 
         // Front matter is data, not content: paint it last so no inner rule
@@ -62,7 +71,8 @@ enum ComposeHighlighter {
             paint(
                 ComposeHighlightStyle(color: .systemGray, italic: true),
                 over: NSRange(location: lower, length: upper - lower),
-                in: result
+                in: result,
+                fontSize: fontSize
             )
         }
 
@@ -111,14 +121,15 @@ enum ComposeHighlighter {
         _ text: String,
         language: ComposeLanguage,
         in range: NSRange,
-        storage: NSMutableAttributedString
+        storage: NSMutableAttributedString,
+        fontSize: CGFloat = 13
     ) {
         guard range.location != NSNotFound, range.length > 0,
               range.upperBound <= (text as NSString).length
         else { return }
 
         storage.addAttributes(
-            [.font: baseFont, .foregroundColor: NSColor.labelColor],
+            [.font: font(ofSize: fontSize), .foregroundColor: NSColor.labelColor],
             range: range
         )
 
@@ -131,7 +142,7 @@ enum ComposeHighlighter {
                 guard let match else { return }
                 let hit = NSIntersectionRange(match.range, range)
                 guard hit.length > 0 else { return }
-                paint(rule.style, over: hit, in: storage)
+                paint(rule.style, over: hit, in: storage, fontSize: fontSize)
             }
         }
 
@@ -146,14 +157,15 @@ enum ComposeHighlighter {
                 paint(
                     ComposeHighlightStyle(color: .systemGray, italic: true),
                     over: hit,
-                    in: storage
+                    in: storage,
+                    fontSize: fontSize
                 )
             }
         }
 
         // #235: Autolink bracket post-processing for the repainted range.
         if language == .markdown {
-            repaintAutolinkBrackets(text, in: range, storage: storage)
+            repaintAutolinkBrackets(text, in: range, storage: storage, fontSize: fontSize)
         }
     }
 
@@ -163,7 +175,8 @@ enum ComposeHighlighter {
     private static func repaintAutolinkBrackets(
         _ text: String,
         in range: NSRange,
-        storage: NSMutableAttributedString
+        storage: NSMutableAttributedString,
+        fontSize: CGFloat
     ) {
         let nsText = text as NSString
         guard let regex = try? NSRegularExpression(pattern: "<[^<>\\s]+>", options: []) else { return }
@@ -177,9 +190,13 @@ enum ComposeHighlighter {
                 length: 1
             )
             let hitLead = NSIntersectionRange(leadingBracket, range)
-            if hitLead.length > 0 { paint(plain, over: hitLead, in: storage) }
+            if hitLead.length > 0 {
+                paint(plain, over: hitLead, in: storage, fontSize: fontSize)
+            }
             let hitTrail = NSIntersectionRange(trailingBracket, range)
-            if hitTrail.length > 0 { paint(plain, over: hitTrail, in: storage) }
+            if hitTrail.length > 0 {
+                paint(plain, over: hitTrail, in: storage, fontSize: fontSize)
+            }
         }
     }
 
@@ -202,12 +219,8 @@ enum ComposeHighlighter {
     private static let note = ComposeHighlightStyle(color: .systemTeal)
     private static let comment = ComposeHighlightStyle(color: .secondaryLabelColor, italic: true)
 
-    private static var baseFont: NSFont {
-        NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-    }
-
-    private static var boldFont: NSFont {
-        NSFont.monospacedSystemFont(ofSize: 13, weight: .bold)
+    private static func font(ofSize fontSize: CGFloat) -> NSFont {
+        NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
     }
 
     // MARK: - Markdown (CommonMark 0.31.2 + Oliver's opt-in extensions)
@@ -320,26 +333,44 @@ enum ComposeHighlighter {
     private static func paint(
         _ style: ComposeHighlightStyle,
         over range: NSRange,
-        in attributed: NSMutableAttributedString
+        in attributed: NSMutableAttributedString,
+        fontSize: CGFloat
     ) {
         guard range.location != NSNotFound, range.length > 0 else { return }
         attributed.addAttribute(.foregroundColor, value: style.color, range: range)
         if style.bold {
-            attributed.addAttribute(.font, value: boldFont, range: range)
+            attributed.addAttribute(
+                .font,
+                value: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .bold),
+                range: range
+            )
         } else if style.italic {
-            let italic = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+            let italic = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
                 .withTraits(.italic)
             attributed.addAttribute(.font, value: italic, range: range)
         }
     }
+}
 
-    // MARK: - #235 Autolink post-processing
+extension NSFont {
+    func withTraits(_ traits: NSFontDescriptor.SymbolicTraits) -> NSFont {
+        let descriptor = fontDescriptor.withSymbolicTraits(traits)
+        return NSFont(descriptor: descriptor, size: pointSize) ?? self
+    }
+}
 
+// MARK: - #235 Autolink bracket post-processing
+
+private extension ComposeHighlighter {
     /// #235: Paints the angle brackets of autolinks (`<url>`) back to plain
     /// text so the URL itself is easier to read. Runs after all rules have
     /// been applied. Only fires for Markdown (autolinks are a CommonMark
     /// feature; Cooklang and Textile use different link syntax).
-    private static func paintAutolinkBrackets(_ text: String, in attributed: NSMutableAttributedString) {
+    static func paintAutolinkBrackets(
+        _ text: String,
+        in attributed: NSMutableAttributedString,
+        fontSize: CGFloat
+    ) {
         let nsText = text as NSString
         let full = NSRange(location: 0, length: nsText.length)
         // Match autolinks: <scheme:path> or <user@host>
@@ -355,15 +386,8 @@ enum ComposeHighlighter {
                 location: match.range.location + match.range.length - 1,
                 length: 1
             )
-            paint(plain, over: leadingBracket, in: attributed)
-            paint(plain, over: trailingBracket, in: attributed)
+            paint(plain, over: leadingBracket, in: attributed, fontSize: fontSize)
+            paint(plain, over: trailingBracket, in: attributed, fontSize: fontSize)
         }
-    }
-}
-
-extension NSFont {
-    func withTraits(_ traits: NSFontDescriptor.SymbolicTraits) -> NSFont {
-        let descriptor = fontDescriptor.withSymbolicTraits(traits)
-        return NSFont(descriptor: descriptor, size: pointSize) ?? self
     }
 }

--- a/Sources/Compose/ComposeLineGutter.swift
+++ b/Sources/Compose/ComposeLineGutter.swift
@@ -16,13 +16,26 @@ final class ComposeLineGutter: NSView {
         guard let textView else { return 36 }
         let lines = max(1, lineCount(in: textView.string))
         let digits = max(3, "\(lines)".count)
-        let charWidth: CGFloat = 7.8 // ~13pt ui-monospace average
+        let charWidth: CGFloat = fontSize * 0.6 // ~monospace average
         let computed = CGFloat(digits) * charWidth + 12
         return max(36, computed)
     }
 
-    private let baseFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-    private let boldFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold)
+    /// #264: the gutter digits ride the reading-comfort type ladder.
+    var fontSize: CGFloat = 13 {
+        didSet {
+            guard oldValue != fontSize else { return }
+            needsDisplay = true
+        }
+    }
+
+    private var baseFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+    }
+
+    private var boldFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: fontSize, weight: .semibold)
+    }
 
     override var isOpaque: Bool { false }
 

--- a/Sources/Compose/ComposeTextCoordinator.swift
+++ b/Sources/Compose/ComposeTextCoordinator.swift
@@ -1,0 +1,310 @@
+import AppKit
+import SwiftUI
+
+/// The AppKit coordinator behind `ComposeTextView`: buffer sync, heuristic
+/// painting, click-to-line / go-to-line jumps, toolbar format application
+/// (#263), and the reading-comfort font ladder + gutter visibility (#264).
+/// Declared in a nested-type extension so callers keep using
+/// `ComposeTextView.Coordinator`.
+extension ComposeTextView {
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var document: ComposeDocument
+        /// Cooklang completion vocabulary, updated on view syncs so a
+        /// freshly-built `.boris/` index reaches the popup without a reload.
+        var completion: ComposeCookCompletion = .empty
+        weak var textView: NSTextView?
+        weak var scrollView: NSScrollView?
+        weak var gutter: ComposeLineGutter?
+        private var isApplying = false
+        /// #264: current ladder size; the single font source for this host.
+        var fontSize: CGFloat = 13
+        /// #264: gutter visibility, synced from `ComposeTypography`.
+        var showsLineNumbers = true
+        /// Last click-to-line offset we applied, so re-syncs do not re-jump.
+        private var lastJumpedCharacter: Int?
+        /// #238: Weak reference to the hosted NSTextView, set once during
+        /// `makeNSView` so `jumpToLine` can register undo and scroll.
+        weak var hostedTextView: NSTextView?
+
+        /// Last state we painted, so programmatic syncs (which fire on every
+        /// `document` change) do not re-paint an unchanged buffer.
+        private var lastHighlightedText: String?
+        private var lastHighlightedLanguage: ComposeLanguage?
+
+        init(document: ComposeDocument, completion: ComposeCookCompletion = .empty) {
+            self.document = document
+            self.completion = completion
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard
+                !isApplying,
+                let textView = notification.object as? NSTextView
+            else { return }
+            isApplying = true
+            defer { isApplying = false }
+
+            let oldText = document.text
+            let newText = textView.string
+            document.text = newText
+            repaintChanged(oldText: oldText, newText: newText, textView: textView, language: document.language)
+            maybeOpenCompletion(in: textView, previousText: oldText)
+            updateGutterWidth()
+            gutter?.needsDisplay = true
+            document.updateCursor(textView.selectedRange())
+            // Keep gutter height in sync with textView's content height
+            if let gutter {
+                var gutterFrame = gutter.frame
+                gutterFrame.size.height = max(textView.bounds.height, scrollView?.contentSize.height ?? 0)
+                gutter.frame = gutterFrame
+            }
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else {
+                gutter?.needsDisplay = true
+                return
+            }
+            gutter?.needsDisplay = true
+            document.updateCursor(textView.selectedRange())
+        }
+
+        /// Update gutter width and text container padding when line count grows
+        /// beyond 4 digits. Minimum 36pt. Collapses to the base inset when the
+        /// gutter is hidden (#264).
+        func updateGutterWidth() {
+            guard let gutter, let textView else { return }
+            guard showsLineNumbers else {
+                applyGutterVisibility()
+                return
+            }
+            let newWidth = max(gutter.gutterWidth, 36)
+            if abs(gutter.frame.width - newWidth) > 0.5 {
+                var gutterFrame = gutter.frame
+                gutterFrame.size.width = newWidth
+                gutter.frame = gutterFrame
+                textView.textContainer?.lineFragmentPadding = newWidth
+                textView.needsLayout = true
+                gutter.needsDisplay = true
+            }
+        }
+
+        /// #264: shows/hides the line-number gutter and collapses the
+        /// reserved `lineFragmentPadding` back to the base inset when hidden.
+        func applyGutterVisibility() {
+            guard let gutter, let textView else { return }
+            // Digits ride the type ladder (#264).
+            gutter.fontSize = fontSize
+            if gutter.isHidden != !showsLineNumbers {
+                gutter.isHidden = !showsLineNumbers
+                gutter.needsDisplay = true
+            }
+            let targetPadding: CGFloat = showsLineNumbers ? max(gutter.gutterWidth, 36) : 5
+            if abs((textView.textContainer?.lineFragmentPadding ?? 0) - targetPadding) > 0.5 {
+                textView.textContainer?.lineFragmentPadding = targetPadding
+                textView.needsLayout = true
+                gutter.needsDisplay = true
+            }
+        }
+
+        /// LATER-3.4: when the author types a Cooklang token marker (`@`,
+        /// `#`, `~`) in a Cooklang buffer with a corpus vocabulary, open the
+        /// native completion popup. The popup is fed by
+        /// `textView(_:completions:forPartialWordRange:indexOfSelectedItem:)`
+        /// below; everything stays inside the single NSTextView surface.
+        private func maybeOpenCompletion(in textView: NSTextView, previousText: String) {
+            guard
+                document.language == .cooklang,
+                !completion.isEmpty,
+                let inserted = CookMarkerScanner.insertedMarker(
+                    from: previousText,
+                    to: textView.string
+                ),
+                CookMarkerScanner.markers.contains(inserted)
+            else { return }
+            textView.complete(nil)
+        }
+
+        // MARK: NSTextView completion (LATER-3.4)
+
+        func textView(
+            _ textView: NSTextView,
+            completions words: [String],
+            forPartialWordRange charRange: NSRange,
+            indexOfSelectedItem index: UnsafeMutablePointer<Int>?
+        ) -> [String] {
+            guard document.language == .cooklang, !completion.isEmpty else { return words }
+            let text = textView.string as NSString
+            guard
+                charRange.location > 0,
+                let marker = CookMarkerScanner.marker(
+                    before: charRange.location,
+                    in: text
+                )
+            else { return words }
+            let prefix = text.substring(with: charRange)
+            let suggestions = completion.suggestions(marker: marker, prefix: prefix)
+            index?.pointee = 0
+            return suggestions
+        }
+
+        /// Incremental repaint (LATER-3.2): restyle only the changed line(s)
+        /// in place instead of replacing the whole storage, so a keystroke in
+        /// a large buffer no longer repaints (and re-lays-out) off-screen
+        /// text. Full paint still runs on load / language change / program-
+        /// matic sync (`applyHighlight`).
+        private func repaintChanged(
+            oldText: String,
+            newText: String,
+            textView: NSTextView,
+            language: ComposeLanguage
+        ) {
+            let change = ComposeHighlighter.changedRange(old: oldText, new: newText)
+            let nsNew = newText as NSString
+            let clampedLocation = min(max(change.location, 0), nsNew.length)
+            let clampedLength = min(max(change.length, 1), nsNew.length - clampedLocation)
+            // Expand to the full containing line(s) so `^`-anchored rules and
+            // delimiters on the edited line restyle together.
+            let target = nsNew.lineRange(
+                for: NSRange(location: clampedLocation, length: clampedLength)
+            )
+            guard target.length > 0, let storage = textView.textStorage as? NSMutableAttributedString else {
+                lastHighlightedText = newText
+                lastHighlightedLanguage = language
+                return
+            }
+            storage.beginEditing()
+            ComposeHighlighter.repaint(newText, language: language, in: target, storage: storage)
+            storage.endEditing()
+            lastHighlightedText = newText
+            lastHighlightedLanguage = language
+        }
+
+        func applyHighlight(_ textView: NSTextView, text: String, language: ComposeLanguage, force: Bool = false) {
+            guard force || text != lastHighlightedText || language != lastHighlightedLanguage else { return }
+            lastHighlightedText = text
+            lastHighlightedLanguage = language
+
+            let highlighted = ComposeHighlighter.highlight(text, language: language, fontSize: fontSize)
+            if let storage = textView.textStorage {
+                storage.beginEditing()
+                storage.setAttributedString(highlighted)
+                // #264: reading line spacing rides on the full paint.
+                if highlighted.length > 0 {
+                    storage.addAttribute(
+                        .paragraphStyle,
+                        value: paragraphStyle,
+                        range: NSRange(location: 0, length: highlighted.length)
+                    )
+                }
+                storage.endEditing()
+            }
+            textView.typingAttributes = [
+                .font: currentFont,
+                .foregroundColor: NSColor.labelColor,
+                .paragraphStyle: paragraphStyle,
+            ]
+        }
+
+        /// #264: applies a new ladder size to the buffer — font, typing
+        /// attributes, and a forced full repaint so attributed sizes refresh.
+        func setFontSize(_ newSize: CGFloat) {
+            guard newSize != fontSize else { return }
+            fontSize = newSize
+            guard let textView else { return }
+            textView.font = currentFont
+            applyHighlight(textView, text: document.text, language: document.language, force: true)
+            updateGutterWidth()
+            applyGutterVisibility()
+        }
+
+        /// Moves the selection to a character offset (click-to-line).
+        /// Runs after highlight so the storage is current; clamps so a
+        /// stale span can never exceed the buffer.
+        func jump(to character: Int?, in textView: NSTextView) {
+            guard let character, character != lastJumpedCharacter else { return }
+            lastJumpedCharacter = character
+            let nsString = textView.string as NSString
+            let clamped = min(max(character, 0), nsString.length)
+            let range = NSRange(location: clamped, length: 0)
+            textView.setSelectedRange(range)
+            textView.scrollRangeToVisible(range)
+        }
+
+        /// #238: Jump to a 1-based line number. Registers the current cursor
+        /// position in the undo stack so ⌘Z restores it. Clamps to the
+        /// buffer range; empty buffers jump to offset 0.
+        func jumpToLine(_ line: Int) {
+            guard let textView = hostedTextView else { return }
+            let nsString = textView.string as NSString
+            guard nsString.length > 0 else { return }
+            let currentRange = textView.selectedRange()
+            let undoManager = textView.undoManager
+            undoManager?.registerUndo(withTarget: textView) { target in
+                target.setSelectedRange(currentRange)
+                target.scrollRangeToVisible(currentRange)
+            }
+            undoManager?.setActionName("Go to Line")
+            let totalLines = max(1, nsString.components(separatedBy: "\n").count)
+            let clamped = max(1, min(line, totalLines))
+            var foundLine = 1
+            var targetLocation = 0
+            nsString.enumerateSubstrings(
+                in: NSRange(location: 0, length: nsString.length),
+                options: [.byLines, .substringNotRequired]
+            ) { _, range, _, stop in
+                if foundLine == clamped {
+                    targetLocation = range.location
+                    stop.pointee = true
+                }
+                foundLine += 1
+            }
+            let range = NSRange(location: targetLocation, length: 0)
+            textView.setSelectedRange(range)
+            textView.scrollRangeToVisible(range)
+        }
+
+        /// #263: applies a toolbar format at the current selection. The
+        /// mutation flows through `shouldChangeText` / `didChangeText` so the
+        /// undo stack records one group per press and the ordinary
+        /// `textDidChange` delegate path (buffer sync + repaint) runs
+        /// unchanged.
+        func apply(_ format: ComposeFormat) {
+            guard let textView, document.language.supportsFormatting else { return }
+            guard
+                let edit = ComposeFormat.apply(
+                    format,
+                    to: textView.string,
+                    selectedRange: textView.selectedRange(),
+                    language: document.language
+                )
+            else { return }
+            let undoManager = textView.undoManager
+            undoManager?.beginUndoGrouping()
+            defer { undoManager?.endUndoGrouping() }
+            undoManager?.setActionName(format.actionName)
+            if textView.shouldChangeText(in: edit.replacedRange, replacementString: edit.replacement) {
+                textView.textStorage?.replaceCharacters(
+                    in: edit.replacedRange,
+                    with: edit.replacement
+                )
+                textView.didChangeText()
+                textView.setSelectedRange(edit.selection)
+            }
+        }
+
+        /// #264: the single font source for this host — the ladder size.
+        var currentFont: NSFont {
+            NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        }
+
+        /// #264: breathing-room paragraph style applied to typed and
+        /// painted text alike.
+        var paragraphStyle: NSParagraphStyle {
+            let style = NSMutableParagraphStyle()
+            style.lineSpacing = ComposeTypography.lineSpacing
+            return style
+        }
+    }
+}

--- a/Sources/Compose/ComposeTextView.swift
+++ b/Sources/Compose/ComposeTextView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// `NSScrollView` (which conforms to `NSTextFinderBarContainer`). This gives
 /// ⌘F / ⌘⌥F / ⌘G / ⇧⌘G, wrap-around, case-insensitive and regex toggles for
 /// free — no custom UI.
-struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_body_length
+struct ComposeTextView: NSViewRepresentable {
     @Bindable var document: ComposeDocument
     /// Click-to-line target (LATER-3.1); nil = no pending jump.
     var jumpToCharacter: Int?
@@ -22,6 +22,11 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
     /// #263: toolbar-to-coordinator seam; the editor view owns the bus and
     /// the coordinator registers its applier on it.
     var formatApplier: ComposeFormatApplier?
+    /// #264: reading-comfort ladder size (11…21, default 13). The editor
+    /// view reads the observable's scalars so SwiftUI re-syncs on change.
+    var fontSize: CGFloat = 13
+    /// #264: gutter visibility from `ComposeTypography`.
+    var showsLineNumbers: Bool = true
 
     func makeCoordinator() -> Coordinator {
         Coordinator(document: document, completion: completion)
@@ -44,8 +49,11 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
         textView.isContinuousSpellCheckingEnabled = false
-        textView.font = baseFont
-        textView.textContainerInset = NSSize(width: 10, height: 10)
+        context.coordinator.fontSize = fontSize
+        textView.font = context.coordinator.currentFont
+        // #264: breathing room — vertical inset + paragraph line spacing.
+        textView.textContainerInset = NSSize(width: 10, height: 14)
+        textView.defaultParagraphStyle = context.coordinator.paragraphStyle
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
@@ -77,6 +85,7 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
         )
         // Gutter width tracks line count; update after initial paint.
         context.coordinator.updateGutterWidth()
+        context.coordinator.applyGutterVisibility()
         gutter.needsDisplay = true
         document.updateCursor(textView.selectedRange())
         return scrollView
@@ -103,6 +112,9 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
         context.coordinator.textView = textView
         context.coordinator.scrollView = scrollView
         registerFormatApplier(context.coordinator)
+        // #264: reading-comfort syncs (font ladder + gutter visibility).
+        context.coordinator.setFontSize(fontSize)
+        context.coordinator.showsLineNumbers = showsLineNumbers
         // Re-bind gutter if view was recreated (SwiftUI .id)
         if let gutter = context.coordinator.gutter, gutter.superview !== textView {
             gutter.textView = textView
@@ -133,6 +145,7 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
         }
         document.updateCursor(textView.selectedRange())
         context.coordinator.updateGutterWidth()
+        context.coordinator.applyGutterVisibility()
         // Keep gutter height in sync with textView content height
         if let gutter = context.coordinator.gutter {
             var gutterFrame = gutter.frame
@@ -142,255 +155,12 @@ struct ComposeTextView: NSViewRepresentable { // swiftlint:disable:this type_bod
         }
     }
 
-    private var baseFont: NSFont {
-        NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-    }
-
     /// #263: point the toolbar bus at this coordinator (weakly — the bus is
     /// owned by the SwiftUI view and outlives view rebuilds).
     private func registerFormatApplier(_ coordinator: Coordinator) {
         guard let formatApplier else { return }
         formatApplier.handler = { [weak coordinator] format in
             coordinator?.apply(format)
-        }
-    }
-
-    @MainActor
-    final class Coordinator: NSObject, NSTextViewDelegate {
-        var document: ComposeDocument
-        /// Cooklang completion vocabulary, updated on view syncs so a
-        /// freshly-built `.boris/` index reaches the popup without a reload.
-        var completion: ComposeCookCompletion = .empty
-        weak var textView: NSTextView?
-        weak var scrollView: NSScrollView?
-        weak var gutter: ComposeLineGutter?
-        private var isApplying = false
-        /// Last click-to-line offset we applied, so re-syncs do not re-jump.
-        private var lastJumpedCharacter: Int?
-        /// #238: Weak reference to the hosted NSTextView, set once during
-        /// `makeNSView` so `jumpToLine` can register undo and scroll.
-        weak var hostedTextView: NSTextView?
-
-        /// Last state we painted, so programmatic syncs (which fire on every
-        /// `document` change) do not re-paint an unchanged buffer.
-        private var lastHighlightedText: String?
-        private var lastHighlightedLanguage: ComposeLanguage?
-
-        init(document: ComposeDocument, completion: ComposeCookCompletion = .empty) {
-            self.document = document
-            self.completion = completion
-        }
-
-        func textDidChange(_ notification: Notification) {
-            guard
-                !isApplying,
-                let textView = notification.object as? NSTextView
-            else { return }
-            isApplying = true
-            defer { isApplying = false }
-
-            let oldText = document.text
-            let newText = textView.string
-            document.text = newText
-            repaintChanged(oldText: oldText, newText: newText, textView: textView, language: document.language)
-            maybeOpenCompletion(in: textView, previousText: oldText)
-            updateGutterWidth()
-            gutter?.needsDisplay = true
-            document.updateCursor(textView.selectedRange())
-            // Keep gutter height in sync with textView's content height
-            if let gutter {
-                var gutterFrame = gutter.frame
-                gutterFrame.size.height = max(textView.bounds.height, scrollView?.contentSize.height ?? 0)
-                gutter.frame = gutterFrame
-            }
-        }
-
-        func textViewDidChangeSelection(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else {
-                gutter?.needsDisplay = true
-                return
-            }
-            gutter?.needsDisplay = true
-            document.updateCursor(textView.selectedRange())
-        }
-
-        /// Update gutter width and text container padding when line count grows
-        /// beyond 4 digits. Minimum 36pt.
-        func updateGutterWidth() {
-            guard let gutter, let textView else { return }
-            let newWidth = gutter.gutterWidth
-            if abs(gutter.frame.width - newWidth) > 0.5 {
-                var gutterFrame = gutter.frame
-                gutterFrame.size.width = newWidth
-                gutter.frame = gutterFrame
-                textView.textContainer?.lineFragmentPadding = newWidth
-                textView.needsLayout = true
-                gutter.needsDisplay = true
-            }
-        }
-
-        /// LATER-3.4: when the author types a Cooklang token marker (`@`,
-        /// `#`, `~`) in a Cooklang buffer with a corpus vocabulary, open the
-        /// native completion popup. The popup is fed by
-        /// `textView(_:completions:forPartialWordRange:indexOfSelectedItem:)`
-        /// below; everything stays inside the single NSTextView surface.
-        private func maybeOpenCompletion(in textView: NSTextView, previousText: String) {
-            guard
-                document.language == .cooklang,
-                !completion.isEmpty,
-                let inserted = CookMarkerScanner.insertedMarker(
-                    from: previousText,
-                    to: textView.string
-                ),
-                CookMarkerScanner.markers.contains(inserted)
-            else { return }
-            textView.complete(nil)
-        }
-
-        // MARK: NSTextView completion (LATER-3.4)
-
-        func textView(
-            _ textView: NSTextView,
-            completions words: [String],
-            forPartialWordRange charRange: NSRange,
-            indexOfSelectedItem index: UnsafeMutablePointer<Int>?
-        ) -> [String] {
-            guard document.language == .cooklang, !completion.isEmpty else { return words }
-            let text = textView.string as NSString
-            guard
-                charRange.location > 0,
-                let marker = CookMarkerScanner.marker(
-                    before: charRange.location,
-                    in: text
-                )
-            else { return words }
-            let prefix = text.substring(with: charRange)
-            let suggestions = completion.suggestions(marker: marker, prefix: prefix)
-            index?.pointee = 0
-            return suggestions
-        }
-
-        /// Incremental repaint (LATER-3.2): restyle only the changed line(s)
-        /// in place instead of replacing the whole storage, so a keystroke in
-        /// a large buffer no longer repaints (and re-lays-out) off-screen
-        /// text. Full paint still runs on load / language change / program-
-        /// matic sync (`applyHighlight`).
-        private func repaintChanged(
-            oldText: String,
-            newText: String,
-            textView: NSTextView,
-            language: ComposeLanguage
-        ) {
-            let change = ComposeHighlighter.changedRange(old: oldText, new: newText)
-            let nsNew = newText as NSString
-            let clampedLocation = min(max(change.location, 0), nsNew.length)
-            let clampedLength = min(max(change.length, 1), nsNew.length - clampedLocation)
-            // Expand to the full containing line(s) so `^`-anchored rules and
-            // delimiters on the edited line restyle together.
-            let target = nsNew.lineRange(
-                for: NSRange(location: clampedLocation, length: clampedLength)
-            )
-            guard target.length > 0, let storage = textView.textStorage as? NSMutableAttributedString else {
-                lastHighlightedText = newText
-                lastHighlightedLanguage = language
-                return
-            }
-            storage.beginEditing()
-            ComposeHighlighter.repaint(newText, language: language, in: target, storage: storage)
-            storage.endEditing()
-            lastHighlightedText = newText
-            lastHighlightedLanguage = language
-        }
-
-        func applyHighlight(_ textView: NSTextView, text: String, language: ComposeLanguage, force: Bool = false) {
-            guard force || text != lastHighlightedText || language != lastHighlightedLanguage else { return }
-            lastHighlightedText = text
-            lastHighlightedLanguage = language
-
-            let highlighted = ComposeHighlighter.highlight(text, language: language)
-            textView.textStorage?.beginEditing()
-            textView.textStorage?.setAttributedString(highlighted)
-            textView.textStorage?.endEditing()
-            textView.typingAttributes = [.font: baseFont, .foregroundColor: NSColor.labelColor]
-        }
-
-        /// Moves the selection to a character offset (click-to-line).
-        /// Runs after highlight so the storage is current; clamps so a
-        /// stale span can never exceed the buffer.
-        func jump(to character: Int?, in textView: NSTextView) {
-            guard let character, character != lastJumpedCharacter else { return }
-            lastJumpedCharacter = character
-            let nsString = textView.string as NSString
-            let clamped = min(max(character, 0), nsString.length)
-            let range = NSRange(location: clamped, length: 0)
-            textView.setSelectedRange(range)
-            textView.scrollRangeToVisible(range)
-        }
-
-        /// #238: Jump to a 1-based line number. Registers the current cursor
-        /// position in the undo stack so ⌘Z restores it. Clamps to the
-        /// buffer range; empty buffers jump to offset 0.
-        func jumpToLine(_ line: Int) {
-            guard let textView = hostedTextView else { return }
-            let nsString = textView.string as NSString
-            guard nsString.length > 0 else { return }
-            let currentRange = textView.selectedRange()
-            let undoManager = textView.undoManager
-            undoManager?.registerUndo(withTarget: textView) { target in
-                target.setSelectedRange(currentRange)
-                target.scrollRangeToVisible(currentRange)
-            }
-            undoManager?.setActionName("Go to Line")
-            let totalLines = max(1, nsString.components(separatedBy: "\n").count)
-            let clamped = max(1, min(line, totalLines))
-            var foundLine = 1
-            var targetLocation = 0
-            nsString.enumerateSubstrings(
-                in: NSRange(location: 0, length: nsString.length),
-                options: [.byLines, .substringNotRequired]
-            ) { _, range, _, stop in
-                if foundLine == clamped {
-                    targetLocation = range.location
-                    stop.pointee = true
-                }
-                foundLine += 1
-            }
-            let range = NSRange(location: targetLocation, length: 0)
-            textView.setSelectedRange(range)
-            textView.scrollRangeToVisible(range)
-        }
-
-        /// #263: applies a toolbar format at the current selection. The
-        /// mutation flows through `shouldChangeText` / `didChangeText` so the
-        /// undo stack records one group per press and the ordinary
-        /// `textDidChange` delegate path (buffer sync + repaint) runs
-        /// unchanged.
-        func apply(_ format: ComposeFormat) {
-            guard let textView, document.language.supportsFormatting else { return }
-            guard
-                let edit = ComposeFormat.apply(
-                    format,
-                    to: textView.string,
-                    selectedRange: textView.selectedRange(),
-                    language: document.language
-                )
-            else { return }
-            let undoManager = textView.undoManager
-            undoManager?.beginUndoGrouping()
-            defer { undoManager?.endUndoGrouping() }
-            undoManager?.setActionName(format.actionName)
-            if textView.shouldChangeText(in: edit.replacedRange, replacementString: edit.replacement) {
-                textView.textStorage?.replaceCharacters(
-                    in: edit.replacedRange,
-                    with: edit.replacement
-                )
-                textView.didChangeText()
-                textView.setSelectedRange(edit.selection)
-            }
-        }
-
-        private var baseFont: NSFont {
-            NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
         }
     }
 }

--- a/Sources/Compose/ComposeTypography.swift
+++ b/Sources/Compose/ComposeTypography.swift
@@ -1,0 +1,80 @@
+import AppKit
+import Observation
+
+/// #264: single source of truth for the compose buffer's reading type —
+/// one ladder of sizes (11…21 pt, default 13), a gutter toggle, and their
+/// UserDefaults persistence (machine state → plist; D2-safe). Both old
+/// hardcode sites (`ComposeTextView.baseFont` and its Coordinator duplicate)
+/// consume this.
+@MainActor
+@Observable
+final class ComposeTypography {
+    static let defaultSize: CGFloat = 13
+    static let minSize: CGFloat = 11
+    static let maxSize: CGFloat = 21
+    /// Breathing-room paragraph line spacing (#264), buffer-only cosmetic.
+    static let lineSpacing: CGFloat = 4
+
+    static let sizeStorageKey = "composeBufferFontSize"
+    static let gutterStorageKey = "composeShowLineNumbers"
+
+    private(set) var size: CGFloat
+    private(set) var showsLineNumbers: Bool
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let stored = defaults.double(forKey: Self.sizeStorageKey)
+        size = stored == 0
+            ? Self.defaultSize
+            : min(max(CGFloat(stored), Self.minSize), Self.maxSize)
+        // Checked by default: the gutter ships on until the author turns it off.
+        showsLineNumbers =
+            defaults.object(forKey: Self.gutterStorageKey) == nil
+                || defaults.bool(forKey: Self.gutterStorageKey)
+    }
+
+    var font: NSFont {
+        NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+    }
+
+    var boldFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: size, weight: .bold)
+    }
+
+    var italicFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: size, weight: .regular).withTraits(.italic)
+    }
+
+    /// Paragraph style carrying the reading line spacing.
+    var paragraphStyle: NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = Self.lineSpacing
+        return style
+    }
+
+    func zoomIn() {
+        store(size: size + 1)
+    }
+
+    func zoomOut() {
+        store(size: size - 1)
+    }
+
+    func resetToActualSize() {
+        store(size: Self.defaultSize)
+    }
+
+    func setLineNumbers(_ visible: Bool) {
+        showsLineNumbers = visible
+        defaults.set(visible, forKey: Self.gutterStorageKey)
+    }
+
+    private func store(size newValue: CGFloat) {
+        let clamped = min(max(newValue, Self.minSize), Self.maxSize)
+        guard clamped != size else { return }
+        size = clamped
+        defaults.set(Double(size), forKey: Self.sizeStorageKey)
+    }
+}

--- a/Sources/Compose/ComposeWindow.swift
+++ b/Sources/Compose/ComposeWindow.swift
@@ -46,7 +46,8 @@ struct ComposeWindow: View {
                     themeCSS: themeCSS,
                     cookCompletion: cookCompletion,
                     onSave: save,
-                    externalJump: externalJump
+                    externalJump: externalJump,
+                    typography: runtime.composeTypography
                 )
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     ComposeStatusBar(

--- a/Tests/ContractTests/ComposeReadingComfortTests.swift
+++ b/Tests/ContractTests/ComposeReadingComfortTests.swift
@@ -1,0 +1,113 @@
+import AppKit
+import XCTest
+
+/// #264 — Compose reading comfort: the type-size ladder (⌘+/⌘−/⌘0), its
+/// UserDefaults persistence, and the gutter toggle's padding collapse.
+@MainActor
+final class ComposeReadingComfortTests: XCTestCase {
+    private var suiteName: String { "compose-typography-\(UUID().uuidString)" }
+    private var suites: [String] = []
+
+    private func makeDefaults() -> UserDefaults {
+        let name = suiteName
+        suites.append(name)
+        return UserDefaults(suiteName: name)!
+    }
+
+    override func tearDown() {
+        for name in suites {
+            UserDefaults().removePersistentDomain(forName: name)
+        }
+        suites.removeAll()
+    }
+
+    // MARK: - Size ladder
+
+    func testFontSizeStepsClampAtBounds() {
+        let typography = ComposeTypography(defaults: makeDefaults())
+        XCTAssertEqual(typography.size, 13)
+
+        // Walk up to the ceiling.
+        for _ in 0..<20 {
+            typography.zoomIn()
+        }
+        XCTAssertEqual(typography.size, 21, "the ladder clamps at 21")
+
+        // Walk down to the floor.
+        for _ in 0..<30 {
+            typography.zoomOut()
+        }
+        XCTAssertEqual(typography.size, 11, "the ladder clamps at 11")
+    }
+
+    func testActualSizeRestoresDefault() {
+        let typography = ComposeTypography(defaults: makeDefaults())
+        typography.zoomIn()
+        typography.zoomIn()
+        XCTAssertEqual(typography.size, 15)
+
+        typography.resetToActualSize()
+        XCTAssertEqual(typography.size, 13)
+        XCTAssertEqual(typography.font.pointSize, 13)
+    }
+
+    func testStoredSizeIsClampedAndPersisted() {
+        let defaults = makeDefaults()
+        defaults.set(99.0, forKey: ComposeTypography.sizeStorageKey)
+        XCTAssertEqual(ComposeTypography(defaults: defaults).size, 21)
+
+        defaults.set(2.0, forKey: ComposeTypography.sizeStorageKey)
+        XCTAssertEqual(ComposeTypography(defaults: defaults).size, 11)
+
+        let typography = ComposeTypography(defaults: defaults)
+        typography.zoomIn()
+        XCTAssertEqual(
+            defaults.double(forKey: ComposeTypography.sizeStorageKey), 12,
+            "size changes persist to machine state"
+        )
+    }
+
+    // MARK: - Gutter toggle
+
+    func testLineNumbersDefaultOnAndPersist() {
+        let defaults = makeDefaults()
+        XCTAssertTrue(ComposeTypography(defaults: defaults).showsLineNumbers)
+
+        let typography = ComposeTypography(defaults: defaults)
+        typography.setLineNumbers(false)
+        XCTAssertFalse(ComposeTypography(defaults: defaults).showsLineNumbers)
+    }
+
+    func testGutterToggleCollapsesPadding() {
+        let coordinator = ComposeTextView.Coordinator(document: ComposeDocument(text: "a\nb\nc"))
+        let textView = NSTextView()
+        coordinator.textView = textView
+        coordinator.hostedTextView = textView
+
+        let gutter = ComposeLineGutter()
+        gutter.textView = textView
+        coordinator.gutter = gutter
+
+        // Visible: reserved padding tracks the gutter width.
+        coordinator.showsLineNumbers = true
+        coordinator.updateGutterWidth()
+        coordinator.applyGutterVisibility()
+        XCTAssertFalse(gutter.isHidden)
+        XCTAssertGreaterThanOrEqual(textView.textContainer?.lineFragmentPadding ?? 0, 36)
+
+        // Hidden: digits gone and the reserved padding collapses to the
+        // base inset.
+        coordinator.showsLineNumbers = false
+        coordinator.updateGutterWidth()
+        coordinator.applyGutterVisibility()
+        XCTAssertTrue(gutter.isHidden)
+        XCTAssertEqual(textView.textContainer?.lineFragmentPadding, 5)
+    }
+
+    // MARK: - Paragraph spacing
+
+    func testParagraphStyleCarriesLineSpacing() {
+        let typography = ComposeTypography(defaults: makeDefaults())
+        XCTAssertEqual(typography.paragraphStyle.lineSpacing, 4)
+    }
+}

--- a/docs/help.md
+++ b/docs/help.md
@@ -75,6 +75,15 @@ Every menu verb and keyboard shortcut:
 | Editor | `⌘⇧E` | Open the Editor companion window (token-isolated host for `boris-editor`). |
 | Compose | `⌘⇧C` | Open the Compose window (native Markdown / Textile / Cooklang editor for the selected page; Oliver-powered preview; Save flows into the coordinator's validate gate). |
 
+### Format
+
+| Verb | Shortcut | Description |
+| --- | --- | --- |
+| Zoom In | `⌘+` | Grow the Compose buffer type one step (11–21 pt ladder). Applies to the buffer, typing attributes, and the gutter digits. |
+| Zoom Out | `⌘-` | Shrink the Compose buffer type one step (11–21 pt ladder). |
+| Actual Size | `⌘0` | Restore the Compose buffer's default 13 pt type. |
+| Line Numbers | — | Toggle the Compose line-number gutter (checked by default). Hiding it collapses its reserved padding. |
+
 ### Help
 
 | Verb | Shortcut | Description |


### PR DESCRIPTION
Closes #264 (child of tracker #262). Runs after #263 (shares `ComposeTextView.swift`) — based on that merge.

## What

- **Type size steps**: Format-menu **Zoom In / Zoom Out / Actual Size** (`⌘+` / `⌘-` / `⌘0`) over an 11…21 pt ladder, default 13. Single source of truth in new `ComposeTypography` (`@Observable`, on `AppRuntime`); both old hardcoded font sites are gone. The highlight paint threads the size through so bold/italic variants scale; gutter digits ride the same ladder.
- **Persistence**: `@AppStorage`-equivalent machine state via `UserDefaults` keys `composeBufferFontSize` / `composeShowLineNumbers` (D2-safe). Relaunch keeps the size.
- **Line spacing + breathing room**: paragraph line spacing 4 pt applied to typing attributes and the full repaint; container inset bumped to 14 pt vertical.
- **Gutter toggle**: Format-menu **Line Numbers** (checked by default); hidden state collapses the reserved `lineFragmentPadding` back to the base 5 pt and hides `ComposeLineGutter`.
- **HelpAudit gate**: every verb rowed in `docs/help.md` (new Format section); HelpAuditTests stays green.
- Refactor: `Coordinator` moved to a nested-type extension (`ComposeTextCoordinator.swift`) for file-length limits; no API change.

## Tests

`ComposeReadingComfortTests`: ladder clamps at 11…21, actual-size restores 13, stored sizes clamp + persist, gutter default-on + persists, hidden gutter collapses padding to base inset, paragraph style carries 4 pt spacing.

`SKIP_EMBED_BORIS=1 make build`, `make test`, `make lint` green.

## Must-not-land honored

Buffer stays plain monospace text (no proportional mode, no WYSIWYG); one app-wide setting (no per-document size); highlight rules and diagnostics jump math untouched.