### PR TITLE
engine: settings tell the truth — drop dead binary pickers, hard-gate embedded engines

### DIFF
--- a/.github/workflows/release-notarize.yml
+++ b/.github/workflows/release-notarize.yml
@@ -181,7 +181,18 @@ jobs:
             exit 1
           fi
 
-          # Companion tools: verify universal binary and --version where supported.
+          # Oliver renderer: must be present and universal — a sandboxed
+          # app cannot fall back to SOLIPSIST_OLIVER_BIN (#292).
+          OLIVER_PATH="$APP_PATH/Contents/Resources/oliver"
+          if [ -f "$OLIVER_PATH" ]; then
+            echo "==> oliver:"
+            lipo -info "$OLIVER_PATH"
+          else
+            echo "FAIL: Contents/Resources/oliver missing from the release bundle (sandboxed apps cannot exec outside the bundle)" >&2
+            exit 1
+          fi
+
+          # Companion tools: must be present and universal.
           COMPANIONS="boris-editor boris-package boris-source-rag boris-content-audit"
           for comp in $COMPANIONS; do
             COMP_PATH="$APP_PATH/Contents/Resources/$comp"
@@ -189,7 +200,8 @@ jobs:
               echo "==> $comp:"
               lipo -info "$COMP_PATH"
             else
-              echo "WARNING: $comp missing from release bundle" >&2
+              echo "FAIL: Contents/Resources/$comp missing from the release bundle" >&2
+              exit 1
             fi
           done
 

--- a/Sources/App/Settings/EngineSettingsPane.swift
+++ b/Sources/App/Settings/EngineSettingsPane.swift
@@ -1,46 +1,24 @@
-import AppKit
 import SwiftUI
 
-/// Settings pane displaying the Boris compiler and Oliver renderer binary status,
-/// active paths, detected versions, custom path selection, and search-order guidance.
+/// Settings pane displaying the Boris compiler, Oliver renderer, and
+/// boris-editor host status: resolved paths, detected versions, origin,
+/// and search-order guidance (#292). There are no binary pickers — under
+/// App Sandbox only the embedded engines can execute; developers override
+/// via `SOLIPSIST_BORIS_BIN` / `SOLIPSIST_OLIVER_BIN` /
+/// `SOLIPSIST_BORIS_EDITOR_BIN`.
 struct EngineSettingsPane: View {
     @Environment(AppRuntime.self) private var runtime
-    @State private var refreshTrigger = UUID()
-
-    @AppStorage("customBorisBinaryPath") private var customBorisPath: String = ""
-    @AppStorage("customOliverBinaryPath") private var customOliverPath: String = ""
-    @AppStorage("customBorisEditorBinaryPath") private var customEditorPath: String = ""
 
     private var borisURL: URL? {
-        _ = refreshTrigger
-        return BorisBinary.locate()
+        runtime.enginePath.map(URL.init(fileURLWithPath:)) ?? BorisBinary.locate()
     }
 
     private var oliverURL: URL? {
-        _ = refreshTrigger
-        return OliverBinary.locate(borisBinary: borisURL)
+        OliverBinary.locate(borisBinary: borisURL)
     }
 
     private var editorURL: URL? {
-        _ = refreshTrigger
-        if !customEditorPath.isEmpty, FileManager.default.isExecutableFile(atPath: customEditorPath) {
-            return URL(fileURLWithPath: customEditorPath)
-        }
-        if let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_EDITOR_BIN"],
-           !env.isEmpty, FileManager.default.isExecutableFile(atPath: env)
-        {
-            return URL(fileURLWithPath: env)
-        }
-        if let boris = borisURL {
-            let sibling = boris.deletingLastPathComponent().appendingPathComponent("boris-editor")
-            if FileManager.default.isExecutableFile(atPath: sibling.path) { return sibling }
-        }
-        if let bundled = Bundle.main.url(forResource: "boris-editor", withExtension: nil),
-           FileManager.default.isExecutableFile(atPath: bundled.path)
-        {
-            return bundled
-        }
-        return nil
+        borisURL.flatMap { EditorServerFactory.findEditorBinary(relativeTo: $0) }
     }
 
     var body: some View {
@@ -76,25 +54,6 @@ struct EngineSettingsPane: View {
                             .foregroundStyle(.red)
                     }
                 }
-
-                LabeledContent("Custom Binary") {
-                    HStack(spacing: 8) {
-                        Button("Choose Custom Boris…") {
-                            chooseBinary(prompt: "Select Boris executable") { path in
-                                customBorisPath = path
-                                runtime.reloadEngine()
-                                refreshTrigger = UUID()
-                            }
-                        }
-                        if !customBorisPath.isEmpty {
-                            Button("Reset to Embedded") {
-                                customBorisPath = ""
-                                runtime.reloadEngine()
-                                refreshTrigger = UUID()
-                            }
-                        }
-                    }
-                }
             } header: {
                 Text("Boris Compiler")
             }
