### PR TITLE
editor: typed error guidance instead of string matching

### DIFF
--- a/Sources/Companions/Editor/EditorCopy.swift
+++ b/Sources/Companions/Editor/EditorCopy.swift
@@ -12,9 +12,47 @@ enum EditorIdleCopy {
     }
 }
 
+/// #280: maps typed session failures to actionable guidance for the idle
+/// state. Switches on `EditorSessionError` cases — compiler-checked against
+/// the enum instead of substring matching raw wording. Cases with no
+/// dedicated guidance return nil so the view falls back to the idle copy.
+enum EditorFailureGuidance {
+    struct Guidance: Equatable {
+        let headline: String
+        let detail: String
+    }
+
+    static func guidance(for error: EditorSessionError) -> Guidance? {
+        switch error {
+        case .binaryNotFound:
+            return Guidance(
+                headline: "boris-editor binary not found",
+                detail: "Install boris-editor or set SOLIPSIST_BORIS_EDITOR_BIN in your environment."
+            )
+        case .timeout:
+            return Guidance(
+                headline: "Editor host did not report a token URL within \(EditorSession.connectTimeoutDescription)",
+                detail: "The editor host may be slow to start. Try again or check the boris-editor logs."
+            )
+        case .crashLoop:
+            return Guidance(
+                headline: error.message,
+                detail: "The editor host crashed. Check the boris-editor logs for details."
+            )
+        case .engineUnavailable:
+            return Guidance(
+                headline: error.message,
+                detail: "Ensure Boris is built and the engine binary is accessible."
+            )
+        case .launchFailed, .folderUnresolved:
+            return nil
+        }
+    }
+}
+
 /// #267: human phase copy for the editor chrome — display-only mapping;
