### PR TITLE
sidebar: persisted tree shape, branch badge, sync spinner, header landmark (#274)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -108,6 +108,7 @@ targets:
       - path: Sources/App/CoordinatorPolicy.swift
       - path: Sources/App/SaveValidateGate.swift
       - path: Sources/Workspace/Source.swift
+      - path: Sources/Workspace/SidebarExpansionState.swift
       - path: Sources/Workspace/WorkspacePersistence.swift
       - path: Sources/Workspace/WorkspaceSelection.swift
       - path: Sources/Workspace/Local/LocalSource.swift

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
 /// Left column. Each source is an account header; mailboxes are the folders.
+/// The tree shape (collapsed sources, Pages disclosures) persists across
+/// launches via `WorkspaceStore.expansion` (#274).
 struct SourceSidebar: View {
     @Environment(WorkspaceStore.self) private var store
 
     @State private var toolbarBand: CGFloat = 0
-    @State private var collapsedSources: Set<SourceID> = []
 
     var body: some View {
         List(selection: selectedRow) {
@@ -44,14 +45,8 @@ struct SourceSidebar: View {
 
     private func isExpanded(for sourceID: SourceID) -> Binding<Bool> {
         Binding(
-            get: { !collapsedSources.contains(sourceID) },
-            set: { expanded in
-                if expanded {
-                    collapsedSources.remove(sourceID)
-                } else {
-                    collapsedSources.insert(sourceID)
-                }
-            }
+            get: { !store.expansion.collapsedSources.contains(sourceID.raw.uuidString) },
+            set: { store.setSourceExpanded(sourceID, expanded: $0) }
         )
     }
 
@@ -137,15 +132,21 @@ private struct SourceSection: View {
 
 /// Pages plus its trunk-folder children. One child row per trunk;
 /// the selection value is the trunk **id**. Clicking Pages writes
-/// `pages`; clicking a trunk writes its raw id. Expansion is not
-/// persisted (resets to expanded each launch).
+/// `pages`; clicking a trunk writes its raw id. Expansion persists
+/// per source via the store (#274).
 private struct PagesGroup: View {
     let item: SourceItem
     let store: WorkspaceStore
-    @State private var expanded = true
 
     private var pagesRowID: MailboxRowID {
         MailboxRowID(sourceID: item.id, mailbox: WorkspaceMailbox.pages)
+    }
+
+    private var isExpanded: Binding<Bool> {
+        Binding(
+            get: { SidebarExpansionState.pagesExpanded(store.expansion, id: item.id) },
+            set: { store.setPagesExpanded(item.id, expanded: $0) }
+        )
     }
 
     private var graph: Graph? {
@@ -172,7 +173,7 @@ private struct PagesGroup: View {
             .tag(pagesRowID)
             .contextMenu { sourceMenu(item, store: store) }
         } else {
-            DisclosureGroup(isExpanded: $expanded) {
+            DisclosureGroup(isExpanded: isExpanded) {
                 ForEach(trunks, id: \.id) { trunk in
                     let trunkCount = LocalPlayGraph.pages(in: allPages, trunkID: trunk.id).count
                     TrunkRow(item: item, trunk: trunk, count: trunkCount)
@@ -301,6 +302,14 @@ private struct SourceAccountHeader: View {
                     .font(.system(size: 13.5, weight: .bold))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
+                // #274: the checkout branch is known at add/load time —
+                // surface it instead of hiding it in the Remote mailbox.
+                if let branch = item.branch, !branch.isEmpty, item.isAvailable {
+                    Label(branch, systemImage: "arrow.triangle.branch")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
                 if !item.isAvailable {
                     Text("Unreachable — Relocate / Remove")
                         .font(.caption2)
@@ -309,6 +318,13 @@ private struct SourceAccountHeader: View {
                 }
             }
             Spacer()
+            // #274: git work in flight is visible at a glance.
+            if item.isSyncing {
+                ProgressView()
+                    .controlSize(.small)
+                    .help("Syncing…")
+                    .accessibilityLabel("Syncing")
+            }
         }
         .padding(.vertical, 3)
         .help(
@@ -326,5 +342,7 @@ private struct SourceAccountHeader: View {
                 ? "Select this account"
                 : "Unreachable. Relocate or remove this source."
         )
+        // #274: source headers are VoiceOver rotor landmarks.
+        .accessibilityAddTraits(.isHeader)
     }
 }

--- a/Sources/Workspace/SidebarExpansionState.swift
+++ b/Sources/Workspace/SidebarExpansionState.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// #274: the sidebar's tree shape — which sources are collapsed and whether
+/// each source's Pages disclosure is open. Machine state (D2): one
+/// UserDefaults key, JSON payload, injected defaults for tests.
+///
+/// Pure rules + codec live here so ContractTests can pin the round-trip;
+/// `WorkspaceStore` (deliberately not in the test target) delegates to this.
+enum SidebarExpansionState {
+    static let defaultsKey = "sidebarExpansion"
+
+    struct Payload: Codable, Equatable, Sendable {
+        /// Source ids whose Section is collapsed. Absent = expanded.
+        var collapsedSources: [String] = []
+        /// Source id → Pages-disclosure openness. Absent = expanded (the
+        /// shipping default).
+        var pagesExpanded: [String: Bool] = [:]
+    }
+
+    // MARK: - Codec
+
+    static func encode(_ payload: Payload) throws -> Data {
+        try JSONEncoder().encode(payload)
+    }
+
+    static func decode(_ data: Data) -> Payload? {
+        try? JSONDecoder().decode(Payload.self, from: data)
+    }
+
+    /// Reads the persisted shape; a missing or undecodable payload means
+    /// "everything expanded" — never an error surface.
+    static func load(defaults: UserDefaults) -> Payload {
+        guard let data = defaults.data(forKey: defaultsKey) else { return Payload() }
+        return decode(data) ?? Payload()
+    }
+
+    static func save(_ payload: Payload, defaults: UserDefaults) {
+        guard let data = try? encode(payload) else { return }
+        defaults.set(data, forKey: defaultsKey)
+    }
+
+    // MARK: - Rules
+
+    static func isCollapsed(_ payload: Payload, id: SourceID) -> Bool {
+        payload.collapsedSources.contains(id.raw.uuidString)
+    }
+
+    static func collapsing(_ payload: Payload, id: SourceID) -> Payload {
+        var next = payload
+        let key = id.raw.uuidString
+        if !next.collapsedSources.contains(key) {
+            next.collapsedSources.append(key)
+        }
+        return next
+    }
+
+    static func expanding(_ payload: Payload, id: SourceID) -> Payload {
+        var next = payload
+        next.collapsedSources.removeAll { $0 == id.raw.uuidString }
+        return next
+    }
+
+    static func pagesExpanded(_ payload: Payload, id: SourceID) -> Bool {
+        payload.pagesExpanded[id.raw.uuidString] ?? true
+    }
+
+    static func settingPages(
+        _ payload: Payload,
+        id: SourceID,
+        expanded: Bool
+    ) -> Payload {
+        var next = payload
+        next.pagesExpanded[id.raw.uuidString] = expanded
+        return next
+    }
+}

--- a/Sources/Workspace/Source.swift
+++ b/Sources/Workspace/Source.swift
@@ -137,4 +137,10 @@ enum SourceItem: Identifiable, Hashable, Sendable {
         case .github(let source): return source.branch
         }
     }
+
+    /// True while a git sync is in flight (GitHub sources only, M15).
+    var isSyncing: Bool {
+        if case .github(let github) = self { return github.isSyncing }
+        return false
+    }
 }

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -25,9 +25,37 @@ final class WorkspaceStore {
     /// lookups are never cached, so a later build can make it appear.
     private(set) var graphs: [SourceID: Graph] = [:]
 
+    /// #274: the sidebar's persisted tree shape. Rules + codec live in
+    /// `SidebarExpansionState` (test-target friendly); the store owns the
+    /// UserDefaults round-trip.
+    private(set) var expansion = SidebarExpansionState.Payload()
+
+    /// #274: collapses or expands a source section, persisting immediately.
+    func setSourceExpanded(_ id: SourceID, expanded: Bool) {
+        let next = expanded
+            ? SidebarExpansionState.expanding(expansion, id: id)
+            : SidebarExpansionState.collapsing(expansion, id: id)
+        guard next != expansion else { return }
+        expansion = next
+        saveExpansion()
+    }
+
+    /// #274: sets one source's Pages-disclosure openness, persisting.
+    func setPagesExpanded(_ id: SourceID, expanded: Bool) {
+        let next = SidebarExpansionState.settingPages(expansion, id: id, expanded: expanded)
+        guard next != expansion else { return }
+        expansion = next
+        saveExpansion()
+    }
+
+    private func saveExpansion() {
+        SidebarExpansionState.save(expansion, defaults: defaults)
+    }
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         load()
+        expansion = SidebarExpansionState.load(defaults: defaults)
         refreshRecentFolders()
     }
 

--- a/Tests/ContractTests/SidebarExpansionStateTests.swift
+++ b/Tests/ContractTests/SidebarExpansionStateTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+/// #274 — Sidebar expansion persistence. The tree shape (collapsed
+/// sources, per-source Pages disclosures) survives relaunch via one
+/// UserDefaults payload; rules + codec are pinned here.
+@MainActor
+final class SidebarExpansionStateTests: XCTestCase {
+    private var suiteName: String { "sidebar-expansion-\(UUID().uuidString)" }
+    private var suites: [String] = []
+
+    private func makeDefaults() -> UserDefaults {
+        let name = suiteName
+        suites.append(name)
+        return UserDefaults(suiteName: name)!
+    }
+
+    override func tearDown() {
+        for name in suites {
+            UserDefaults().removePersistentDomain(forName: name)
+        }
+        suites.removeAll()
+    }
+
+    func testCollapseExpandRoundTrip() {
+        let defaults = makeDefaults()
+        let id = SourceID()
+
+        var payload = SidebarExpansionState.load(defaults: defaults)
+        XCTAssertFalse(SidebarExpansionState.isCollapsed(payload, id: id), "everything starts expanded")
+
+        payload = SidebarExpansionState.collapsing(payload, id: id)
+        XCTAssertTrue(SidebarExpansionState.isCollapsed(payload, id: id))
+        SidebarExpansionState.save(payload, defaults: defaults)
+
+        let reloaded = SidebarExpansionState.load(defaults: defaults)
+        XCTAssertTrue(SidebarExpansionState.isCollapsed(reloaded, id: id), "collapse survives a reload")
+    }
+
+    func testExpandingRemovesCollapseEntry() {
+        let id = SourceID()
+        var payload = SidebarExpansionState.Payload()
+        payload = SidebarExpansionState.collapsing(payload, id: id)
+        payload = SidebarExpansionState.expanding(payload, id: id)
+        XCTAssertFalse(SidebarExpansionState.isCollapsed(payload, id: id))
+    }
+
+    func testPagesDisclosurePersistsPerSource() {
+        let defaults = makeDefaults()
+        let sourceA = SourceID()
+        let sourceB = SourceID()
+
+        var payload = SidebarExpansionState.load(defaults: defaults)
+        XCTAssertTrue(SidebarExpansionState.pagesExpanded(payload, id: sourceA), "default is expanded")
+        XCTAssertEqual(
+            SidebarExpansionState.pagesExpanded(payload, id: sourceA),
+            SidebarExpansionState.pagesExpanded(payload, id: sourceB),
+            "both sources default the same"
+        )
+
+        payload = SidebarExpansionState.settingPages(payload, id: sourceA, expanded: false)
+        SidebarExpansionState.save(payload, defaults: defaults)
+
+        let reloaded = SidebarExpansionState.load(defaults: defaults)
+        XCTAssertFalse(SidebarExpansionState.pagesExpanded(reloaded, id: sourceA))
+        XCTAssertTrue(
+            SidebarExpansionState.pagesExpanded(reloaded, id: sourceB),
+            "source B keeps the default"
+        )
+    }
+
+    func testMissingOrGarbagePayloadMeansAllExpanded() {
+        let defaults = makeDefaults()
+        XCTAssertEqual(
+            SidebarExpansionState.load(defaults: defaults),
+            SidebarExpansionState.Payload(),
+            "no key → everything expanded"
+        )
+        defaults.set(Data("not json".utf8), forKey: SidebarExpansionState.defaultsKey)
+        XCTAssertEqual(
+            SidebarExpansionState.load(defaults: defaults),
+            SidebarExpansionState.Payload(),
+            "undecodable payload degrades to the default shape, never an error"
+        )
+    }
+}


### PR DESCRIPTION
Closes #274 (child of tracker #273).

## What

- **Persisted expansion**: collapsed sources + per-source Pages-disclosure state survive relaunch. New pure `SidebarExpansionState` (one UserDefaults key, JSON payload, injected-defaults rules following the `WorkspaceSelectionRules` pattern); `SourceSidebar` binds `Section(isExpanded:)` / the Pages `DisclosureGroup` to the store instead of local `@State`. Missing/garbage payload degrades to everything-expanded.
- **Branch badge**: account headers show `⎇ <branch>` when the source has one (data was already read at add/load; previously visible only in Remote).
- **Sync spinner**: GitHub sources show a small `ProgressView` on the header while `isSyncing`.
- **VoiceOver landmark**: `.accessibilityAddTraits(.isHeader)` on `SourceAccountHeader` — the rotor can now jump between sources.
- New `SourceItem.isSyncing` accessor (GitHub-only, Local → false).

## Tests

`SidebarExpansionStateTests`: collapse/expand round-trip across a reload, expanding clears the entry, per-source Pages flags with per-source defaults, missing/garbage payload → default shape.

`SKIP_EMBED_BORIS=1 make build`, `make test`, `make lint` green.

## Must-not-land honored

No trunk-level disclosure persistence, no selection-rule changes, no counts beyond Pages.