@@ -117,23 +76,6 @@ struct EngineSettingsPane: View {
                             .foregroundStyle(.secondary)
                             .textSelection(.enabled)
                             .lineLimit(2)
-                    }
-                }
-
-                LabeledContent("Custom Binary") {
-                    HStack(spacing: 8) {
-                        Button("Choose Custom Oliver…") {
-                            chooseBinary(prompt: "Select Oliver executable") { path in
-                                customOliverPath = path
-                                refreshTrigger = UUID()
-                            }
-                        }
-                        if !customOliverPath.isEmpty {
-                            Button("Reset to Default") {
-                                customOliverPath = ""
-                                refreshTrigger = UUID()
-                            }
-                        }
                     }
                 }
             } header: {
@@ -160,23 +102,6 @@ struct EngineSettingsPane: View {
                             .lineLimit(2)
                     }
                 }
-
-                LabeledContent("Custom Binary") {
-                    HStack(spacing: 8) {
-                        Button("Choose Custom Editor…") {
-                            chooseBinary(prompt: "Select boris-editor executable") { path in
-                                customEditorPath = path
-                                refreshTrigger = UUID()
-                            }
-                        }
-                        if !customEditorPath.isEmpty {
-                            Button("Reset to Default") {
-                                customEditorPath = ""
-                                refreshTrigger = UUID()
-                            }
-                        }
-                    }
-                }
             } header: {
                 Text("Boris Editor Host")
             }