-/// the session's `Phase` enum is untouched. Enumerates all five cases (the
-/// A11Y-4 pattern) so a new case cannot compile without a label.
+/// the session's `Phase` enum shape is untouched. Enumerates all five cases
+/// (the A11Y-4 pattern) so a new case cannot compile without a label.
 enum EditorPhaseCopy {
     static func label(for phase: EditorSession.Phase) -> String {
         switch phase {
@@ -26,8 +64,8 @@ enum EditorPhaseCopy {
             return "Ready"
         case .reconnecting(let attempt):
             return "Connection lost — retrying (\(attempt) of \(EditorAutoReconnect.maxAttempts))"
-        case .failed(let message):
-            return message
+        case .failed(let error):
+            return error.message
         }
     }
 

--- a/Sources/Companions/Editor/EditorSession.swift
+++ b/Sources/Companions/Editor/EditorSession.swift
@@ -45,6 +45,58 @@ enum EditorAutoReconnect {
     static let windowDescription = "\(window.components.seconds)s"
 }
 
+/// #280: typed reasons an editor host lifecycle fails. `Phase.failed`
+/// carries one of these instead of a raw message, so chrome mapping is
+/// compiler-checked (`EditorFailureGuidance`) rather than substring
+/// matching against wording that can drift.
+enum EditorSessionError: Equatable {
+    /// No engine binary is available to host the editor from.
+    case engineUnavailable
+    /// The `boris-editor` binary could not be located — a permanent
+    /// configuration error, never a crash-reconnect candidate (#232).
+    case binaryNotFound
+    /// The host started but never reported a token URL within
+    /// `EditorSession.connectTimeout`.
+    case timeout
+    /// The host crashed more than `EditorAutoReconnect.maxAttempts` times
+    /// inside the reconnect window; manual restart required. Carries the
+    /// trimmed stderr tail for the status line.
+    case crashLoop(stderrTail: String)
+    /// The host factory threw something other than a launch-configuration error.
+    case launchFailed(String)
+    /// The selected source's content/project folders could not be resolved.
+    case folderUnresolved(String)
+
+    /// Maps permanent factory configuration errors onto their typed cases;
+    /// exhaustive over `EditorHostLaunchError`, so a new case cannot be
+    /// added without deciding its session-level meaning.
+    init(_ launchError: EditorHostLaunchError) {
+        switch launchError {
+        case .editorBinaryNotFound:
+            self = .binaryNotFound
+        }
+    }
+
+    /// Human-readable status line, surfaced verbatim by the chrome.
+    var message: String {
+        switch self {
+        case .engineUnavailable:
+            return "Boris engine not available."
+        case .binaryNotFound:
+            return EditorHostLaunchError.editorBinaryNotFound.errorDescription ?? "boris-editor binary not found."
+        case .timeout:
+            return "Editor host did not report a token URL within \(EditorSession.connectTimeoutDescription)."
+        case .crashLoop(let stderrTail):
+            let suffix = stderrTail.isEmpty ? "" : " — \(stderrTail.suffix(200))"
+            return "Editor host crashed \(EditorAutoReconnect.maxAttempts) times within \(EditorAutoReconnect.windowDescription). Manual restart required.\(suffix)"
+        case .launchFailed(let underlying):
+            return "Could not start editor host: \(underlying)"
+        case .folderUnresolved(let title):
+            return "Could not resolve project folder for '\(title)'"
+        }
+    }
+}
+
 /// Drives the M6 author companion surface (A14 / #75): owns the `boris-editor`
 /// subprocess host lifetime and hands the tokenized session URL to the editor web view.
 ///
@@ -65,11 +117,18 @@ final class EditorSession {
         case connected(URL)
         /// Spontaneous exit; an automatic restart is pending (attempt N).
         case reconnecting(attempt: Int)
-        case failed(String)
+        case failed(EditorSessionError)
     }
 
     /// Builds a host. Always invoked on the main actor (`start()`'s context).
     typealias HostFactory = @MainActor (_ engine: BorisEngine, _ workingDirectory: URL) throws -> any EditorHost
+
+    /// How long the host gets to report its token URL before the start
+    /// attempt is failed as `.timeout`.
+    nonisolated static let connectTimeout: Duration = .seconds(15)
+
+    /// Human form of `connectTimeout` for status copy ("15s").
+    nonisolated static var connectTimeoutDescription: String { "\(connectTimeout.components.seconds)s" }
 
     private(set) var phase: Phase = .idle
 
@@ -106,8 +165,8 @@ final class EditorSession {
             return "Connected to \(url.host ?? "loopback")"
         case .reconnecting(let attempt):
             return "boris-editor exited unexpectedly — restarting automatically (attempt \(attempt) of \(EditorAutoReconnect.maxAttempts))…"
-        case .failed(let message):
-            return message
+        case .failed(let error):
+            return error.message
         }
     }
 
@@ -168,7 +227,7 @@ final class EditorSession {
         rootPath = root
 
         guard let engine else {
-            setPhase(.failed("Boris engine not available."))
+            setPhase(.failed(.engineUnavailable))
             return
         }
 
@@ -183,16 +242,16 @@ final class EditorSession {
             server.onExit = { [weak self] exit in
                 Task { @MainActor in self?.handleExit(exit) }
             }
+        } catch let error as EditorHostLaunchError {
+            timeoutTask?.cancel()
+            timeoutTask = nil
+            // Permanent configuration error — surface verbatim through the
+            // typed case, never a crash-reconnect candidate (#232).
+            setPhase(.failed(EditorSessionError(error)))
         } catch {
             timeoutTask?.cancel()
             timeoutTask = nil
-            if error is EditorHostLaunchError {
-                // Permanent configuration error — surface verbatim, no
-                // prefix, and never a crash-reconnect candidate (#232).
-                setPhase(.failed(error.localizedDescription))
-            } else {
-                setPhase(.failed("Could not start editor host: \(error)"))
-            }
+            setPhase(.failed(.launchFailed("\(error)")))
         }
     }
 
@@ -226,10 +285,10 @@ final class EditorSession {
         )
     }
 
