### PR TITLE
compose: front-matter form auto-show + friendly labels (#266)

### DIFF
--- a/Sources/Compose/ComposeEditorView.swift
+++ b/Sources/Compose/ComposeEditorView.swift
@@ -36,7 +36,10 @@ struct ComposeEditorView: View {
     @State private var jumpToCharacter: Int?
     @State private var showPreview = true
     /// LATER-3.3: leading pane editing the closed front-matter key set.
+    /// #266: seeded per page load — a page carrying front matter shows the
+    /// pane without a click; an explicit toggle wins until the next page.
     @State private var showFrontmatter = false
+    @State private var userToggledFrontmatter = false
     @State private var previewOptions = MarkupRenderOptions()
     /// #263: toolbar-to-text-view seam for formatting verbs.
     @State private var formatApplier = ComposeFormatApplier()
@@ -45,6 +48,22 @@ struct ComposeEditorView: View {
     private var autosaveName: String {
         "ComposeSplit-\(document.language.rawValue)"
     }
+
+    /// #266: the author's own toggle routes through here so auto-show never
+    /// overrides an explicit choice while the page stays loaded.
+    private var frontmatterBinding: Binding<Bool> {
+        Binding(
+            get: { showFrontmatter },
+            set: { newValue in
+                userToggledFrontmatter = true
+                showFrontmatter = newValue
+            }
+        )
+    }
+
+    // #266: pane visibility — seeded from presence on page load; once the
+    // author toggles, their choice wins until the next page. The rule
+    // itself lives on `ComposeFrontmatter.paneVisibility`.
 
     @State private var saveError: String?
     /// #238: Go to Line — when set, the editor jumps to this line number.
@@ -104,6 +123,16 @@ struct ComposeEditorView: View {
         }
         .task(id: externalJump) {
             if let externalJump { jumpToCharacter = externalJump }
+        }
+        // #266: seed the pane per page load. The preference resets with the
+        // page — a fresh document that carries front matter shows the form.
+        .task(id: document.fileURL) {
+            userToggledFrontmatter = false
+            showFrontmatter = ComposeFrontmatter.paneVisibility(
+                current: showFrontmatter,
+                present: document.frontmatter != nil,
+                userToggled: userToggledFrontmatter
+            )
         }
         // #238: Go to Line — ⌘L opens the dialog via a hidden button
         // (onKeyPress overload resolution is ambiguous in macOS 26).
@@ -178,7 +207,7 @@ struct ComposeEditorView: View {
             .accessibilityHint("Toggle the Oliver preview pane")
             .accessibilityAddTraits(showPreview ? .isSelected : [])
 
-            Toggle(isOn: $showFrontmatter) {
+            Toggle(isOn: frontmatterBinding) {
                 Label("Front Matter", systemImage: "doc.text.magnifyingglass")
             }
             .toggleStyle(.button)

--- a/Sources/Compose/ComposeFrontmatter.swift
+++ b/Sources/Compose/ComposeFrontmatter.swift
@@ -28,6 +28,13 @@ enum ComposeFrontmatter {
         static let empty = Fields()
     }
 
+    /// #266: front-matter pane visibility rule — seeded from presence on
+    /// page load; once the author toggles the pane, their choice wins until
+    /// the next page.
+    static func paneVisibility(current: Bool, present: Bool, userToggled: Bool) -> Bool {
+        userToggled ? current : present
+    }
+
     // MARK: - Parse (minimal YAML subset for the closed keys)
 
     /// Reads the closed keys out of a front-matter payload. Unknown keys are

--- a/Sources/Compose/ComposeFrontmatterForm.swift
+++ b/Sources/Compose/ComposeFrontmatterForm.swift
@@ -5,6 +5,10 @@ import SwiftUI
 /// buffer on Apply. Boundary 4 holds — Apply touches only the buffer;
 /// the explicit Save / ⌘S is the only disk writer. Unknown keys in the
 /// payload are preserved (never destroyed by the form).
+///
+/// #266: every field carries a human label plus a tooltip naming its
+/// schema key, Apply is named for what it does ("Apply to Source"), and a
+/// page without front matter gets an empty state that can add one.
 struct ComposeFrontmatterForm: View {
     @Bindable var document: ComposeDocument
 
@@ -16,52 +20,13 @@ struct ComposeFrontmatterForm: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Label("Front Matter", systemImage: "doc.text.magnifyingglass")
-                    .font(.headline)
-                Spacer()
-                Button("Apply") { apply() }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .help("Overlay these fields onto the buffer's front matter")
+            header
+            if document.frontmatter != nil {
+                Divider()
+                editorForm
+            } else {
+                emptyState
             }
-            .padding(10)
-            Divider()
-            Form {
-                Section("Identity") {
-                    TextField("ID", text: $fields.id)
-                    TextField("Title", text: $fields.title)
-                    TextField("Parent", text: $fields.parent)
-                    Picker("Status", selection: $fields.status) {
-                        Text("—").tag("")
-                        Text("Draft").tag("draft")
-                        Text("Published").tag("published")
-                        Text("Archived").tag("archived")
-                    }
-                }
-                Section("Publication") {
-                    TextField("Published At", text: $fields.publishedAt)
-                    TextField("Summary", text: $fields.summary)
-                    TextField("Servings", text: $fields.servings)
-                }
-                Section("Tags") {
-                    TextField("Comma-separated", text: tagsText)
-                }
-                Section("Relations") {
-                    ForEach(Array($fields.relations.enumerated()), id: \.offset) { _, $relation in
-                        HStack(spacing: 6) {
-                            TextField("kind", text: $relation.kind)
-                                .frame(minWidth: 70)
-                            TextField("target", text: $relation.target)
-                        }
-                    }
-                    Button("Add Relation") {
-                        fields.relations.append(ComposeFrontmatter.Relation(kind: "", target: ""))
-                    }
-                }
-            }
-            .formStyle(.grouped)
-            .font(.callout)
         }
         .frame(minWidth: 230, idealWidth: 260)
         .task(id: document.fileURL) {
@@ -70,6 +35,122 @@ struct ComposeFrontmatterForm: View {
         .onChange(of: document.text) { _, _ in
             syncFromBuffer()
         }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack {
+                Label("Front Matter", systemImage: "doc.text.magnifyingglass")
+                    .font(.headline)
+                Spacer()
+                Button("Apply to Source") { apply() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(document.frontmatter == nil && fields == .empty)
+                    .help("Overlay these fields onto the buffer's front matter")
+            }
+            // Boundary 4 made legible (#266): Apply edits the buffer; disk
+            // waits for the explicit save.
+            Text("Edits the buffer only — Save (⌘S) writes the file.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(10)
+    }
+
+    // MARK: - Empty state (#266)
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Label("No Front Matter", systemImage: "doc.plaintext")
+                .font(.headline)
+            Text(
+                "This page starts straight in with its body. Add a front-matter "
+                    + "block to set metadata like ID, status, or tags."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            Button("Add Front Matter") {
+                addFrontMatter()
+            }
+            .controlSize(.small)
+            .help("Insert a starter front-matter block at the top of the buffer")
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+
+    // MARK: - Form
+
+    private var editorForm: some View {
+        Form {
+            Section("Identity") {
+                labeledRow("Page ID", help: "`id` — stable identifier used by links and the graph.") {
+                    TextField("page-id", text: $fields.id)
+                }
+                labeledRow("Title", help: "`title` — the page title shown in mailboxes and the graph.") {
+                    TextField("Title", text: $fields.title)
+                }
+                labeledRow("Appears under", help: "`parent` — the page this one appears under (its parent trunk).") {
+                    TextField("parent-page", text: $fields.parent)
+                }
+                labeledRow("Status", help: "`status` — draft, published, or archived.") {
+                    Picker("Status", selection: $fields.status) {
+                        Text("—").tag("")
+                        Text("Draft").tag("draft")
+                        Text("Published").tag("published")
+                        Text("Archived").tag("archived")
+                    }
+                }
+            }
+            Section("Publication") {
+                labeledRow("Publish date", help: "`published_at` — when the page goes live (e.g. 2026-08-19).") {
+                    TextField("2026-08-19", text: $fields.publishedAt)
+                }
+                labeledRow("Summary", help: "`summary` — short summary for listings.") {
+                    TextField("Summary", text: $fields.summary)
+                }
+                labeledRow("Servings", help: "`servings` — recipe yield (Cooklang recipes only).") {
+                    TextField("Servings", text: $fields.servings)
+                }
+            }
+            Section("Tags") {
+                labeledRow("Tags", help: "`tags` — comma-separated list.") {
+                    TextField("Comma-separated", text: tagsText)
+                }
+            }
+            Section("Relations") {
+                ForEach(Array($fields.relations.enumerated()), id: \.offset) { _, $relation in
+                    HStack(spacing: 6) {
+                        TextField("Relationship type", text: $relation.kind)
+                            .frame(minWidth: 70)
+                        TextField("Links to", text: $relation.target)
+                    }
+                    .help("`relations` entry — `kind` / `target` pair linking a related page.")
+                }
+                Button("Add Relation") {
+                    fields.relations.append(ComposeFrontmatter.Relation(kind: "", target: ""))
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .font(.callout)
+    }
+
+    /// Visible label + control + schema-faithful tooltip (#266).
+    private func labeledRow(
+        _ label: String,
+        help: String,
+        @ViewBuilder control: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+            control()
+        }
+        .help(help)
     }
 
     private var tagsText: Binding<String> {
@@ -83,6 +164,8 @@ struct ComposeFrontmatterForm: View {
             }
         )
     }
+
+    // MARK: - Sync / apply
 
     private func syncFromBuffer() {
         if let frontmatter = document.frontmatter {
@@ -112,5 +195,14 @@ struct ComposeFrontmatterForm: View {
             document.text = newBlock + document.text
         }
         appliedPayload = newPayload
+    }
+
+    /// #266: inserts a starter block through the existing apply path. A
+    /// draft status seeds the payload so the block is never empty.
+    private func addFrontMatter() {
+        if fields == .empty {
+            fields = ComposeFrontmatter.Fields(status: "draft")
+        }
+        apply()
     }
 }

--- a/Tests/ContractTests/ComposeFrontmatterProminenceTests.swift
+++ b/Tests/ContractTests/ComposeFrontmatterProminenceTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+/// #266 — Front-matter form prominence + friendly labels.
+@MainActor
+final class ComposeFrontmatterProminenceTests: XCTestCase {
+    // MARK: - Auto-show rule
+
+    func testAutoShowOnlyWhenFrontmatterPresent() {
+        XCTAssertTrue(
+            ComposeFrontmatter.paneVisibility(current: false, present: true, userToggled: false),
+            "a page carrying front matter shows the pane without a click"
+        )
+        XCTAssertFalse(
+            ComposeFrontmatter.paneVisibility(current: false, present: false, userToggled: false),
+            "a page without front matter keeps the pane hidden"
+        )
+    }
+
+    func testExplicitToggleBeatsAutoShow() {
+        // The author toggled the pane off; a re-sync must not force it open…
+        XCTAssertFalse(
+            ComposeFrontmatter.paneVisibility(current: false, present: true, userToggled: true)
+        )
+        // …nor an auto-showed pane closed.
+        XCTAssertTrue(
+            ComposeFrontmatter.paneVisibility(current: true, present: false, userToggled: true)
+        )
+    }
+
+    // MARK: - Add-front-matter default block
+
+    func testAddFrontmatterInsertsDefaultBlock() {
+        var fields = ComposeFrontmatter.Fields.empty
+        XCTAssertTrue(fields == .empty, "a fresh form starts empty")
+
+        // The empty state seeds a draft status so the block is never empty,
+        // then inserts through the existing apply path.
+        if fields == .empty {
+            fields = ComposeFrontmatter.Fields(status: "draft")
+        }
+        let payload = ComposeFrontmatter.apply(fields, to: "")
+        XCTAssertEqual(payload, "status: draft")
+
+        let overlay = ComposeFrontmatter.apply(fields, to: "custom: keep-me")
+        XCTAssertEqual(overlay, "custom: keep-me\nstatus: draft", "unknown keys survive the insert")
+    }
+
+    func testUnclosedOpenerIsNotFrontMatter() {
+        let document = ComposeDocument(text: "---\nid: nope")
+        XCTAssertNil(document.frontmatter, "an unclosed opener is not front matter per Oliver's rule")
+    }
+}


### PR DESCRIPTION
Closes #266 (child of tracker #262). Runs after #263 (shares `ComposeEditorView.swift`).

## What

- **Auto-show**: a page whose buffer carries front matter opens with the form visible — no click. Seeded per page load via `.task(id: document.fileURL)`; an explicit toggle wins while the page stays loaded (toggle routes through a binding that flags user intent; preference resets on page switch).
- **Friendly labels + schema-faithful help**: every field gets a visible label and a tooltip naming its schema key — Page ID (`id`, "stable identifier used by links and the graph"), Appears under (`parent`), Status (`status`), Publish date (`published_at`, ISO-date hint matching the corpus), Summary, Servings ("recipes only"), Tags. Relations rows read "Relationship type" / "Links to" with the `kind`/`target` pair named in the tooltip.
- **Apply naming**: button reads **"Apply to Source"** with the caption "Edits the buffer only — Save (⌘S) writes the file." Boundary 4 made legible; no disk writes added.
- **Empty state**: pages without front matter show short copy plus an **Add Front Matter** button that seeds `status: draft` and inserts through the existing `apply()` path (unknown keys still preserved).
- Unclosed `---` stays not-front-matter (Oliver's rule); visibility seeding treats it as absent.

## Tests

`ComposeFrontmatterProminenceTests`: auto-show only when present, explicit toggle beats re-seed both directions, add-front-matter produces the default block through the apply path (and preserves unknown keys), unclosed opener is nil.

`SKIP_EMBED_BORIS=1 make build`, `make test`, `make lint` green; existing `ComposeFrontmatterTests` untouched and green.