@@ -190,26 +115,25 @@ struct EngineSettingsPane: View {
                     VStack(alignment: .leading, spacing: 4) {
                         searchStep(
                             index: "1",
-                            title: "Settings Custom Preference",
-                            detail: "User-selected path saved in Preferences"
-                        )
-                        searchStep(
-                            index: "2",
                             title: "Environment Variables",
                             detail: "SOLIPSIST_BORIS_BIN / SOLIPSIST_OLIVER_BIN / SOLIPSIST_BORIS_EDITOR_BIN"
                         )
                         searchStep(
-                            index: "3",
+                            index: "2",
                             title: "App Bundle (Embedded)",
                             detail: "Solipsist.app/Contents/Resources/…"
                         )
                         searchStep(
-                            index: "4",
+                            index: "3",
                             title: "Sibling Repository / Kits",
                             detail: "SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/… or ../boris/zig-out/bin/…"
                         )
                     }
                     .padding(.top, 2)
+
+                    Text("App Sandbox can only execute binaries inside our own bundle, so there is no user-selected engine setting. Developer overrides use the environment variables above.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             } header: {
                 Text("Binary Discovery & Sourcing")
@@ -217,18 +141,6 @@ struct EngineSettingsPane: View {
         }
         .formStyle(.grouped)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private func chooseBinary(prompt: String, onSelect: @escaping (String) -> Void) {
-        let panel = NSOpenPanel()
-        panel.title = prompt
-        panel.canChooseFiles = true
-        panel.canChooseDirectories = false
-        panel.allowsMultipleSelection = false
-        panel.resolvesAliases = true
-        if panel.runModal() == .OK, let url = panel.url {
-            onSelect(url.path)
-        }
     }
 
     private func searchStep(index: String, title: String, detail: String) -> some View {
@@ -248,9 +160,7 @@ struct EngineSettingsPane: View {
     }
 
     private func originDescription(for path: String) -> String {
-        if !customBorisPath.isEmpty, path == customBorisPath {
-            return "User-selected custom binary"
-        } else if path.contains(".app/Contents/Resources") {
+        if path.contains(".app/Contents/Resources") {
             return "Embedded in Solipsist.app bundle"
         } else if let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_BIN"], !env.isEmpty, path == env {
             return "Custom override via SOLIPSIST_BORIS_BIN"

--- a/Sources/App/SolipsistApp.swift
+++ b/Sources/App/SolipsistApp.swift
@@ -50,6 +50,7 @@ struct SolipsistApp: App {
         if CommandLine.arguments.contains(GitCredentialHelper.flag) {
             GitCredentialHelper.runAndExit()
         }
+        EngineBinaryDefaults.removeLegacyCustomPaths()
         _appDelegate = NSApplicationDelegateAdaptor(AppDelegate.self)
         _store = State(initialValue: WorkspaceStore())
         _runtime = State(initialValue: AppRuntime())

--- a/Sources/Companions/Editor/EditorServerFactory.swift
+++ b/Sources/Companions/Editor/EditorServerFactory.swift
@@ -30,11 +30,6 @@ enum EditorServerFactory {
     }
 
     static func findEditorBinary(relativeTo engineBinary: URL) -> URL? {
-        if let custom = UserDefaults.standard.string(forKey: "customBorisEditorBinaryPath"), !custom.isEmpty {
-            let url = URL(fileURLWithPath: custom)
-            if FileManager.default.isExecutableFile(atPath: url.path) { return url }
-        }
-
         let env = ProcessInfo.processInfo.environment["SOLIPSIST_BORIS_EDITOR_BIN"]
         if let env, !env.isEmpty, FileManager.default.isExecutableFile(atPath: env) {
             return URL(fileURLWithPath: env)

--- a/Sources/Engine/BorisBinary.swift
+++ b/Sources/Engine/BorisBinary.swift
@@ -17,11 +17,6 @@ public enum BorisBinary {
             fm.isExecutableFile(atPath: url.path)
         }
 
-        if let custom = UserDefaults.standard.string(forKey: "customBorisBinaryPath"), !custom.isEmpty {
-            let url = URL(fileURLWithPath: custom)
-            if isExecutable(url) { return url }
-        }
-
         if let override = environment["SOLIPSIST_BORIS_BIN"], !override.isEmpty {
             let url = URL(fileURLWithPath: override)
             if isExecutable(url) { return url }

--- a/Sources/Engine/EngineBinaryDefaults.swift
+++ b/Sources/Engine/EngineBinaryDefaults.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Removes the legacy `custom*BinaryPath` preference keys (#292).
+///
+/// Settings → Engine no longer offers binary pickers: App Sandbox denies
+/// exec outside our own bundle, so a saved custom path could never work
+/// in a signed build and would only shadow the embedded engine. The
+/// locators stopped reading these keys; this clears any stale values
+/// written by older builds.
+public enum EngineBinaryDefaults {
+    public static let legacyKeys = [
+        "customBorisBinaryPath",
+        "customOliverBinaryPath",
+        "customBorisEditorBinaryPath",
+    ]
+
+    public static func removeLegacyCustomPaths(defaults: UserDefaults = .standard) {
+        for key in legacyKeys where defaults.object(forKey: key) != nil {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}

--- a/Sources/Engine/OliverBinary.swift
+++ b/Sources/Engine/OliverBinary.swift
@@ -19,11 +19,6 @@ public enum OliverBinary {
             fm.isExecutableFile(atPath: url.path)
         }
 
-        if let custom = UserDefaults.standard.string(forKey: "customOliverBinaryPath"), !custom.isEmpty {
-            let url = URL(fileURLWithPath: custom)
-            if isExecutable(url) { return url }
-        }
-
         if let override = environment["SOLIPSIST_OLIVER_BIN"], !override.isEmpty {
             let url = URL(fileURLWithPath: override)
             if isExecutable(url) { return url }

--- a/Tests/ContractTests/EngineBinaryLocatorTests.swift
+++ b/Tests/ContractTests/EngineBinaryLocatorTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+final class EngineBinaryLocatorTests: XCTestCase {
+    override func tearDown() {
+        for key in EngineBinaryDefaults.legacyKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Environment rung stays first (#292 must-not-land guard)
+
+    func testBorisEnvironmentOverrideWins() {
+        let url = BorisBinary.locate(environment: ["SOLIPSIST_BORIS_BIN": "/bin/ls"])
+        XCTAssertEqual(url?.path, "/bin/ls")
+    }
+
+    func testOliverEnvironmentOverrideWins() {
+        let url = OliverBinary.locate(
+            environment: ["SOLIPSIST_OLIVER_BIN": "/bin/ls"],
+            borisBinary: nil
+        )
+        XCTAssertEqual(url?.path, "/bin/ls")
+    }
+
+    // MARK: - Stale custom-path defaults are ignored
+
+    func testStaleBorisDefaultDoesNotShadowResolution() {
+        UserDefaults.standard.set("/bin/echo", forKey: "customBorisBinaryPath")
+        let url = BorisBinary.locate(environment: [:])
+        XCTAssertNotEqual(url?.path, "/bin/echo")
+    }
+
+    func testStaleOliverDefaultDoesNotShadowResolution() {
+        UserDefaults.standard.set("/bin/echo", forKey: "customOliverBinaryPath")
+        let url = OliverBinary.locate(environment: [:], borisBinary: nil)
+        XCTAssertNotEqual(url?.path, "/bin/echo")
+    }
+
+    func testStaleEditorDefaultDoesNotShadowResolution() {
+        UserDefaults.standard.set("/bin/echo", forKey: "customBorisEditorBinaryPath")
+        let url = EditorServerFactory.findEditorBinary(
+            relativeTo: URL(fileURLWithPath: "/usr/bin/boris")
+        )
+        XCTAssertNotEqual(url?.path, "/bin/echo")
+    }
+
+    // MARK: - Launch-time cleanup of legacy keys
+
+    func testRemoveLegacyCustomPathsClearsAllThreeKeys() {
+        let defaults = UserDefaults.standard
+        defaults.set("/bin/echo", forKey: "customBorisBinaryPath")
+        defaults.set("/bin/echo", forKey: "customOliverBinaryPath")
+        defaults.set("/bin/echo", forKey: "customBorisEditorBinaryPath")
+
+        EngineBinaryDefaults.removeLegacyCustomPaths(defaults: defaults)
+
+        for key in EngineBinaryDefaults.legacyKeys {
+            XCTAssertNil(defaults.object(forKey: key), "\(key) should be removed on launch")
+        }
+    }
+
+    func testRemoveLegacyCustomPathsLeavesOtherKeysAlone() {
+        let defaults = UserDefaults.standard
+        defaults.set("keep me", forKey: "someUnrelatedKey")
+        defer { defaults.removeObject(forKey: "someUnrelatedKey") }
+
+        EngineBinaryDefaults.removeLegacyCustomPaths(defaults: defaults)
+
+        XCTAssertEqual(defaults.string(forKey: "someUnrelatedKey"), "keep me")
+    }
+}

--- a/docs/SHIP-HARDENING.md
+++ b/docs/SHIP-HARDENING.md
@@ -38,6 +38,14 @@ Solipsist.app/
 2. `Bundle.main.resourceURL.appendingPathComponent("boris")` (production bundled path).
 3. Relative developer checkout paths (`SUPPORT-NOT-FOR-GITHUB/`, `zig-out/`).
 
+There are **no user-facing binary pickers** (#292): App Sandbox denies
+exec of any binary outside our own bundle, so a user-selected engine can
+never work in a signed build. Settings → Engine is status-only
+(version, resolved path, origin); the locators no longer read the legacy
+`customBorisBinaryPath` / `customOliverBinaryPath` /
+`customBorisEditorBinaryPath` defaults, and `EngineBinaryDefaults`
+removes any stale values on launch.
+
 ### Universal Slicing (`scripts/embed-boris.sh`)
 When building release packages:
 - If discrete `arm64` and `x86_64` Mach-O binaries are found, `scripts/embed-boris.sh` invokes `lipo -create -output` to assemble a universal Mach-O fat binary.
@@ -90,7 +98,11 @@ feeds the discrete binaries to `scripts/embed-boris.sh` via
 phase lipo-merges a fat engine (no `GITHUB_ACTIONS` skip — that opt-out is
 now explicit `SKIP_EMBED_BORIS=1`, set by the PR compile job only), pins
 `ARCHS="arm64 x86_64"` for the app build, and **fails** if
-`Contents/Resources/boris` is missing from the release bundle. Signing and
+`Contents/Resources/boris`, `Contents/Resources/oliver`, or any companion
+tool (`boris-editor`, `boris-package`, `boris-source-rag`,
+`boris-content-audit`) is missing from the release bundle or not a
+universal fat binary (#292 — under sandbox there is no env-var fallback,
+so a bundle shipped without one of these is silently broken). Signing and
 notarization steps are gated on **job-level** `env.*` mapped from
 `secrets.*` (`secrets` is illegal in `steps.if` and GitHub rejects the
 workflow at startup; step-level `env.*` is invisible to that step's

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -55,5 +55,12 @@ Status (2026-08-21): all five accessibility children merged — #243 (PR
 #244), #239 (PR #247), #240 (PR #249), #241 (PR #251), #242 (PR #252).
 #236 tracker closed.
 
+Post-M17 ship-posture draft (the bundling half of banal#209 already
+landed as M9/#78; this is the residual honesty half):
+
+| Draft | Issue | Lane |
+|-------|-------|------|
+| [Engine settings tell the truth](engine-settings-truth.md) | [#292](https://github.com/drawmeanelephant/solipsist/issues/292) | `Sources/App/Settings/EngineSettingsPane.swift` + `Sources/Engine/*Binary.swift` + release gate |
+
 Do not ask: unifying `compiler` field names, library mode, relaxing
 editor token/CSP, shipping `boris-editor` in the agent-pack.

--- a/docs/issues/engine-settings-truth.md
+++ b/docs/issues/engine-settings-truth.md
@@ -1,0 +1,128 @@
+# Engine Settings Tell the Truth — drop the dead binary pickers, hard-gate the embedded engines
+
+**Track:** Ship posture / Settings honesty
+**Milestone:** Post-M17 polish
+**Issue:** [#292](https://github.com/drawmeanelephant/solipsist/issues/292)
+**Lane:** `Sources/App/Settings/EngineSettingsPane.swift` + the three locators + release gate
+
+Sibling of banal#209 ("Bundle Oliver and Boris inside the app for sandbox
+self-containment"). Solipsist already did the bundling half (M9, #78):
+boris, oliver, and the companion tools are lipo'd universal, hardened-
+runtime-signed, and embedded at `Contents/Resources/`. What we never
+revisited is the UI and the release gate around that decision — and both
+now promise things the shipped app cannot do.
+
+## Problem
+
+Three problems, one root cause: the pre-M9 world (locate a binary from
+the host) is still visible in surfaces that the M9 world (bundle
+everything, sandbox everything) has made dead or dangerous.
+
+1. **The pickers cannot work in the shipped build.**
+   Settings → Engine offers "Choose Custom Boris… / Oliver… / Editor…"
+   (`EngineSettingsPane.swift:80-97, 123-138, 164-179`). The app runs
+   under `com.apple.security.app-sandbox` (`Solipsist.entitlements:5`);
+   App Sandbox denies exec of any binary outside our own bundle, so a
+   user-picked engine fails with EPERM in exactly the build where a
+   consumer would try it. Developer plumbing posing as a consumer
+   setting.
+2. **A stale preference shadows the working embedded engine.**
+   All three locators read a `custom*BinaryPath` default *first*
+   (`BorisBinary.swift:20-23`, `OliverBinary.swift:22-25`,
+   `EditorServerFactory.swift:33-36`). A path saved under an older
+   build (or by a curious user pointing at a random file) silently
+   outranks the signed, universal engine we ship. Same trap shape as
+   banal#202 ("CI-green, machine-specific").
+3. **The release gate trusts boris but winks at everything else.**
+   `release-notarize.yml:176-180` exits 1 when `Resources/boris` is
+   missing; oliver and the four companions only get a WARNING
+   (`:185-193`), and `embed-boris.sh:183` treats missing oliver as a
+   notice. Under sandbox there is no fallback to warn about:
+   a Finder-launched release never inherits `SOLIPSIST_OLIVER_BIN`
+   (launchd strips shell env; `open` strips it too), so a bundle that
+   ships without oliver is silently-broken compose preview with no
+   recourse. That is precisely the gap banal#209 exists to close on
+   their side; we closed the bundling but left the gate soft.
+
+## Verified current state
+
+- Pickers + "Reset" buttons: `EngineSettingsPane.swift:80-97` (boris),
+  `:123-138` (oliver), `:164-179` (editor); `NSOpenPanel` helper at
+  `:222-232`; in-app search-order explainer lists "Settings Custom
+  Preference" as step 1 (`:184-216`).
+- Custom-pref first rung: `BorisBinary.swift:20-23`,
+  `OliverBinary.swift:22-25`, `EditorServerFactory.swift:33-36`.
+  Grep confirms nothing else reads the three defaults keys; **no test
+  references them**.
+- Env rung: `SOLIPSIST_BORIS_BIN` / `SOLIPSIST_OLIVER_BIN` /
+  `SOLIPSIST_BORIS_EDITOR_BIN`. Used by CI
+  (`ci.yml:61`), scripts (`embed-boris.sh`, `harvest-stunt-fixtures.sh`,
+  `stunt-smoke.sh`), and the non-sandboxed test host. Keep.
+- Embedded binaries land in `Contents/Resources/` (not Helpers) via
+  xcodegen phase → `embed-boris.sh`; companions embedded alongside:
+  boris-editor, boris-package, boris-source-rag, boris-content-audit.
+- Release inspection: boris = hard fail + `lipo -info` + `--version`;
+  companions = WARNING only (`release-notarize.yml:174-193`).
+- `README.md:58-60` already documents the honest order (env → bundle →
+  dev checkouts) with no mention of the pref — the docs got the memo,
+  the code and UI didn't.
+
+## Scope
+
+### Must land
+
+- **Remove the three pickers and Reset buttons** from
+  `EngineSettingsPane`. The pane becomes status-only: green/red dot +
+  version, resolved path, origin line ("Embedded in Solipsist.app
+  bundle", etc.). Keep `originDescription` minus the custom-path case.
+- **Remove the `custom*BinaryPath` first rung** from all three locators.
+  Search order collapses to: env override → bundled `Resources/…` /
+  sibling-of-boris → dev checkouts. Delete the three keys from
+  preferences on launch so stale values don't linger as zombies
+  (`UserDefaults.removeObject`, one-time, cheap, silent).
+- **Update the in-app explainer** (`searchStep` list): renumber, drop
+  the Settings rung.
+- **Hard-gate the release bundle:** in `release-notarize.yml`, require
+  `Resources/oliver` and all four companions to exist (exit 1, matching
+  boris), and `lipo -info` each one — every embedded engine must be
+  arm64 + x86_64 or the release does not ship.
+- **Doc updates, same change:** `docs/SHIP-HARDENING.md` §2 (search
+  precedence drops the env-only caveat stays; note pickers removed),
+  `docs/issues/README.md` index row.
+
+### Must not land
+
+- Do not remove the env-var overrides — CI, scripts, and the test host
+  depend on them (`make test` must stay green with zero embedding).
+- Do not remove the dev-checkout candidates — ad-hoc dev builds with
+  `SKIP_EMBED_BORIS=1` rely on kit/sibling resolution.
+- Do not move binaries from `Resources/` to `Contents/Helpers/` — churn
+  with no functional win under our signing setup.
+- Do not add a hidden DEBUG-only picker. Env vars are the developer
+  escape hatch; two escape hatches is how we got here.
+
+## Gate
+
+1. Signed sandboxed release build: Settings → Engine shows status only;
+   engine resolves to `Contents/Resources/boris`; origin reads
+   "Embedded". No NSOpenPanel anywhere in the pane.
+2. Negative test: strip `Resources/oliver` from a staged release app →
+   the workflow's inspect step exits 1. Same for any companion.
+3. Stale-defaults test: set `customBorisBinaryPath` to a bogus
+   executable path, launch, confirm the app runs the embedded engine
+   and the key is gone after first launch.
+4. `SKIP_EMBED_BORIS=1 make build` + `make test` green (locators still
+   resolve via env/dev candidates in the unsandboxed test host).
+
+## Edge cases
+
+- `BorisBinary.locate(environment:)` keeps its injectable signature —
+  tests and previews pass explicit environments; only the UserDefaults
+  read disappears.
+- The editor locator's sibling-of-boris rung
+  (`EditorServerFactory.swift:43-46`) already covers the embedded layout
+  (boris-editor sits next to boris in Resources); verify the Bundle.main
+  fallback behind it stays for standalone launches.
+- Ad-hoc dev builds (no Developer ID): codesign of embedded copies falls
+  back to `-` in embed-boris.sh — unchanged by this card; the workflow's
+  spctl gate already skips those correctly.


### PR DESCRIPTION
Closes #292. Sibling of banal#209 — Solipsist already did the bundling half (M9, #78); this lands the residual honesty half.

## What

- **Settings → Engine is status-only** (`EngineSettingsPane`): version dot, resolved path, origin, search-order explainer. The three "Choose Custom …" pickers are gone — App Sandbox denies exec outside our own bundle, so a user-picked engine could never work in a signed build.
- **Locators drop the `custom*BinaryPath` first rung** (`BorisBinary`, `OliverBinary`, `EditorServerFactory`). Search order collapses to env override → embedded `Resources/` → sibling/dev checkouts. New `EngineBinaryDefaults.removeLegacyCustomPaths()` clears stale keys on launch so an old default can't shadow the embedded engine.
- **Release gate hardened**: `release-notarize.yml` now exits 1 when `Resources/oliver` or any companion tool (`boris-editor`, `boris-package`, `boris-source-rag`, `boris-content-audit`) is missing from the bundle, and `lipo -info`s each — universal or the release does not ship. Previously boris was the only hard gate; oliver/companions were WARNING-only, and under sandbox there is no env-var fallback to warn about.
- **Docs**: SHIP-HARDENING §2 (no pickers, legacy-key cleanup) + §4 (companion hard gates); draft filed as docs/issues/engine-settings-truth.md and indexed.

## Not changed (must-not-land)

Env-var overrides stay (CI/scripts/test host depend on them), dev-checkout candidates stay (`SKIP_EMBED_BORIS=1` builds), binaries stay in `Contents/Resources/`, no DEBUG-only picker resurrection.

## Verification

- `SKIP_EMBED_BORIS=1 make build` ✅
- `make test` — 505 tests, 0 failures (7 new `EngineBinaryLocatorTests`: env rung wins, stale defaults ignored for all three locators, legacy keys cleared, unrelated keys untouched) ✅
- `make lint` — swiftformat + swiftlint --strict, 0 violations ✅
- Manual gate remaining for release: negative-test the workflow inspect step by stripping `Resources/oliver` from a staged app.