### PR TITLE
sidebar: mailbox verbs, source cycling, folder filter, richer context menu (#276)

### DIFF
--- a/Project.yml
+++ b/Project.yml
@@ -109,6 +109,7 @@ targets:
       - path: Sources/App/SaveValidateGate.swift
       - path: Sources/Workspace/Source.swift
       - path: Sources/Workspace/SidebarExpansionState.swift
+      - path: Sources/Workspace/SidebarNavigation.swift
       - path: Sources/Workspace/WorkspacePersistence.swift
       - path: Sources/Workspace/WorkspaceSelection.swift
       - path: Sources/Workspace/Local/LocalSource.swift

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -225,6 +225,62 @@ struct SolipsistCommands: Commands {
             ))
         }
 
+        /// #276: sidebar navigation verbs — mailbox jumps for the selected
+        /// source and next/previous source cycling.
+        CommandGroup(after: .sidebar) {
+            Divider()
+
+            Button("Pages") {
+                store.select(mailbox: WorkspaceMailbox.pages)
+            }
+            .keyboardShortcut("1", modifiers: .command)
+            .disabled(!hasSource)
+
+            Button("Outputs") {
+                store.select(mailbox: WorkspaceMailbox.outputs)
+            }
+            .keyboardShortcut("2", modifiers: .command)
+            .disabled(!hasSource)
+
+            Button("Publish") {
+                store.select(mailbox: WorkspaceMailbox.publish)
+            }
+            .keyboardShortcut("3", modifiers: .command)
+            .disabled(!hasSource)
+
+            Button("Plan") {
+                store.select(mailbox: WorkspaceMailbox.plan)
+            }
+            .keyboardShortcut("4", modifiers: .command)
+            .disabled(!hasSource)
+
+            Button("Activity") {
+                store.select(mailbox: WorkspaceMailbox.activity)
+            }
+            .keyboardShortcut("5", modifiers: .command)
+            .disabled(!hasSource)
+
+            Button("Content Audit") {
+                store.select(mailbox: WorkspaceMailbox.contentAudit)
+            }
+            .keyboardShortcut("6", modifiers: .command)
+            .disabled(!hasSource)
+
+            Divider()
+
+            Button("Select Next Source") {
+                cycleSource(forward: true)
+            }
+            .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+            .disabled(store.sources.count < 2)
+
+            Button("Select Previous Source") {
+                cycleSource(forward: false)
+            }
+            .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+            .disabled(store.sources.count < 2)
+        }
+
         CommandGroup(replacing: .help) {
             Button("Solipsist Help") {
                 openWindow(id: "help")
@@ -246,5 +302,16 @@ struct SolipsistCommands: Commands {
     private var hasOutput: Bool {
         let kind = store.selection.noun?.kind
         return kind == "target" || kind == "edition"
+    }
+
+    /// #276: walk the sidebar's source order one step, wrapping.
+    private func cycleSource(forward: Bool) {
+        let next = SidebarNavigation.cycledSource(
+            current: store.selection.sourceID,
+            ids: store.sourceIDs,
+            forward: forward
+        )
+        guard let next else { return }
+        store.select(next)
     }
 }

--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -7,6 +7,9 @@ struct SourceSidebar: View {
     @Environment(WorkspaceStore.self) private var store
 
     @State private var toolbarBand: CGFloat = 0
+    /// #276: sidebar filter — case-insensitive trunk-title substring,
+    /// in-session only (never persisted).
+    @State private var folderFilter = ""
 
     var body: some View {
         List(selection: selectedRow) {
@@ -14,11 +17,17 @@ struct SourceSidebar: View {
                 SourceSection(
                     item: item,
                     isExpanded: isExpanded(for: item.id),
-                    store: store
+                    store: store,
+                    folderFilter: folderFilter
                 )
             }
         }
         .listStyle(.sidebar)
+        .searchable(
+            text: $folderFilter,
+            placement: .sidebar,
+            prompt: "Filter folders"
+        )
         .navigationTitle("Mailboxes")
         .safeAreaPadding(.top, max(toolbarBand, 62))
         .background(ToolbarBandReader { toolbarBand = $0 })
@@ -74,6 +83,8 @@ private struct SourceSection: View {
     let item: SourceItem
     @Binding var isExpanded: Bool
     let store: WorkspaceStore
+    /// #276: trunk-title filter handed down from the sidebar search field.
+    var folderFilter: String = ""
     /// The github source awaiting a sign-out confirmation, when any.
     @State private var signOutItem: SourceItem?
 
@@ -84,7 +95,7 @@ private struct SourceSection: View {
                     // Pages grows trunk-folder children from the decoded
                     // graph (M13-1). No graph yet → no children, not an
                     // error; Chrome never parses JSON.
-                    PagesGroup(item: item, store: store)
+                    PagesGroup(item: item, store: store, folderFilter: folderFilter)
                 } else {
                     MailboxRow(item: item, box: box)
                         .tag(MailboxRowID(sourceID: item.id, mailbox: box))
@@ -137,6 +148,8 @@ private struct SourceSection: View {
 private struct PagesGroup: View {
     let item: SourceItem
     let store: WorkspaceStore
+    /// #276: trunk-title filter; empty passes everything through.
+    var folderFilter: String = ""
 
     private var pagesRowID: MailboxRowID {
         MailboxRowID(sourceID: item.id, mailbox: WorkspaceMailbox.pages)
@@ -155,10 +168,14 @@ private struct PagesGroup: View {
         store.cachedGraph(for: item.id).map(LocalPlayGraph.snapshot) ?? .empty
     }
 
+    private var visibleTrunks: [PlayPage] {
+        snapshot.trunks.filter { SidebarNavigation.matches(filter: folderFilter, title: $0.title) }
+    }
+
     var body: some View {
         let snap = snapshot
         Group {
-            if snap.trunks.isEmpty {
+            if visibleTrunks.isEmpty {
                 MailboxRow(
                     item: item,
                     box: WorkspaceMailbox.pages,
@@ -168,7 +185,7 @@ private struct PagesGroup: View {
                 .contextMenu { sourceMenu(item, store: store) }
             } else {
                 DisclosureGroup(isExpanded: isExpanded) {
-                    ForEach(snap.trunks, id: \.id) { trunk in
+                    ForEach(visibleTrunks, id: \.id) { trunk in
                         TrunkRow(item: item, trunk: trunk, count: snap.countsByTrunk[trunk.id] ?? 0)
                             .tag(MailboxRowID(sourceID: item.id, mailbox: trunk.id))
                             .contextMenu { sourceMenu(item, store: store) }
@@ -229,13 +246,32 @@ private struct TrunkRow: View {
     }
 }
 
+/// #276: Reveal / Copy Path / Sync Now join Relocate and Remove — every
+/// action rides an existing store API.
 @ViewBuilder
 fileprivate func sourceMenu(_ item: SourceItem, store: WorkspaceStore) -> some View {
     if !item.isAvailable {
         Button("Relocate…") {
             store.presentRelocatePanel(for: item.id)
         }
+    } else {
+        Button("Reveal in Finder") {
+            store.revealInFinder(item.id)
+        }
+        Button("Copy Path") {
+            store.copyPath(item.id)
+        }
+        if case .github = item, item.isSyncing {
+            Button("Cancel Sync") {
+                store.cancelSyncGithub(item.id)
+            }
+        } else if case .github = item {
+            Button("Sync Now") {
+                Task { await store.syncGithub(item.id) }
+            }
+        }
     }
+    Divider()
     Button("Remove from Sidebar", role: .destructive) {
         store.remove(item.id)
     }

--- a/Sources/Workspace/SidebarNavigation.swift
+++ b/Sources/Workspace/SidebarNavigation.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// #276: sidebar navigation rules — source cycling order math and the
+/// trunk-filter predicate. Pure, so ContractTests can pin them; the store
+/// and sidebar call these.
+enum SidebarNavigation {
+    /// The id that becomes selected when walking `ids` one step from
+    /// `current`. Wraps at both ends. Fewer than two sources (or a missing
+    /// list entry handled below) never moves the selection off a working
+    /// value.
+    static func cycledSource(
+        current: SourceID?,
+        ids: [SourceID],
+        forward: Bool
+    ) -> SourceID? {
+        guard ids.count > 1 else { return current }
+        guard let index = ids.firstIndex(where: { $0 == current }) else {
+            // No valid current selection: enter at the near end.
+            return forward ? ids[0] : ids[ids.count - 1]
+        }
+        if forward {
+            return ids[(index + 1) % ids.count]
+        }
+        return ids[(index - 1 + ids.count) % ids.count]
+    }
+
+    /// Trunk-filter predicate (#276): case-insensitive substring on the
+    /// title; an empty (or whitespace-only) query passes everything.
+    static func matches(filter query: String, title: String) -> Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        return title.range(of: trimmed, options: .caseInsensitive) != nil
+    }
+}

--- a/Sources/Workspace/WorkspaceStore.swift
+++ b/Sources/Workspace/WorkspaceStore.swift
@@ -525,6 +525,27 @@ final class WorkspaceStore {
         }
     }
 
+    // MARK: - Sidebar conveniences (#276)
+
+    /// Reveal the source's folder in Finder (selected).
+    func revealInFinder(_ id: SourceID) {
+        guard let url = resolvedURL(for: id) else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    /// Copy the source's folder path to the general pasteboard.
+    func copyPath(_ id: SourceID) {
+        guard let url = resolvedURL(for: id) else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(url.path, forType: .string)
+    }
+
+    /// The source ids in sidebar order (source cycling, #276).
+    var sourceIDs: [SourceID] {
+        sources.map(\.id)
+    }
+
     func addLocal(url: URL) {
         lastError = nil
         let standardized = url.standardizedFileURL

--- a/Tests/ContractTests/SidebarNavigationTests.swift
+++ b/Tests/ContractTests/SidebarNavigationTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+/// #276 — Sidebar navigation rules: source cycling order math and the
+/// trunk-filter predicate.
+final class SidebarNavigationTests: XCTestCase {
+    private var idA = SourceID()
+    private var idB = SourceID()
+    private var idC = SourceID()
+
+    // MARK: - Source cycling
+
+    func testCycleWalksForwardAndWraps() {
+        let ids = [idA, idB, idC]
+        XCTAssertEqual(
+            SidebarNavigation.cycledSource(current: idA, ids: ids, forward: true), idB
+        )
+        XCTAssertEqual(
+            SidebarNavigation.cycledSource(current: idB, ids: ids, forward: true), idC
+        )
+        XCTAssertEqual(
+            SidebarNavigation.cycledSource(current: idC, ids: ids, forward: true), idA,
+            "forward wraps to the first source"
+        )
+    }
+
+    func testCycleWalksBackwardAndWraps() {
+        let ids = [idA, idB, idC]
+        XCTAssertEqual(
+            SidebarNavigation.cycledSource(current: idC, ids: ids, forward: false), idB
+        )
+        XCTAssertEqual(
+            SidebarNavigation.cycledSource(current: idA, ids: ids, forward: false), idC,
+            "backward wraps to the last source"
+        )
+    }
+
+    func testCycleWithFewerThanTwoSourcesIsNoOp() {
+        XCTAssertEqual(
+            SidebarNavigation.cycledSource(current: idA, ids: [idA], forward: true), idA
+        )
+        XCTAssertNil(
+            SidebarNavigation.cycledSource(current: nil, ids: [], forward: true)
+        )
+    }
+
+    func testCycleWithoutSelectionEntersAtNearEnd() {
+        let ids = [idA, idB, idC]
+        XCTAssertEqual(
+            SidebarNavigation.cycledSource(current: nil, ids: ids, forward: true), idA,
+            "forward from nothing lands on the first"
+        )
+        XCTAssertEqual(
+            SidebarNavigation.cycledSource(current: nil, ids: ids, forward: false), idC,
+            "backward from nothing lands on the last"
+        )
+    }
+
+    // MARK: - Trunk filter
+
+    func testFilterMatchesCaseInsensitiveSubstring() {
+        XCTAssertTrue(SidebarNavigation.matches(filter: "guide", title: "Guides"))
+        XCTAssertTrue(SidebarNavigation.matches(filter: "UIDE", title: "Guides"))
+        XCTAssertFalse(SidebarNavigation.matches(filter: "recipes", title: "Guides"))
+    }
+
+    func testEmptyFilterPassesEverything() {
+        XCTAssertTrue(SidebarNavigation.matches(filter: "", title: "Anything"))
+        XCTAssertTrue(SidebarNavigation.matches(filter: "   ", title: "Anything"))
+    }
+}

--- a/docs/help.md
+++ b/docs/help.md
@@ -74,6 +74,16 @@ Every menu verb and keyboard shortcut:
 | Preview | `⌘⇧P` | Open the Preview companion window (live preview via `watch --serve` with loopback URL validation and SSE reload). |
 | Editor | `⌘⇧E` | Open the Editor companion window (token-isolated host for `boris-editor`). |
 | Compose | `⌘⇧C` | Open the Compose window (native Markdown / Textile / Cooklang editor for the selected page; Oliver-powered preview; Save flows into the coordinator's validate gate). |
+| Pages | `⌘1` | Jump the selected source's sidebar to the Pages mailbox. |
+| Outputs | `⌘2` | Jump the selected source's sidebar to the Outputs mailbox. |
+| Publish | `⌘3` | Jump the selected source's sidebar to the Publish mailbox. |
+| Plan | `⌘4` | Jump the selected source's sidebar to the Plan mailbox. |
+| Activity | `⌘5` | Jump the selected source's sidebar to the Activity mailbox. |
+| Content Audit | `⌘6` | Jump the selected source's sidebar to the Content Audit mailbox. |
+| Select Next Source | `⌘⌥→` | Cycle the sidebar selection to the next source (wraps). |
+| Select Previous Source | `⌘⌥←` | Cycle the sidebar selection to the previous source (wraps). |
+
+The sidebar also carries a **Filter folders** search field: it narrows trunk folders under Pages by title (case-insensitive) while typed, and resets when cleared. Right-clicking a source offers Reveal in Finder, Copy Path, and Sync Now (GitHub sources).
 
 ### Format
 


### PR DESCRIPTION
Closes #276 (child of tracker #273). Based on #275's merge.

## What

- **Mailbox verbs**: ⌘1…⌘6 jump the selected source's sidebar to Pages / Outputs / Publish / Plan / Activity / Content Audit. Disabled without a selected source.
- **Source cycling**: Select Next / Previous Source (⌘⌥→ / ⌘⌥←) walks `store.sources` order with wrap; disabled under two sources. Pure math in `SidebarNavigation.cycledSource`.
- **Folder filter**: sidebar `.searchable` ("Filter folders") narrows trunk rows by case-insensitive title substring; in-session `@State` only — nothing persisted.
- **Context menus** gain Reveal in Finder, Copy Path, and Sync Now / Cancel Sync for GitHub sources (all riding existing store APIs: bookmark resolution, `syncGithub`, `cancelSyncGithub`).
- **help.md**: every new verb rowed in the View section plus a filter/context-menu note — HelpAuditTests stays green.

## Tests

`SidebarNavigationTests`: forward/backward wrap both ends, fewer-than-two no-op, entry from nil selection at the near end, filter substring/case/empty-passthrough.

`SKIP_EMBED_BORIS=1 make build`, `make test`, `make lint` green.

## Must-not-land honored

No page-row filtering inside mailboxes, no reorder/rename of sources, no persistence added for the filter.