-    func fail(_ message: String) {
+    func fail(_ error: EditorSessionError) {
         cancelAutoReconnect()
         teardown()
-        setPhase(.failed(message))
+        setPhase(.failed(error))
     }
 
     func stop() {
@@ -291,13 +350,7 @@ final class EditorSession {
             setPhase(.reconnecting(attempt: attempt))
             scheduleAutoReconnect(after: reconnectBaseDelay * attempt)
         case .giveUp:
-            let tail = exit.stderrTail.trimmingCharacters(in: .whitespacesAndNewlines)
-            let suffix = tail.isEmpty ? "" : " — \(tail.suffix(200))"
-            setPhase(
-                .failed(
-                    "Editor host crashed \(EditorAutoReconnect.maxAttempts) times within \(EditorAutoReconnect.windowDescription). Manual restart required.\(suffix)"
-                )
-            )
+            setPhase(.failed(.crashLoop(stderrTail: exit.stderrTail.trimmingCharacters(in: .whitespacesAndNewlines))))
         }
     }
 
@@ -312,7 +365,7 @@ final class EditorSession {
 
     private func scheduleTimeout() {
         timeoutTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(15))
+            try? await Task.sleep(for: EditorSession.connectTimeout)
             guard !Task.isCancelled else { return }
             guard let self else { return }
             self.failTimeout()
@@ -324,7 +377,7 @@ final class EditorSession {
         server = nil
         timeoutTask = nil
         rootPath = nil
-        setPhase(.failed("Editor host did not report a token URL within 15s."))
+        setPhase(.failed(.timeout))
     }
 
     /// Phase transitions leave the connected state, so any transient

--- a/Sources/Companions/Editor/EditorWindow.swift
+++ b/Sources/Companions/Editor/EditorWindow.swift
@@ -3,8 +3,6 @@ import Observation
 import SwiftUI
 import WebKit
 
-// swiftlint:disable file_length
-
 /// Companion host for `boris-editor` (Svelte). Chassis registers the window
 /// and leaves it closed; the editor opens against the selected page.
 ///
@@ -71,7 +69,7 @@ struct EditorWindow: View { // swiftlint:disable:this type_body_length
               let projectRoot = try? folder.workspaceRoot(),
               let contentRoot = try? folder.contentRoot()
         else {
-            session.fail("Could not resolve project folder for '\(source.title)'")
+            session.fail(.folderUnresolved(source.title))
             return
         }
         session.start(
@@ -142,34 +140,12 @@ struct EditorWindow: View { // swiftlint:disable:this type_body_length
         }
     }
 
-    /// #237: Maps raw error messages from the session to actionable guidance.
-    private var errorGuidance: (headline: String, detail: String)? {
-        guard case .failed(let message) = session.phase else { return nil }
-        if message.contains("binary not found") {
-            return (
-                "boris-editor binary not found",
-                "Install boris-editor or set SOLIPSIST_BORIS_EDITOR_BIN in your environment."
-            )
-        }
-        if message.contains("did not report a token URL") {
-            return (
-                "Editor host did not report a token URL within 15s",
-                "The editor host may be slow to start. Try again or check the boris-editor logs."
-            )
-        }
-        if message.contains("exited (") {
-            return (
-                message,
-                "The editor host crashed. Check the boris-editor logs for details."
-            )
-        }
-        if message.contains("not available") {
-            return (
-                message,
-                "Ensure Boris is built and the engine binary is accessible."
-            )
-        }
-        return nil
+    /// #280: Maps typed failures from the session to actionable guidance;
+    /// the case-to-copy switch lives in `EditorFailureGuidance` where it is
+    /// compiler-checked against `EditorSessionError`.
+    private var errorGuidance: EditorFailureGuidance.Guidance? {
+        guard case .failed(let error) = session.phase else { return nil }
+        return EditorFailureGuidance.guidance(for: error)
     }
 
     private func header(for source: SourceItem) -> some View {

--- a/Tests/ContractTests/EditorChromeCopyTests.swift
+++ b/Tests/ContractTests/EditorChromeCopyTests.swift
@@ -14,7 +14,7 @@ final class EditorChromeCopyTests: XCTestCase {
             EditorPhaseCopy.label(for: .reconnecting(attempt: 2)),
             "Connection lost — retrying (2 of \(EditorAutoReconnect.maxAttempts))"
         )
-        XCTAssertEqual(EditorPhaseCopy.label(for: .failed("host exited")), "host exited")
+        XCTAssertEqual(EditorPhaseCopy.label(for: .failed(.engineUnavailable)), "Boris engine not available.")
     }
 
     func testPhaseAccessibilityLabelsEnumerateAllCases() {
@@ -24,7 +24,7 @@ final class EditorChromeCopyTests: XCTestCase {
             .starting,
             .connected(url),
             .reconnecting(attempt: 1),
-            .failed("boom"),
+            .failed(.launchFailed("boom")),
         ]
         for phase in phases {
             XCTAssertFalse(EditorPhaseCopy.accessibilityLabel(for: phase).isEmpty)

--- a/Tests/ContractTests/EditorSessionErrorTests.swift
+++ b/Tests/ContractTests/EditorSessionErrorTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+
+/// #280 — typed editor failures. Pins the status-line copy per case and the
+/// `EditorFailureGuidance` switch that replaced substring matching on raw
+/// messages; wording drift now fails here instead of silently breaking the
+/// editor chrome's guidance.
+final class EditorSessionErrorTests: XCTestCase {
+    // MARK: Status lines
+
+    func testMessagesAreNonEmptyForEveryCase() {
+        let errors: [EditorSessionError] = [
+            .engineUnavailable,
+            .binaryNotFound,
+            .timeout,
+            .crashLoop(stderrTail: ""),
+            .crashLoop(stderrTail: "panic: token rejected"),
+            .launchFailed("port in use"),
+            .folderUnresolved("happy"),
+        ]
+        for error in errors {
+            XCTAssertFalse(error.message.isEmpty, "\(error)")
+        }
+    }
+
+    func testEngineUnavailableMessage() {
+        XCTAssertEqual(EditorSessionError.engineUnavailable.message, "Boris engine not available.")
+    }
+
+    func testBinaryNotFoundSurfacesLaunchErrorVerbatim() {
+        XCTAssertEqual(
+            EditorSessionError.binaryNotFound.message,
+            EditorHostLaunchError.editorBinaryNotFound.errorDescription
+        )
+    }
+
+    func testTimeoutMessagePinsBudget() {
+        XCTAssertEqual(
+            EditorSessionError.timeout.message,
+            "Editor host did not report a token URL within \(EditorSession.connectTimeoutDescription)."
+        )
+    }
+
+    func testCrashLoopMessagePinsCapWindowAndTail() {
+        let plain = EditorSessionError.crashLoop(stderrTail: "").message
+        XCTAssertTrue(plain.contains("\(EditorAutoReconnect.maxAttempts) times"), plain)
+        XCTAssertTrue(plain.contains(EditorAutoReconnect.windowDescription), plain)
+        XCTAssertTrue(plain.contains("Manual restart required"), plain)
+        XCTAssertFalse(plain.contains("—"), plain)
+
+        let tailed = EditorSessionError.crashLoop(stderrTail: "boom").message
+        XCTAssertTrue(tailed.hasSuffix(" — boom"), tailed)
+    }
+
+    func testLaunchFailedKeepsPrefix() {
+        XCTAssertEqual(
+            EditorSessionError.launchFailed("port in use").message,
+            "Could not start editor host: port in use"
+        )
+    }
+
+    func testFolderUnresolvedMessage() {
+        XCTAssertEqual(
+            EditorSessionError.folderUnresolved("stunts").message,
+            "Could not resolve project folder for 'stunts'"
+        )
+    }
+
+    func testLaunchErrorInitMapsEveryFactoryCase() {
+        XCTAssertEqual(EditorSessionError(EditorHostLaunchError.editorBinaryNotFound), .binaryNotFound)
+    }
+
+    // MARK: Guidance mapping
+
+    func testGuidanceCoversActionableCases() {
+        XCTAssertNotNil(EditorFailureGuidance.guidance(for: .binaryNotFound))
+        XCTAssertNotNil(EditorFailureGuidance.guidance(for: .timeout))
+        XCTAssertNotNil(EditorFailureGuidance.guidance(for: .crashLoop(stderrTail: "")))
+        XCTAssertNotNil(EditorFailureGuidance.guidance(for: .engineUnavailable))
+    }
+
+    func testGuidanceNilForPassThroughCases() {
+        XCTAssertNil(EditorFailureGuidance.guidance(for: .launchFailed("x")))
+        XCTAssertNil(EditorFailureGuidance.guidance(for: .folderUnresolved("y")))
+    }
+
+    func testGuidanceDetailsPinActionableAdvice() {
+        XCTAssertEqual(
+            EditorFailureGuidance.guidance(for: .binaryNotFound)?.detail,
+            "Install boris-editor or set SOLIPSIST_BORIS_EDITOR_BIN in your environment."
+        )
+        XCTAssertEqual(
+            EditorFailureGuidance.guidance(for: .timeout)?.detail,
+            "The editor host may be slow to start. Try again or check the boris-editor logs."
+        )
+        XCTAssertEqual(
+            EditorFailureGuidance.guidance(for: .crashLoop(stderrTail: ""))?.detail,
+            "The editor host crashed. Check the boris-editor logs for details."
+        )
+        XCTAssertEqual(
+            EditorFailureGuidance.guidance(for: .engineUnavailable)?.detail,
+            "Ensure Boris is built and the engine binary is accessible."
+        )
+    }
+
+    func testCrashAndEngineGuidanceHeadlineCarriesFullStatusLine() {
+        XCTAssertEqual(
+            EditorFailureGuidance.guidance(for: .engineUnavailable)?.headline,
+            EditorSessionError.engineUnavailable.message
+        )
+        XCTAssertEqual(
+            EditorFailureGuidance.guidance(for: .crashLoop(stderrTail: "boom"))?.headline,
+            EditorSessionError.crashLoop(stderrTail: "boom").message
+        )
+    }
+}

--- a/Tests/ContractTests/EditorSessionReconnectTests.swift
+++ b/Tests/ContractTests/EditorSessionReconnectTests.swift
@@ -163,7 +163,7 @@ final class EditorSessionReconnectTests: XCTestCase {
 
         // No engine: permanent configuration error, not a crash (#232).
         session.start(contentRoot: root, projectRoot: project, engine: nil)
-        XCTAssertEqual(session.phase, .failed("Boris engine not available."))
+        XCTAssertEqual(session.phase, .failed(.engineUnavailable))
         XCTAssertTrue(recorder.hosts.isEmpty)
     }
 
@@ -201,11 +201,12 @@ final class EditorSessionReconnectTests: XCTestCase {
         // Fourth crash within the window: cap reached, manual restart required.
         recorder.last?.crash(exitCode: 1)
         await settle()
-        guard case .failed(let message) = session.phase else {
+        guard case .failed(let error) = session.phase else {
             return XCTFail("expected failed phase, got \(session.phase)")
         }
-        XCTAssertTrue(message.contains("Manual restart required"), message)
-        XCTAssertTrue(message.contains("3 times"), message)
+        XCTAssertEqual(error, .crashLoop(stderrTail: ""))
+        XCTAssertTrue(error.message.contains("Manual restart required"), error.message)
+        XCTAssertTrue(error.message.contains("3 times"), error.message)
 
         await settle(milliseconds: 120)
         XCTAssertEqual(recorder.hosts.count, 4, "no fifth host may spawn after the cap")


### PR DESCRIPTION
Closes #280.

## What

`EditorSession.Phase.failed` now carries a typed `EditorSessionError` instead of a raw message, and `EditorWindow.errorGuidance` switches on enum cases via the pure `EditorFailureGuidance` mapping — no more `String.contains()` on wording that could drift.

## Cases

- `.engineUnavailable` — no engine binary
- `.binaryNotFound` — permanent config error, copy stays verbatim from `EditorHostLaunchError` (single source of truth)
- `.timeout` — token URL never arrived; budget centralized as `EditorSession.connectTimeout` (was hardcoded "15s" in three places)
- `.crashLoop(stderrTail:)` — reconnect cap reached, manual restart required
- `.launchFailed(String)` / `.folderUnresolved(String)` — pass-through cases, guidance nil (falls back to idle copy, same as before)

The `EditorHostLaunchError → EditorSessionError` init is exhaustive, so a new factory case cannot be added without deciding its session meaning; a new session case cannot be added without updating `EditorFailureGuidance` and `EditorPhaseCopy`.

## Verification

- `make lint` — 0 violations
- `make test` — 498 tests, 0 failures (new `EditorSessionErrorTests` pins per-case copy and the guidance mapping)
- app target builds (with `SOLIPSIST_BORIS_BIN`)