### PR TITLE
sidebar: live graph refresh, off-main decode, one-pass trunk snapshot (#275)

### DIFF
--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -34,10 +34,13 @@ struct MainWindow: View {
         .onAppear {
             runtime.coordinator.syncSaveWatch(store: store, runtime: runtime)
             runtime.coordinator.syncValidateWatch(store: store, runtime: runtime)
+            store.startSidebarWatch(for: store.selection.sourceID)
         }
         .onChange(of: store.selection.sourceID) {
             runtime.coordinator.syncSaveWatch(store: store, runtime: runtime)
             runtime.coordinator.syncValidateWatch(store: store, runtime: runtime)
+            // #275: the sidebar's live graph watch follows the selection.
+            store.startSidebarWatch(for: store.selection.sourceID)
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             statusBar

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -149,46 +149,44 @@ private struct PagesGroup: View {
         )
     }
 
-    private var graph: Graph? {
-        store.graph(for: item.id)
-    }
-
-    private var allPages: [PlayPage] {
-        guard let graph else { return [] }
-        return LocalPlayGraph.pages(from: graph)
-    }
-
-    private var trunks: [PlayPage] {
-        guard let graph else { return [] }
-        return LocalPlayGraph.trunks(from: graph)
+    /// #275: cached-only read + one-pass snapshot. The async seed below
+    /// fills the cache without ever decoding during body evaluation.
+    private var snapshot: LocalPlayGraph.SidebarSnapshot {
+        store.cachedGraph(for: item.id).map(LocalPlayGraph.snapshot) ?? .empty
     }
 
     var body: some View {
-        if trunks.isEmpty {
-            MailboxRow(
-                item: item,
-                box: WorkspaceMailbox.pages,
-                count: allPages.isEmpty ? nil : allPages.count
-            )
-            .tag(pagesRowID)
-            .contextMenu { sourceMenu(item, store: store) }
-        } else {
-            DisclosureGroup(isExpanded: isExpanded) {
-                ForEach(trunks, id: \.id) { trunk in
-                    let trunkCount = LocalPlayGraph.pages(in: allPages, trunkID: trunk.id).count
-                    TrunkRow(item: item, trunk: trunk, count: trunkCount)
-                        .tag(MailboxRowID(sourceID: item.id, mailbox: trunk.id))
-                        .contextMenu { sourceMenu(item, store: store) }
-                }
-            } label: {
+        let snap = snapshot
+        Group {
+            if snap.trunks.isEmpty {
                 MailboxRow(
                     item: item,
                     box: WorkspaceMailbox.pages,
-                    count: allPages.isEmpty ? nil : allPages.count
+                    count: snap.pageCount == 0 ? nil : snap.pageCount
                 )
                 .tag(pagesRowID)
                 .contextMenu { sourceMenu(item, store: store) }
+            } else {
+                DisclosureGroup(isExpanded: isExpanded) {
+                    ForEach(snap.trunks, id: \.id) { trunk in
+                        TrunkRow(item: item, trunk: trunk, count: snap.countsByTrunk[trunk.id] ?? 0)
+                            .tag(MailboxRowID(sourceID: item.id, mailbox: trunk.id))
+                            .contextMenu { sourceMenu(item, store: store) }
+                    }
+                } label: {
+                    MailboxRow(
+                        item: item,
+                        box: WorkspaceMailbox.pages,
+                        count: snap.pageCount == 0 ? nil : snap.pageCount
+                    )
+                    .tag(pagesRowID)
+                    .contextMenu { sourceMenu(item, store: store) }
+                }
             }
+        }
+        // #275: seed the cache off-main when this section first appears.
+        .task(id: item.id) {
+            store.requestGraph(for: item.id)
         }
     }
 }

--- a/Sources/Play/Local/LocalPlayGraph.swift
+++ b/Sources/Play/Local/LocalPlayGraph.swift
@@ -88,6 +88,34 @@ enum LocalPlayGraph {
         pages.filter { $0.trunkID == trunkID }
     }
 
+    /// One-pass sidebar snapshot (#275): pages, trunks, and per-trunk
+    /// counts derived together so a render never walks the graph twice
+    /// and never recounts O(trunks × pages) per body evaluation.
+    struct SidebarSnapshot: Equatable, Sendable {
+        var allPages: [PlayPage] = []
+        var trunks: [PlayPage] = []
+        /// trunk id → number of pages inside that trunk.
+        var countsByTrunk: [String: Int] = [:]
+
+        var pageCount: Int { allPages.count }
+        static let empty = SidebarSnapshot()
+    }
+
+    static func snapshot(from graph: Graph) -> SidebarSnapshot {
+        let allPages = pages(from: graph)
+        var counts: [String: Int] = [:]
+        for page in allPages {
+            if let trunkID = page.trunkID {
+                counts[trunkID, default: 0] += 1
+            }
+        }
+        return SidebarSnapshot(
+            allPages: allPages,
+            trunks: allPages.filter { $0.depth == 0 && $0.role == .trunk },
+            countsByTrunk: counts
+        )
+    }
+
     /// The sidebar's folder rows under Pages (M13-1): roots whose role
     /// is `trunk`. Satellites and non-trunk roots are not folders.
     static func trunks(from graph: Graph) -> [PlayPage] {

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -438,6 +438,80 @@ final class WorkspaceStore {
         graphs[id] = graph
     }
 
+    // MARK: - Live sidebar (#275)
+
+    /// Sidebar-only read: returns whatever is cached, nil otherwise. Never
+    /// touches disk synchronously — seeding happens through `requestGraph`,
+    /// so a big first decode cannot hitch body evaluation. Other surfaces
+    /// (ReadingPane) keep the lazy synchronous `graph(for:)`.
+    func cachedGraph(for id: SourceID) -> Graph? {
+        graphs[id]
+    }
+
+    /// Sources with an async decode in flight, so concurrent requests
+    /// (watch burst + task seed) coalesce into one decode.
+    private var inFlightGraphDecodes: Set<SourceID> = []
+    private var sidebarWatcher: ContentTreeWatcher?
+    private var sidebarDebounceTask: Task<Void, Never>?
+
+    /// Fire-and-forget refresh: decodes `<root>/.boris/graph.json` off the
+    /// main actor and pushes through `updateGraph`. A missing file clears
+    /// nothing — a stale cache outlives a vanished artifact until a real
+    /// rebuild writes a new one.
+    func requestGraph(for id: SourceID) {
+        guard !inFlightGraphDecodes.contains(id) else { return }
+        guard let url = resolvedURL(for: id) else { return }
+        inFlightGraphDecodes.insert(id)
+        let fileURL = url
+            .appendingPathComponent(".boris", isDirectory: true)
+            .appendingPathComponent("graph.json")
+        Task.detached { [weak self] in
+            let decoded = try? JSONDecoder().decode(
+                Graph.self,
+                from: Data(contentsOf: fileURL)
+            )
+            await MainActor.run {
+                guard let self else { return }
+                if let decoded {
+                    self.updateGraph(decoded, for: id)
+                }
+                self.inFlightGraphDecodes.remove(id)
+            }
+        }
+    }
+
+    /// Watches the selected source's content root so the sidebar tracks
+    /// `graph.json` live (#275). Call on selection change; no-op without an
+    /// available source. Debounced — FSEvents bursts coalesce into one
+    /// refresh ~300 ms after the last event.
+    func startSidebarWatch(for id: SourceID?) {
+        sidebarWatcher?.stop()
+        sidebarWatcher = nil
+        sidebarDebounceTask?.cancel()
+        sidebarDebounceTask = nil
+
+        guard let id, let url = resolvedURL(for: id) else { return }
+        requestGraph(for: id)
+
+        let watcher = ContentTreeWatcher()
+        watcher.handler = { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.debouncedRefresh(id: id)
+            }
+        }
+        watcher.start(path: url.path)
+        sidebarWatcher = watcher
+    }
+
+    private func debouncedRefresh(id: SourceID) {
+        sidebarDebounceTask?.cancel()
+        sidebarDebounceTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            self?.requestGraph(for: id)
+        }
+    }
+
     private func resolvedURL(for id: SourceID) -> URL? {
         if let url = scopedURLs[id] { return url }
         guard let item = sources.first(where: { $0.id == id }) else { return nil }

--- a/Tests/ContractTests/GraphSidebarSnapshotTests.swift
+++ b/Tests/ContractTests/GraphSidebarSnapshotTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+/// #275 — Live sidebar: the one-pass snapshot that feeds trunk rows and
+/// counts without re-walking the graph per render.
+final class GraphSidebarSnapshotTests: XCTestCase {
+    private func graph(nodes: [GraphNode]) -> Graph {
+        Graph(
+            schemaVersion: "0.3.0",
+            frozen: true,
+            nodes: nodes,
+            edges: [],
+            reverseIndex: [],
+            nav: []
+        )
+    }
+
+    private func node(
+        index: Int,
+        id: String,
+        role: PageRole,
+        parent: String?,
+        title: String
+    ) -> GraphNode {
+        GraphNode(
+            index: index,
+            id: id,
+            sourcePath: id + ".md",
+            role: role,
+            parent: parent,
+            parentIndex: nil,
+            title: title,
+            status: "published",
+            tags: []
+        )
+    }
+
+    func testSnapshotCountsEachTrunkInOnePass() {
+        let snap = LocalPlayGraph.snapshot(from: graph(nodes: [
+            node(index: 0, id: "index", role: .trunk, parent: nil, title: "Home"),
+            node(index: 1, id: "guides", role: .trunk, parent: nil, title: "Guides"),
+            node(index: 2, id: "guides/intro", role: .satellite, parent: "guides", title: "Intro"),
+            node(index: 3, id: "guides/advanced", role: .satellite, parent: "guides", title: "Advanced"),
+            node(index: 4, id: "recipes", role: .trunk, parent: nil, title: "Recipes"),
+            node(index: 5, id: "recipes/pancakes", role: .satellite, parent: "recipes", title: "Pancakes"),
+            node(index: 6, id: "orphan", role: .satellite, parent: "missing", title: "Orphan"),
+        ]))
+
+        XCTAssertEqual(snap.pageCount, 7)
+        XCTAssertEqual(snap.trunks.map(\.id), ["index", "guides", "recipes"])
+        XCTAssertEqual(snap.countsByTrunk["guides"], 3, "trunk row + two satellites")
+        XCTAssertEqual(snap.countsByTrunk["recipes"], 2)
+        XCTAssertEqual(snap.countsByTrunk["index"], 1)
+        XCTAssertNil(snap.countsByTrunk["orphan"], "orphans belong to no trunk")
+    }
+
+    func testEmptyGraphGivesEmptySnapshot() {
+        XCTAssertEqual(LocalPlayGraph.snapshot(from: graph(nodes: [])), .empty)
+        XCTAssertEqual(LocalPlayGraph.snapshot(from: graph(nodes: [])).countsByTrunk, [:])
+    }
+
+    func testSatellitesWithoutTrunkParentsAreNotFolders() {
+        let snap = LocalPlayGraph.snapshot(from: graph(nodes: [
+            node(index: 0, id: "lone", role: .satellite, parent: nil, title: "Lone"),
+        ]))
+        XCTAssertTrue(snap.trunks.isEmpty)
+        XCTAssertEqual(snap.pageCount, 1)
+        XCTAssertTrue(snap.countsByTrunk.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #275 (child of tracker #273). Based on #274's merge.

## What

- **Off-main decode seam**: `WorkspaceStore.requestGraph(for:)` decodes `<root>/.boris/graph.json` on a detached task and pushes through the existing `updateGraph`. Concurrent requests for the same source coalesce via an in-flight set.
- **Live watch**: a sidebar-scoped `ContentTreeWatcher` follows the selected source's content root; FSEvents bursts debounce ~300 ms into a single refresh. Saving in Compose, pulling, or building externally now updates trunks + counts within about a second — no Play round-trip. Started from `MainWindow`'s existing selection-change hooks.
- **No body-eval I/O**: `PagesGroup` now reads `cachedGraph(for:)` (cache-only) and seeds via `.task(id:)`; the lazy synchronous decode in `graph(for:)` remains untouched for its other callers (ReadingPane), so nothing else changes semantics.
- **One-pass snapshot**: new `LocalPlayGraph.SidebarSnapshot` derives pages + trunks + per-trunk counts in a single walk; the render consumes locals instead of recomputing computed properties O(trunks × pages) per evaluation.

## Tests

`GraphSidebarSnapshotTests`: per-trunk counts in one pass (mixed corpus with an orphan node), empty-graph shape, satellites without trunk parents are not folders.

`SKIP_EMBED_BORIS=1 make build`, `make test`, `make lint` green.

## Boundaries honored

The store stays the only JSON reader (M13); the watcher is read-only (boundary 4); the coordinator's save/validate watchers are untouched.