### PR TITLE
docs: sync README status — M0–M17 landed, ship parked on Developer ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ on the left, a reading place in the middle, inspector drawer on the
 right. Preview and the Svelte editor are companion windows we host.
 We do not invent a second compiler.
 
-**Status:** M0–M8 gates plus depth. Next ship is M9
-([#78](https://github.com/drawmeanelephant/solipsist/issues/78)).
-Next product cut is M10 Mail body
-([#98](https://github.com/drawmeanelephant/solipsist/issues/98)).
+**Status:** M0–M17 landed — Mail body
+([#98](https://github.com/drawmeanelephant/solipsist/issues/98)),
+clone, graph folders, watch contract, GitHub source + write verbs,
+Pull Requests mailbox — plus post-ship polish: accessibility
+([#239](https://github.com/drawmeanelephant/solipsist/issues/239)–[#243](https://github.com/drawmeanelephant/solipsist/issues/243)),
+editor/compose depth, live sidebar. Notarized release
+is parked on a paid Apple Developer ID; [#110](https://github.com/drawmeanelephant/solipsist/issues/110)/[#111](https://github.com/drawmeanelephant/solipsist/issues/111)
+closed not-planned — unpark steps in
+[#110](https://github.com/drawmeanelephant/solipsist/issues/110).
 File → Open… a folder under [`Stunts/`](Stunts/) (start with
 `happy/`). `make test` decodes checked-in fixtures (no boris binary).
 


### PR DESCRIPTION
## Problem

The README status block is ~10 milestones stale: "M0–M8 gates plus depth. Next ship is M9 (#78)." ROADMAP.md (authoritative) and AGENTS.md show M0–M17 landed. Ship itself has also moved since ROADMAP §8 was written: #110/#111 were closed NOT_PLANNED on 2026-08-22 — no paid Apple Developer ID; unpark steps are recorded in #110.

## Approach (README status block only, docs-only)

- State M0–M17 landed; name the product-visible cuts (Mail body, clone, graph folders, watch contract, GitHub source + write verbs, Pull Requests mailbox). Link #98 and #110 per the README's explicit-link convention; bare `#N` elsewhere.
- Post-ship polish named functionally — accessibility (#239–#243), editor/compose depth, live sidebar — matching `git log` subjects. No "M18": no repo doc names that milestone, so none is invented.
- Notarized release stated as parked, with the reason and a pointer to #110.
- The File → Open… / `make test` sentences are kept (still true).
- Triage fixes #281–#284 deliberately not enumerated in the block — ordinary fixes, not a milestone.

Note: ROADMAP §8 still orders #110/#111 as the next actions — it needs its own sync pass, deliberately not done here (one concern per branch).

## Verification

Every cited issue cross-checked (`gh issue view -R drawmeanelephant/solipsist N`):

```
#78        CLOSED COMPLETED   2026-08-18  feat(m9): ship to gate
#98        CLOSED COMPLETED   2026-08-18  tracker: M10 Mail body
#239-#243  CLOSED             (a11y children; PRs #244 #247 #249 #251 #252)
#110       CLOSED NOT_PLANNED 2026-08-22  ops(m9): Apple signing secrets
#111       CLOSED NOT_PLANNED 2026-08-22  ops(m9): clean-Mac proof
```

README-only change, no code paths touched. Tests green on this tree:

```
SOLIPSIST_BORIS_BIN=/usr/bin/true make test
→ ** TEST SUCCEEDED **
→ result: Passed | passed: 481 | failed: 0 | skipped: 5  (xcresulttool)
```

No CHANGELOG is kept in this repo — no bullet added.
