### PR TITLE
intents: Siri drafts posts (M18) — journal-schema App Intent + on-device drafting, macOS 27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,6 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Solipsist's deployment target is macOS 27.0, so every job that builds
-# or executes project targets must land on a macOS 27 host. The shared
-# `xcode-27` label may span hosts on older OSes — fail fast there with
-# the reason instead of an opaque xcodebuild destination error.
-
 jobs:
   lint:
     name: lint
@@ -32,15 +27,6 @@ jobs:
     runs-on: xcode-27
     steps:
       - uses: actions/checkout@v7
-      - name: Require macOS 27 host
-        run: |
-          set -euo pipefail
-          version="$(sw_vers -productVersion)"
-          major="$(echo "$version" | cut -d. -f1)"
-          if [ "$major" -lt 27 ]; then
-            echo "::error::Runner is macOS $version; Solipsist requires macOS 27 (deployment target 27.0). Upgrade or relabel this xcode-27 host." >&2
-            exit 1
-          fi
       - uses: actions/checkout@v7
 
       # Same pin as #116 / release-notarize.yml (afterparty, boris#648).
@@ -87,15 +73,6 @@ jobs:
       SKIP_EMBED_BORIS: "1"
     steps:
       - uses: actions/checkout@v7
-      - name: Require macOS 27 host
-        run: |
-          set -euo pipefail
-          version="$(sw_vers -productVersion)"
-          major="$(echo "$version" | cut -d. -f1)"
-          if [ "$major" -lt 27 ]; then
-            echo "::error::Runner is macOS $version; Solipsist requires macOS 27 (deployment target 27.0). Upgrade or relabel this xcode-27 host." >&2
-            exit 1
-          fi
       - uses: actions/checkout@v7
       - name: Generate project and compile the app
         run: make build
@@ -117,15 +94,6 @@ jobs:
     runs-on: xcode-27
     steps:
       - uses: actions/checkout@v7
-      - name: Require macOS 27 host
-        run: |
-          set -euo pipefail
-          version="$(sw_vers -productVersion)"
-          major="$(echo "$version" | cut -d. -f1)"
-          if [ "$major" -lt 27 ]; then
-            echo "::error::Runner is macOS $version; Solipsist requires macOS 27 (deployment target 27.0). Upgrade or relabel this xcode-27 host." >&2
-            exit 1
-          fi
       - uses: actions/checkout@v7
       - name: Decode checked-in contract fixtures
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Solipsist's deployment target is macOS 27.0, so every job that builds
+# or executes project targets must land on a macOS 27 host. The shared
+# `xcode-27` label may span hosts on older OSes — fail fast there with
+# the reason instead of an opaque xcodebuild destination error.
+
 jobs:
   lint:
     name: lint
@@ -26,6 +31,16 @@ jobs:
     name: spike
     runs-on: xcode-27
     steps:
+      - uses: actions/checkout@v7
+      - name: Require macOS 27 host
+        run: |
+          set -euo pipefail
+          version="$(sw_vers -productVersion)"
+          major="$(echo "$version" | cut -d. -f1)"
+          if [ "$major" -lt 27 ]; then
+            echo "::error::Runner is macOS $version; Solipsist requires macOS 27 (deployment target 27.0). Upgrade or relabel this xcode-27 host." >&2
+            exit 1
+          fi
       - uses: actions/checkout@v7
 
       # Same pin as #116 / release-notarize.yml (afterparty, boris#648).
@@ -72,6 +87,16 @@ jobs:
       SKIP_EMBED_BORIS: "1"
     steps:
       - uses: actions/checkout@v7
+      - name: Require macOS 27 host
+        run: |
+          set -euo pipefail
+          version="$(sw_vers -productVersion)"
+          major="$(echo "$version" | cut -d. -f1)"
+          if [ "$major" -lt 27 ]; then
+            echo "::error::Runner is macOS $version; Solipsist requires macOS 27 (deployment target 27.0). Upgrade or relabel this xcode-27 host." >&2
+            exit 1
+          fi
+      - uses: actions/checkout@v7
       - name: Generate project and compile the app
         run: make build
 
@@ -91,6 +116,16 @@ jobs:
     name: fixtures
     runs-on: xcode-27
     steps:
+      - uses: actions/checkout@v7
+      - name: Require macOS 27 host
+        run: |
+          set -euo pipefail
+          version="$(sw_vers -productVersion)"
+          major="$(echo "$version" | cut -d. -f1)"
+          if [ "$major" -lt 27 ]; then
+            echo "::error::Runner is macOS $version; Solipsist requires macOS 27 (deployment target 27.0). Upgrade or relabel this xcode-27 host." >&2
+            exit 1
+          fi
       - uses: actions/checkout@v7
       - name: Decode checked-in contract fixtures
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ zig-out/
 SUPPORT-NOT-FOR-GITHUB/
 /boris-agent-kit/
 /boris/
+/oliver/
 *.tar.gz
 
 # Stunt harvest leftovers

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PROJECT  := Solipsist.xcodeproj
 # Empty SPIKE_CONTENT = spike default ../boris/content.
 SPIKE_CONTENT ?=
 
-.PHONY: tools generate build spike run-spike test lint harvest-fixtures site check-site clean fart
+.PHONY: tools generate build install-app spike run-spike test lint harvest-fixtures site check-site clean fart
 
 tools:
 	@mkdir -p .tools
@@ -28,6 +28,21 @@ generate: tools
 build: generate
 	xcodebuild -project $(PROJECT) -scheme Solipsist -configuration Debug \
 		-derivedDataPath build build
+
+# Siri / Spotlight only register App Intents for apps they index — the
+# Xcode build folder is not it. Install into /Applications and launch
+# once so siriactionsd picks up Metadata.appintents.
+#
+# The product is deleted BEFORE building: the embed phase writes into
+# Resources on every build, and an incremental xcodebuild will happily
+# leave those files outside the code signature ("file added" seal
+# errors). A fresh product directory forces a complete signing pass.
+install-app:
+	rm -rf /Applications/Solipsist.app
+	rm -rf build/Build/Products/Debug/Solipsist.app
+	$(MAKE) build
+	ditto build/Build/Products/Debug/Solipsist.app /Applications/Solipsist.app
+	open /Applications/Solipsist.app
 
 spike: generate
 	xcodebuild -project $(PROJECT) -scheme spike -configuration Debug \

--- a/Project.yml
+++ b/Project.yml
@@ -7,7 +7,7 @@ name: Solipsist
 options:
   bundleIdPrefix: dev.drawmeanelephant
   deploymentTarget:
-    macOS: "26.0"
+    macOS: "27.0"
   createIntermediateGroups: true
 
 settings:
@@ -16,7 +16,7 @@ settings:
     SWIFT_STRICT_CONCURRENCY: complete
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
-    MACOSX_DEPLOYMENT_TARGET: "26.0"
+    MACOSX_DEPLOYMENT_TARGET: "27.0"
     # Local dev builds: ad-hoc sign to run locally (no team required).
     CODE_SIGN_STYLE: Manual
     CODE_SIGN_IDENTITY: "-"
@@ -36,6 +36,7 @@ targets:
       - path: Sources/Inspector
       - path: Sources/Companions
       - path: Sources/Compose
+      - path: Sources/Intents
       - path: Sources/Models
       - path: Sources/Engine
       - path: Sources/Security
@@ -65,6 +66,11 @@ targets:
         com.apple.security.network.client: true
         # `boris watch --serve` (spawned by the app) binds a loopback port.
         com.apple.security.network.server: true
+        # NOTE: FoundationModels drafting (M18) runs without extra
+        # entitlements locally (probed: availability == .available under
+        # ad-hoc signing). App Store distribution will need
+        # com.apple.developer.foundation-model-access + provisioning —
+        # #110 territory.
     preBuildScripts:
       - name: Embed Boris engine binary
         basedOnDependencyAnalysis: false
@@ -139,6 +145,10 @@ targets:
       - path: Sources/Compose/ComposeTextView.swift
       - path: Sources/Compose/ComposeTextCoordinator.swift
       - path: Sources/Compose/ComposeFormat.swift
+      - path: Sources/Compose/ComposeStagedDraft.swift
+      - path: Sources/Intents/StagedPostDraft.swift
+      - path: Sources/Intents/DraftRouter.swift
+      - path: Sources/Intents/PostDraftEngine.swift
       - path: Sources/Compose/ComposeFormatToolbar.swift
       - path: Sources/Compose/ComposeTypography.swift
     settings:

--- a/Project.yml
+++ b/Project.yml
@@ -84,6 +84,10 @@ targets:
   spike:
     type: tool
     platform: macOS
+    # CI hosts may run macOS 26; the spike harness uses nothing newer.
+    # Only the shipped app requires 27.
+    deploymentTarget:
+      macOS: "26.0"
     sources:
       - path: Sources/Models
       - path: Sources/Engine
@@ -92,12 +96,18 @@ targets:
       - path: Spike
     settings:
       base:
+        MACOSX_DEPLOYMENT_TARGET: "26.0"
         PRODUCT_NAME: boris-spike
         GENERATE_INFOPLIST_FILE: YES
 
   ContractTests:
     type: bundle.unit-test
     platform: macOS
+    # Host-agnostic like spike: every API these tests touch is ≤26
+    # (FoundationModels included). The 27-only surface (supportedModes)
+    # lives in the app target only.
+    deploymentTarget:
+      macOS: "26.0"
     sources:
       - path: Tests/ContractTests
       - path: Tests/Fixtures
@@ -153,6 +163,7 @@ targets:
       - path: Sources/Compose/ComposeTypography.swift
     settings:
       base:
+        MACOSX_DEPLOYMENT_TARGET: "26.0"
         PRODUCT_BUNDLE_IDENTIFIER: dev.drawmeanelephant.solipsist.contracttests
         GENERATE_INFOPLIST_FILE: YES
         PRODUCT_NAME: ContractTests

--- a/Sources/App/AppRuntime.swift
+++ b/Sources/App/AppRuntime.swift
@@ -131,6 +131,11 @@ final class AppRuntime {
 
     var pendingComposeJump: ComposeJumpRequest?
 
+    /// M18: a staged AI draft (Siri or File menu) waiting for the compose
+    /// window to accept it into the untitled buffer. Memory-only — it
+    /// becomes content through compose's explicit save, never before.
+    var pendingComposeDraft: StagedPostDraft?
+
     /// #264: reading-comfort state for the compose buffer — the View-menu
     /// zoom / gutter commands and the editor window share this instance.
     var composeTypography = ComposeTypography()

--- a/Sources/App/Commands.swift
+++ b/Sources/App/Commands.swift
@@ -23,6 +23,10 @@ struct SolipsistCommands: Commands {
                 store.presentClonePanel()
             }
 
+            Button("New Draft with Apple Intelligence…") {
+                PostDraftPrompt.runAndStage()
+            }
+
             Menu("Open Recent") {
                 if store.recentFolderURLs.isEmpty {
                     Button("No Recent Folders") {}

--- a/Sources/Chrome/MainWindow.swift
+++ b/Sources/Chrome/MainWindow.swift
@@ -35,6 +35,15 @@ struct MainWindow: View {
             runtime.coordinator.syncSaveWatch(store: store, runtime: runtime)
             runtime.coordinator.syncValidateWatch(store: store, runtime: runtime)
             store.startSidebarWatch(for: store.selection.sourceID)
+            // M18: drafts staged by Siri / the File menu land in compose.
+            let runtime = self.runtime
+            let openWindow = self.openWindow
+            DraftRouter.shared.register { draft in
+                Task { @MainActor in
+                    runtime.pendingComposeDraft = draft
+                    openWindow(id: CompanionID.compose)
+                }
+            }
         }
         .onChange(of: store.selection.sourceID) {
             runtime.coordinator.syncSaveWatch(store: store, runtime: runtime)

--- a/Sources/Compose/ComposeSplitView.swift
+++ b/Sources/Compose/ComposeSplitView.swift
@@ -4,8 +4,12 @@ import SwiftUI
 /// Helper that configures the underlying `NSSplitView` backing a SwiftUI
 /// `HSplitView` (#227). It sets a visible divider (`dividerStyle = .thin`),
 /// an `autosaveName` so the split ratio persists, and enforces minimum pane
-/// widths (frontmatter 230, editor 280, preview 240). It also keeps the
-/// divider keyboard-accessible (NSSplitView does this natively).
+/// widths (frontmatter 230, editor 280, preview 240).
+///
+/// macOS 27 note: the backing split view is managed by an internal
+/// SplitViewController, whose delegate can no longer be modified — AppKit
+/// throws `NSInternalInconsistencyException`. Minimums are therefore
+/// enforced with per-pane width constraints, not delegate callbacks.
 ///
 /// Usage: attach as a background to any pane inside the `HSplitView`:
 ///
@@ -35,7 +39,7 @@ struct SplitViewAutosave: NSViewRepresentable {
         nsView.configureIfNeeded()
     }
 
-    final class AutosaveHelperView: NSView, NSSplitViewDelegate {
+    final class AutosaveHelperView: NSView {
         var autosaveName: String = "" {
             didSet { configureIfNeeded() }
         }
@@ -49,6 +53,7 @@ struct SplitViewAutosave: NSViewRepresentable {
         }
 
         private weak var splitView: NSSplitView?
+        private var widthConstraints: [NSLayoutConstraint] = []
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
@@ -69,10 +74,28 @@ struct SplitViewAutosave: NSViewRepresentable {
             if splitView.dividerStyle != .thin {
                 splitView.dividerStyle = .thin
             }
-            if splitView.delegate !== self {
-                splitView.delegate = self
-            }
+            applyMinimumWidths(to: splitView)
             self.splitView = splitView
+        }
+
+        /// Same minimums the old delegate callbacks enforced, expressed as
+        /// layout constraints. Sub-999 priority so a window narrower than
+        /// the sum of minimums degrades gracefully instead of throwing
+        /// unsatisfiable-constraint diagnostics.
+        private func applyMinimumWidths(to splitView: NSSplitView) {
+            for constraint in widthConstraints {
+                constraint.isActive = false
+            }
+            widthConstraints.removeAll()
+            let mins = minWidths(for: splitView)
+            for (pane, minimum) in zip(splitView.subviews, mins) {
+                let constraint = pane.widthAnchor.constraint(
+                    greaterThanOrEqualToConstant: minimum
+                )
+                constraint.priority = NSLayoutConstraint.Priority(999)
+                constraint.isActive = true
+                widthConstraints.append(constraint)
+            }
         }
 
         private func findSplitView() -> NSSplitView? {
@@ -96,63 +119,6 @@ struct SplitViewAutosave: NSViewRepresentable {
                 if let found = searchSplitView(in: subview) { return found }
             }
             return nil
-        }
-
-        // MARK: NSSplitViewDelegate — enforce minimum widths
-
-        func splitView(_ splitView: NSSplitView, canCollapseSubview subview: NSView) -> Bool {
-            false
-        }
-
-        func splitView(
-            _ splitView: NSSplitView,
-            constrainMinCoordinate proposedMinimumPosition: CGFloat,
-            ofSubviewAt dividerIndex: Int
-        ) -> CGFloat {
-            let mins = minWidths(for: splitView)
-            let thickness = splitView.dividerThickness
-            let totalWidth = splitView.bounds.width
-            let count = splitView.subviews.count
-            guard dividerIndex < count - 1, mins.count == count else { return proposedMinimumPosition }
-
-            // Minimum for this divider = sum of mins up to dividerIndex + thickness * dividerIndex
-            var minPos: CGFloat = 0
-            for idx in 0...dividerIndex {
-                minPos += mins[idx]
-                if idx < dividerIndex { minPos += thickness }
-            }
-            // Also need to include thickness for the divider itself? The
-            // divider's coordinate is its origin, so min is sum of previous pane widths + thicknesses
-            // For divider 0, min = mins[0]
-            // For divider 1, min = mins[0] + thickness + mins[1]
-            // Our loop above already does that if we include thickness for idx < dividerIndex
-            // For divider 0, loop 0...0 => min = mins[0]
-            // For divider 1, loop 0...1 => min = mins[0] + mins[1] + thickness
-            return max(proposedMinimumPosition, minPos)
-        }
-
-        func splitView(
-            _ splitView: NSSplitView,
-            constrainMaxCoordinate proposedMaximumPosition: CGFloat,
-            ofSubviewAt dividerIndex: Int
-        ) -> CGFloat {
-            let mins = minWidths(for: splitView)
-            let thickness = splitView.dividerThickness
-            let totalWidth = splitView.bounds.width
-            let count = splitView.subviews.count
-            guard dividerIndex < count - 1, mins.count == count else { return proposedMaximumPosition }
-
-            // Maximum for this divider = totalWidth - sum of mins after divider - thickness for remaining dividers
-            var remainingMins: CGFloat = 0
-            for idx in (dividerIndex + 1)..<count {
-                remainingMins += mins[idx]
-            }
-            let remainingDividers = count - dividerIndex - 2 // dividers after this one
-            let maxPos = totalWidth - remainingMins - CGFloat(max(0, remainingDividers)) * thickness - thickness
-            // For divider 0 with 3 panes: max = total - mins[1] - mins[2] - 2*thickness
-            // For divider 1 with 3 panes: max = total - mins[2] - thickness
-            // For divider 0 with 2 panes: max = total - mins[1] - thickness
-            return min(proposedMaximumPosition, maxPos)
         }
 
         private func minWidths(for splitView: NSSplitView) -> [CGFloat] {

--- a/Sources/Compose/ComposeStagedDraft.swift
+++ b/Sources/Compose/ComposeStagedDraft.swift
@@ -1,0 +1,31 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+/// M18 staged-draft seams, kept out of `ComposeWindow` so the window
+/// stays under the file-length ceiling and the naming logic stays
+/// testable headless.
+///
+/// Boundary 4 (`AGENTS.md`): the panel is the *only* place an untitled
+/// draft acquires a destination, and it does so on an explicit Save.
+enum ComposeStagedDraft {
+    /// `page-title.md` from the draft's assembled frontmatter; falls back
+    /// to `untitled.md` when the model produced no usable title.
+    static func suggestedFileName(frontmatterPayload: String) -> String {
+        let fields = ComposeFrontmatter.parse(payload: frontmatterPayload)
+        return PostDraftAssembly.slug(fields.title) + ".md"
+    }
+
+    /// The sandbox-safe destination ask for an untitled buffer. Defaults
+    /// to the selected source's content root when one is selected.
+    /// Returns nil when the author cancels — nothing is written then.
+    @MainActor
+    static func runSavePanel(directoryURL: URL?, frontmatterPayload: String) -> URL? {
+        let panel = NSSavePanel()
+        panel.canCreateDirectories = true
+        panel.allowedContentTypes = [.text]
+        panel.directoryURL = directoryURL
+        panel.nameFieldStringValue = suggestedFileName(frontmatterPayload: frontmatterPayload)
+        return panel.runModal() == .OK ? panel.url : nil
+    }
+}

--- a/Sources/Compose/ComposeStatusBar.swift
+++ b/Sources/Compose/ComposeStatusBar.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+/// The compose status bar (#265): word count leads the right-hand
+/// cluster; cursor position, char count, and the coordinator token live
+/// behind a chevron, collapsed by default. Save state is a typed signal
+/// (icon + color), never a substring match. #228's stats stay reachable
+/// in the expanded strip.
+struct ComposeStatusBar: View {
+    let loadError: String?
+    @Bindable var document: ComposeDocument
+    let coordinatorSummary: String
+    let saveSignal: ComposeSaveFlow.Signal?
+    @Binding var showDetailStats: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(spacing: 8) {
+                leftCluster
+                Spacer(minLength: 12)
+                HStack(spacing: 10) {
+                    Text(document.wordCountText)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .layoutPriority(1)
+                        .help("Word count")
+                    if showDetailStats {
+                        detailStats
+                    }
+                    if let signal = saveSignal {
+                        saveSignalView(signal)
+                    }
+                }
+                .accessibilityElement(children: .combine)
+                detailStatsToggle
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+        }
+    }
+
+    @ViewBuilder
+    private var leftCluster: some View {
+        if let loadError {
+            Text(loadError)
+                .font(.caption)
+                .foregroundStyle(.red)
+                .lineLimit(2)
+                .truncationMode(.middle)
+        } else {
+            Text(document.statusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    /// Secondary strip (#265): cursor position, chars/selection, and the
+    /// coordinator token demoted out of the primary bar.
+    private var detailStats: some View {
+        HStack(spacing: 10) {
+            Text(document.cursorText)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .help("Cursor position")
+            Text(document.characterCountText)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .help(document.selectedLength > 0 ? "Selected characters" : "Character count")
+            Text(coordinatorSummary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .help("Save → validate coordinator activity")
+        }
+    }
+
+    /// ✓ Saved in secondary / ✗ + message in red — driven by the outcome
+    /// enum, not text matching.
+    private func saveSignalView(_ signal: ComposeSaveFlow.Signal) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: signal.symbolName)
+                .imageScale(.small)
+            Text(signal.message)
+        }
+        .font(.caption)
+        .foregroundStyle(signal.isError ? Color.red : Color.secondary)
+        .help(signal.isError ? signal.message : "Buffer written to disk")
+        .accessibilityLabel(
+            signal.isError ? "Save failed: \(signal.message)" : "Saved"
+        )
+    }
+
+    private var detailStatsToggle: some View {
+        Button {
+            showDetailStats.toggle()
+        } label: {
+            Image(systemName: showDetailStats ? "chevron.left" : "chevron.right")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 9, height: 9)
+                .padding(3)
+        }
+        .buttonStyle(.borderless)
+        .help(showDetailStats ? "Hide detailed statistics" : "Show detailed statistics")
+        .accessibilityLabel("Detailed statistics")
+        .accessibilityHint("Show or hide cursor position and character counts")
+        .accessibilityAddTraits(showDetailStats ? [.isSelected] : [])
+    }
+}

--- a/Sources/Compose/ComposeWindow.swift
+++ b/Sources/Compose/ComposeWindow.swift
@@ -20,6 +20,9 @@ struct ComposeWindow: View {
     @State private var document = ComposeDocument()
     @State private var currentNoun: WorkspaceNoun?
     @State private var pendingSwitch: WorkspaceNoun?
+    /// M18: a staged draft that arrived while the buffer held unsaved
+    /// work — it waits behind the same discard-confirm as a page switch.
+    @State private var pendingStagedDraft: StagedPostDraft?
     @State private var loadError: String?
     /// #265: typed save signal from `ComposeSaveFlow.run` — no more
     /// string-matching "Saved" in rendered text.
@@ -39,7 +42,7 @@ struct ComposeWindow: View {
 
     var body: some View {
         Group {
-            if let source = selectedLocalSource, pageNoun != nil {
+            if showsEditor {
                 ComposeEditorView(
                     document: document,
                     renderService: OliverRenderService(),
@@ -67,6 +70,18 @@ struct ComposeWindow: View {
         .task(id: store.selection.noun) {
             handleSelection()
         }
+        // M18: accept a staged AI draft (Siri or File menu) into the
+        // untitled buffer. Memory-only until an explicit Save; a dirty
+        // buffer gets the same discard-confirm as a page switch.
+        .task(id: runtime.pendingComposeDraft) {
+            guard let draft = runtime.pendingComposeDraft else { return }
+            runtime.pendingComposeDraft = nil
+            if !document.isDirty {
+                stage(draft)
+            } else {
+                pendingStagedDraft = draft
+            }
+        }
         .task(id: runtime.pendingComposeJump) {
             if let jump = runtime.pendingComposeJump, jump.pageID == pageNoun?.id {
                 if let offset = characterOffset(for: jump.line, column: jump.column, in: document.text) {
@@ -80,8 +95,13 @@ struct ComposeWindow: View {
         .confirmationDialog(
             "Discard unsaved changes?",
             isPresented: Binding(
-                get: { pendingSwitch != nil },
-                set: { if !$0 { pendingSwitch = nil } }
+                get: { pendingSwitch != nil || pendingStagedDraft != nil },
+                set: {
+                    if !$0 {
+                        pendingSwitch = nil
+                        pendingStagedDraft = nil
+                    }
+                }
             ),
             titleVisibility: .visible
         ) {
@@ -89,23 +109,50 @@ struct ComposeWindow: View {
                 if let source = selectedLocalSource, let noun = pendingSwitch {
                     switchTo(noun, source: source)
                 }
+                if let draft = pendingStagedDraft {
+                    stage(draft)
+                }
                 pendingSwitch = nil
+                pendingStagedDraft = nil
             }
             Button("Cancel", role: .cancel) {
                 // Snap the selection back so the compose window keeps the
-                // buffer the author is mid-edit on.
+                // buffer the author is mid-edit on; a discarded staged
+                // draft simply drops (Siri can stage it again).
                 if let noun = currentNoun {
                     store.select(noun: noun)
                 }
                 pendingSwitch = nil
+                pendingStagedDraft = nil
             }
         } message: {
-            Text(currentNoun.map { "“\($0.title)” has unsaved changes." }
-                ?? "The current page has unsaved changes.")
+            Text(discardMessage)
         }
     }
 
+    /// Names what is at stake in the discard dialog: the page being left,
+    /// or the staged draft that would replace the current work.
+    private var discardMessage: String {
+        if let draft = pendingStagedDraft {
+            let title = draft.title.isEmpty ? "an untitled draft" : "“\(draft.title)”"
+            return "The staged draft \(title) replaces your unsaved changes."
+        }
+        return currentNoun.map { "“\($0.title)” has unsaved changes." }
+            ?? "The current page has unsaved changes."
+    }
+
     // MARK: - Selection
+
+    /// The editor shows for a selected page (the M10 rule) or while an
+    /// untitled AI draft is staged / already in the buffer (M18).
+    private var showsEditor: Bool {
+        pageNoun != nil || runtime.pendingComposeDraft != nil || isUntitledDraft
+    }
+
+    /// An unsaved buffer with no backing file — only a staged draft gets here.
+    private var isUntitledDraft: Bool {
+        document.fileURL == nil && !document.text.isEmpty
+    }
 
     private var pageNoun: WorkspaceNoun? {
         guard let noun = store.selection.noun, noun.kind == "page" else { return nil }
@@ -192,8 +239,17 @@ struct ComposeWindow: View {
     /// The single save entry point — toolbar Save, ⌘S, every host verb.
     /// #231: the write happens inside `ComposeSaveFlow`'s tree-write window,
     /// so the preview watch can never observe a partially-written file.
+    /// M18: an untitled draft asks for a destination first; cancelling
+    /// keeps the buffer staged and writes nothing.
     private func save() {
         saveSignal = nil
+        if document.fileURL == nil {
+            guard let destination = ComposeStagedDraft.runSavePanel(
+                directoryURL: selectedLocalSource.map { try? $0.contentRoot() } ?? nil,
+                frontmatterPayload: document.frontmatter?.payloadString ?? ""
+            ) else { return }
+            document.fileURL = destination
+        }
         let outcome = ComposeSaveFlow.run(
             beginTreeWrite: { runtime.coordinator.beginTreeWrite() },
             endTreeWrite: { runtime.coordinator.endTreeWrite() },
@@ -204,6 +260,28 @@ struct ComposeWindow: View {
             outcome: outcome,
             savedMessage: "Saved"
         )
+    }
+
+    // MARK: - Staged AI drafts (M18)
+
+    /// Accept a staged draft into the untitled buffer. Frontmatter comes
+    /// from the repo's canonical closed-key emitter; the buffer starts
+    /// dirty — review is mandatory, saving is explicit.
+    private func stage(_ draft: StagedPostDraft) {
+        document = ComposeDocument(
+            text: PostDraftAssembly.markdown(for: draft),
+            fileURL: nil,
+            language: .markdown
+        )
+        currentNoun = nil
+        loadError = nil
+        saveSignal = nil
+        externalJump = nil
+        if let source = selectedLocalSource, let workspaceRoot = try? source.workspaceRoot() {
+            themeCSS = resolveThemeCSS(workspaceRoot: workspaceRoot)
+        } else {
+            themeCSS = nil
+        }
     }
 
     // MARK: - Chrome
@@ -224,124 +302,12 @@ struct ComposeWindow: View {
         if store.selectedSource == nil {
             return intro
                 + "Add a source first: File → Open… or Settings → Sources "
-                + "(try Stunts/happy), then select a page in the Pages mailbox."
+                + "(try Stunts/happy), then select a page in the Pages mailbox. "
+                + "You can also draft from scratch: File → New Draft with Apple Intelligence…"
         }
         return intro
             + "Select a page in the Pages mailbox, then open it from "
-            + "View → Compose (⌘⇧C), the letter header, or the toolbar."
-    }
-}
-
-/// The compose status bar (#265): word count leads the right-hand
-/// cluster; cursor position, char count, and the coordinator token live
-/// behind a chevron, collapsed by default. Save state is a typed signal
-/// (icon + color), never a substring match. #228's stats stay reachable
-/// in the expanded strip.
-private struct ComposeStatusBar: View {
-    let loadError: String?
-    @Bindable var document: ComposeDocument
-    let coordinatorSummary: String
-    let saveSignal: ComposeSaveFlow.Signal?
-    @Binding var showDetailStats: Bool
-
-    /// #265: word count leads the right-hand cluster; cursor position, char
-    /// count, and the coordinator token live behind a chevron, collapsed by
-    /// default. Save state is a typed signal (icon + color), never a
-    /// substring match. #228's stats stay reachable in the expanded strip.
-    var body: some View {
-        VStack(spacing: 0) {
-            Divider()
-            HStack(spacing: 8) {
-                leftCluster
-                Spacer(minLength: 12)
-                HStack(spacing: 10) {
-                    Text(document.wordCountText)
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.secondary)
-                        .layoutPriority(1)
-                        .help("Word count")
-                    if showDetailStats {
-                        detailStats
-                    }
-                    if let signal = saveSignal {
-                        saveSignalView(signal)
-                    }
-                }
-                .accessibilityElement(children: .combine)
-                detailStatsToggle
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-        }
-    }
-
-    @ViewBuilder
-    private var leftCluster: some View {
-        if let loadError {
-            Text(loadError)
-                .font(.caption)
-                .foregroundStyle(.red)
-                .lineLimit(2)
-                .truncationMode(.middle)
-        } else {
-            Text(document.statusText)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-        }
-    }
-
-    /// Secondary strip (#265): cursor position, chars/selection, and the
-    /// coordinator token demoted out of the primary bar.
-    private var detailStats: some View {
-        HStack(spacing: 10) {
-            Text(document.cursorText)
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
-                .help("Cursor position")
-            Text(document.characterCountText)
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
-                .help(document.selectedLength > 0 ? "Selected characters" : "Character count")
-            Text(coordinatorSummary)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .help("Save → validate coordinator activity")
-        }
-    }
-
-    /// ✓ Saved in secondary / ✗ + message in red — driven by the outcome
-    /// enum, not text matching.
-    private func saveSignalView(_ signal: ComposeSaveFlow.Signal) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: signal.symbolName)
-                .imageScale(.small)
-            Text(signal.message)
-        }
-        .font(.caption)
-        .foregroundStyle(signal.isError ? Color.red : Color.secondary)
-        .help(signal.isError ? signal.message : "Buffer written to disk")
-        .accessibilityLabel(
-            signal.isError ? "Save failed: \(signal.message)" : "Saved"
-        )
-    }
-
-    private var detailStatsToggle: some View {
-        Button {
-            showDetailStats.toggle()
-        } label: {
-            Image(systemName: showDetailStats ? "chevron.left" : "chevron.right")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 9, height: 9)
-                .padding(3)
-        }
-        .buttonStyle(.borderless)
-        .help(showDetailStats ? "Hide detailed statistics" : "Show detailed statistics")
-        .accessibilityLabel("Detailed statistics")
-        .accessibilityHint("Show or hide cursor position and character counts")
-        .accessibilityAddTraits(showDetailStats ? [.isSelected] : [])
+            + "View → Compose (⌘⇧C), the letter header, or the toolbar. "
+            + "Or start fresh: File → New Draft with Apple Intelligence…"
     }
 }

--- a/Sources/Intents/DraftPostIntent.swift
+++ b/Sources/Intents/DraftPostIntent.swift
@@ -1,0 +1,134 @@
+import AppIntents
+import AppKit
+import CoreLocation
+import Foundation
+
+/// Siri / Shortcuts / Spotlight: “Create an entry in Solipsist …”.
+///
+/// Adopts the journal-domain `createEntry` schema so Apple Intelligence
+/// routes entry-creation requests here. Foreground-only: the staged
+/// draft must be visible for review before anything reaches disk.
+///
+/// Semantics against the schema contract:
+/// - `message` is the *topic seed*, expanded by the on-device model;
+///   dictated filler is cleaned up without changing meaning.
+/// - `title`, when spoken, wins over the model-generated headline.
+/// - `entryDate` / `location` / `mediaItems` are accepted because the
+///   schema names them; staging is text-only, so they are not consumed
+///   (files would need an explicit save path — boundary 4).
+///
+/// The model writes *content*, never Boris semantics; nothing touches
+/// the content tree until the author saves in Compose.
+@AppIntent(schema: .journal.createEntry)
+struct DraftPostIntent: AppIntent {
+    static let title: LocalizedStringResource = "Draft Post"
+    static let description = IntentDescription(
+        "Drafts a post with Apple Intelligence and opens it in Solipsist’s compose window."
+    )
+    static var supportedModes: IntentModes { [.foreground] }
+
+    /// Named `message`: that is what the schema expects for entry text.
+    @Parameter(
+        title: "Topic",
+        requestValueDialog: "What should the post be about?"
+    )
+    var message: AttributedString
+
+    @Parameter(title: "Title")
+    var title: String?
+
+    @Parameter(title: "Entry Date")
+    var entryDate: Date?
+
+    @Parameter(title: "Location")
+    var location: CLPlacemark?
+
+    @Parameter(title: "Media Items", default: [])
+    var mediaItems: [IntentFile]
+
+    @MainActor
+    func perform() async throws -> some ReturnsValue<StagedDraftEntity> & ProvidesDialog {
+        let topic = String(message.characters).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !topic.isEmpty else {
+            return .result(
+                value: StagedDraftEntity(topic: message, title: ""),
+                dialog: "Give me a topic and I’ll draft the post."
+            )
+        }
+        var draft = try await PostDraftEngine.draft(topic: topic, origin: .siri)
+        if let spoken = title?.trimmingCharacters(in: .whitespacesAndNewlines), !spoken.isEmpty {
+            draft.title = spoken
+        }
+        DraftRouter.shared.deliver(draft)
+        NSApp.activate(ignoringOtherApps: true)
+        return .result(
+            value: StagedDraftEntity(topic: message, title: draft.title),
+            dialog: "Draft “\(draft.title)” is waiting in Compose for your save."
+        )
+    }
+
+    /// The File-menu path performs the same action by hand; donating it
+    /// teaches suggestions. Donation failures are advisory by nature and
+    /// must not spam alerts over the staged-draft success dialog.
+    @MainActor
+    func donateQuietly() {
+        Task {
+            _ = try? donate()
+        }
+    }
+}
+
+/// Lightweight stand-in for the schema’s journal entry: the staged
+/// draft while it waits in Compose. Carries the schema’s expected
+/// properties so the metadata export can verify the shape; only the
+/// text fields are ever populated. Drafts are transient by design
+/// (memory-only until an explicit save), so the query resolves nothing
+/// after the fact — there is no addressable store to lie about.
+@AppEntity(schema: .journal.entry)
+struct StagedDraftEntity: AppEntity {
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Draft")
+    static let defaultQuery = StagedDraftQuery()
+
+    var id: UUID
+    var message: AttributedString?
+    var title: String?
+    var entryDate: Date?
+    var location: CLPlacemark?
+    var mediaItems: [IntentFile]
+
+    init(topic: AttributedString, title: String) {
+        self.id = UUID()
+        self.message = topic
+        self.title = title.isEmpty ? nil : title
+        self.entryDate = nil
+        self.location = nil
+        self.mediaItems = []
+    }
+
+    var displayRepresentation: DisplayRepresentation {
+        let name = title ?? "Untitled draft"
+        return DisplayRepresentation(title: LocalizedStringResource(stringLiteral: name))
+    }
+}
+
+struct StagedDraftQuery: EntityQuery {
+    func entities(for identifiers: [UUID]) async throws -> [StagedDraftEntity] {
+        []
+    }
+}
+
+struct SolipsistShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: DraftPostIntent(),
+            phrases: [
+                "Draft a post in \(.applicationName)",
+                "Draft a post with \(.applicationName)",
+                "\(.applicationName) draft post",
+                "Create an entry in \(.applicationName)",
+            ],
+            shortTitle: "Draft Post",
+            systemImageName: "square.and.pencil"
+        )
+    }
+}

--- a/Sources/Intents/DraftRouter.swift
+++ b/Sources/Intents/DraftRouter.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// The App Intent → app handoff. Siri (or the File menu) produces a
+/// `StagedPostDraft` before the compose window exists, so delivery is
+/// queued here and flushed when `MainWindow` registers the opener.
+///
+/// Same shape as `AppDelegate.openFolder`'s deferred-delivery pattern:
+/// a MainActor singleton, a pending queue for cold launches, one
+/// consumer closure. Nothing here knows about SwiftUI or windows.
+@MainActor
+final class DraftRouter {
+    static let shared = DraftRouter()
+
+    var consume: ((StagedPostDraft) -> Void)?
+    private var pending: [StagedPostDraft] = []
+
+    /// Producers call this: Siri's `perform()`, the menu prompt.
+    func deliver(_ draft: StagedPostDraft) {
+        if let consume {
+            consume(draft)
+        } else {
+            pending.append(draft)
+        }
+    }
+
+    /// The app side registers its opener once the window group is alive.
+    func register(consumer: @escaping (StagedPostDraft) -> Void) {
+        consume = consumer
+        let queued = pending
+        pending.removeAll()
+        queued.forEach(consumer)
+    }
+
+    /// Test seam: drop everything.
+    func reset() {
+        consume = nil
+        pending.removeAll()
+    }
+}

--- a/Sources/Intents/PostDraftEngine.swift
+++ b/Sources/Intents/PostDraftEngine.swift
@@ -1,0 +1,125 @@
+import Foundation
+import FoundationModels
+
+/// The on-device drafting engine. One job: topic → structured post draft.
+///
+/// Boundaries honored here:
+/// - The model writes *content*, never Boris semantics. It returns a
+///   closed-schema frontmatter candidate plus markdown; assembly and any
+///   write stay in `StagedPostDraft` / compose's explicit save.
+/// - Unavailability is surfaced, never swallowed (boundary 3): every
+///   failure mode is a typed error the caller shows.
+enum PostDraftEngine {
+    /// Mirror of `SystemLanguageModel.Availability.UnavailableReason` so
+    /// callers (and tests) can read a reason without touching the model.
+    enum Unavailability: Equatable, Sendable {
+        case deviceNotEligible
+        case appleIntelligenceNotEnabled
+        case modelNotReady
+        /// Future/unknown reasons from a newer OS.
+        case modelUnavailable
+
+        var message: String {
+            switch self {
+            case .deviceNotEligible:
+                return "This Mac doesn’t support Apple Intelligence."
+            case .appleIntelligenceNotEnabled:
+                return "Apple Intelligence is off. Turn it on in System Settings to draft posts."
+            case .modelNotReady:
+                return "The on-device model isn’t ready yet. Try again shortly."
+            case .modelUnavailable:
+                return "Apple Intelligence isn’t available right now."
+            }
+        }
+    }
+
+    enum EngineError: LocalizedError, Equatable {
+        case unavailable(Unavailability)
+        case emptyResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable(let reason):
+                return reason.message
+            case .emptyResponse:
+                return "The model returned an empty draft. Try rephrasing the topic."
+            }
+        }
+
+        static func from(_ availability: SystemLanguageModel.Availability) -> EngineError? {
+            switch availability {
+            case .available:
+                return nil
+            case .unavailable(.deviceNotEligible):
+                return .unavailable(.deviceNotEligible)
+            case .unavailable(.appleIntelligenceNotEnabled):
+                return .unavailable(.appleIntelligenceNotEnabled)
+            case .unavailable(.modelNotReady):
+                return .unavailable(.modelNotReady)
+            case .unavailable:
+                // A reason this OS build doesn't name yet — still surfaced.
+                return .unavailable(.modelUnavailable)
+            }
+        }
+    }
+
+    /// The guided-generation schema. Field guides keep the model inside
+    /// the shapes compose can actually use: short title, 1–5 tags, body
+    /// that is markdown paragraphs (no frontmatter — we emit that).
+    @Generable
+    struct GeneratedDraft {
+        @Guide(description: "A headline for the post, at most ten words.")
+        var title: String
+        @Guide(description: "One-sentence summary of what the post says.")
+        var summary: String
+        @Guide(description: "Between one and five lowercase topical tags.")
+        var tags: [String]
+        @Guide(description: "The post body in Markdown: short paragraphs, optional headings and lists. No YAML frontmatter.")
+        var body: String
+    }
+
+    static func instructions(origin: StagedPostDraft.Origin) -> String {
+        let voiceNote = origin == .siri
+            ? " The topic may have been dictated by voice: clean up filler without changing meaning."
+            : ""
+        return """
+        You draft posts for a personal publication compiled by Boris. \
+        The author gives a topic; return a headline, a one-sentence \
+        summary, 1–5 lowercase topical tags, and a Markdown body of short \
+        paragraphs. Never include YAML frontmatter in the body.\(voiceNote)
+        """
+    }
+
+    static func prompt(topic: String) -> String {
+        """
+        Draft a post about: \(topic)
+        """
+    }
+
+    /// Topic → staged draft. Throws typed errors; never returns partials.
+    static func draft(topic: String, origin: StagedPostDraft.Origin) async throws -> StagedPostDraft {
+        if let unavailable = EngineError.from(SystemLanguageModel.default.availability) {
+            throw unavailable
+        }
+        let session = LanguageModelSession(
+            model: SystemLanguageModel.default,
+            instructions: instructions(origin: origin)
+        )
+        let response = try await session.respond(
+            to: prompt(topic: topic),
+            generating: GeneratedDraft.self
+        )
+        let generated = response.content
+        let staged = StagedPostDraft(
+            title: generated.title,
+            summary: generated.summary,
+            tags: generated.tags,
+            body: generated.body,
+            origin: origin
+        )
+        guard !staged.title.isEmpty || !staged.body.isEmpty else {
+            throw EngineError.emptyResponse
+        }
+        return staged
+    }
+}

--- a/Sources/Intents/PostDraftPrompt.swift
+++ b/Sources/Intents/PostDraftPrompt.swift
@@ -1,0 +1,44 @@
+import AppKit
+
+/// The File-menu face of M18: ask for a topic, draft with the on-device
+/// model, stage the result in compose. Same pipeline as the Siri intent,
+/// different front door (menus first).
+@MainActor
+enum PostDraftPrompt {
+    static func runAndStage() {
+        guard let topic = requestTopic() else { return }
+        Task {
+            do {
+                let draft = try await PostDraftEngine.draft(topic: topic, origin: .menu)
+                DraftRouter.shared.deliver(draft)
+                // Same action as the Siri intent, performed by hand:
+                // donate so suggestions reflect real usage.
+                DraftPostIntent().donateQuietly()
+            } catch {
+                // Unavailability and model failures are surfaced, never
+                // swallowed (boundary 3).
+                presentFailure(error)
+            }
+        }
+    }
+
+    /// Modal topic prompt. Cancel/Escape returns nil and nothing runs.
+    private static func requestTopic() -> String? {
+        let alert = NSAlert()
+        alert.messageText = "New Draft with Apple Intelligence"
+        alert.informativeText = "What should the post be about?"
+        alert.addButton(withTitle: "Draft")
+        alert.addButton(withTitle: "Cancel")
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        field.placeholderString = "Topic"
+        alert.accessoryView = field
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return nil }
+        return field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func presentFailure(_ error: Error) {
+        let alert = NSAlert(error: error)
+        alert.runModal()
+    }
+}

--- a/Sources/Intents/StagedPostDraft.swift
+++ b/Sources/Intents/StagedPostDraft.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// A finished AI draft, staged for review in the compose buffer. Plain
+/// data on purpose: it crosses the App Intent → app handoff and the
+/// engine seam, and it never touches disk by itself.
+///
+/// Boundary 4 (`AGENTS.md`): staging is memory-only. The buffer becomes
+/// a file only through compose's explicit Save, which routes through the
+/// same `ComposeSaveFlow` tree-write window as every other save.
+struct StagedPostDraft: Equatable, Sendable {
+    var title: String
+    var summary: String
+    var tags: [String]
+    /// Markdown body. No frontmatter — assembly adds that canonically.
+    var body: String
+    var origin: Origin
+
+    enum Origin: String, Equatable, Sendable {
+        case siri
+        case menu
+    }
+
+    init(title: String, summary: String = "", tags: [String] = [], body: String, origin: Origin) {
+        self.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.summary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.tags = tags.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
+        self.body = body
+        self.origin = origin
+    }
+}
+
+enum PostDraftAssembly {
+    /// File-name stem for an untitled draft: `title` → `my-post-title`.
+    /// Punctuation runs become separators; falls back to `"untitled"`
+    /// when nothing survives slugification.
+    static func slug(_ title: String) -> String {
+        var mapped = String.UnicodeScalarView()
+        for scalar in title.lowercased().unicodeScalars {
+            mapped.append(CharacterSet.alphanumerics.contains(scalar) ? scalar : " ")
+        }
+        let cleaned = String(mapped)
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        let capped = String(cleaned.prefix(80))
+        return capped.isEmpty ? "untitled" : String(capped.drop(while: { $0 == "-" }))
+    }
+
+    /// The staged draft as compose-buffer text: canonical frontmatter
+    /// (closed keys only, emitted by `ComposeFrontmatter.apply`) followed
+    /// by the body. We never invent keys — absence == null per schema —
+    /// so `parent`/`status`/`id` are left to the author's front-matter pane.
+    static func markdown(for draft: StagedPostDraft) -> String {
+        var fields = ComposeFrontmatter.Fields.empty
+        fields.title = draft.title
+        fields.summary = draft.summary
+        fields.tags = draft.tags
+        let payload = ComposeFrontmatter.apply(fields, to: "")
+        guard !payload.isEmpty else {
+            return draft.body
+        }
+        return "---\n\(payload)\n---\n\n\(draft.body)\n"
+    }
+}

--- a/Tests/ContractTests/PostDraftTests.swift
+++ b/Tests/ContractTests/PostDraftTests.swift
@@ -1,0 +1,156 @@
+import FoundationModels
+import XCTest
+
+/// M18 — Siri drafts: shaping, handoff, and unavailability mapping.
+/// The model call itself is not unit-testable headless; everything the
+/// model's output flows through is.
+final class PostDraftTests: XCTestCase {
+    // MARK: - Slug
+
+    func testSlugLowercasesAndDashes() {
+        XCTAssertEqual(PostDraftAssembly.slug("My Post Title"), "my-post-title")
+        XCTAssertEqual(PostDraftAssembly.slug("  Spaced   Out  "), "spaced-out")
+    }
+
+    func testSlugDropsPunctuationButKeepsUnicodeLetters() {
+        XCTAssertEqual(PostDraftAssembly.slug("Hello, World! (Again)"), "hello-world-again")
+        XCTAssertEqual(PostDraftAssembly.slug("Über-Cool Æther"), "über-cool-æther")
+    }
+
+    func testSlugFallsBackToUntitled() {
+        XCTAssertEqual(PostDraftAssembly.slug(""), "untitled")
+        XCTAssertEqual(PostDraftAssembly.slug("!!! ???"), "untitled")
+    }
+
+    func testSlugIsCapped() {
+        let long = String(repeating: "word ", count: 40)
+        XCTAssertLessThanOrEqual(PostDraftAssembly.slug(long).count, 80)
+    }
+
+    // MARK: - Assembly
+
+    private var sample = StagedPostDraft(
+        title: "Field Notes",
+        summary: "What the trip taught me.",
+        tags: ["travel", "notes"],
+        body: "First paragraph.\n\nSecond paragraph.",
+        origin: .siri
+    )
+
+    @MainActor
+    func testAssembledMarkdownCarriesClosedKeysOnly() throws {
+        let text = PostDraftAssembly.markdown(for: sample)
+        XCTAssertTrue(text.hasPrefix("---\n"))
+        XCTAssertTrue(text.contains("title: Field Notes"))
+        XCTAssertTrue(text.contains("summary: What the trip taught me."))
+        XCTAssertTrue(text.contains("tags:\n  - travel\n  - notes"))
+
+        // No invented keys: id / parent / status stay absent.
+        let payload = try XCTUnwrap(ComposeDocument(text: text).frontmatter).payloadString
+        for key in ["id:", "parent:", "status:", "published_at:", "servings:", "relations:"] {
+            XCTAssertFalse(payload.contains(key), "assembly must not emit \(key)")
+        }
+    }
+
+    @MainActor
+    func testAssembledFrontmatterParsesBackThroughTheCanonicalReader() throws {
+        let text = PostDraftAssembly.markdown(for: sample)
+        let frontmatter = try XCTUnwrap(ComposeDocument(text: text).frontmatter)
+        let fields = ComposeFrontmatter.parse(payload: frontmatter.payloadString)
+        XCTAssertEqual(fields.title, "Field Notes")
+        XCTAssertEqual(fields.summary, "What the trip taught me.")
+        XCTAssertEqual(fields.tags, ["travel", "notes"])
+        XCTAssertEqual(frontmatter.kind, .yaml)
+    }
+
+    func testBodySurvivesAfterFrontmatter() {
+        let text = PostDraftAssembly.markdown(for: sample)
+        XCTAssertTrue(text.hasSuffix("First paragraph.\n\nSecond paragraph.\n"))
+    }
+
+    func testEmptyMetadataYieldsBareBody() {
+        let bare = StagedPostDraft(title: "", summary: "", tags: [], body: "Just words.", origin: .menu)
+        XCTAssertEqual(PostDraftAssembly.markdown(for: bare), "Just words.")
+    }
+
+    func testStagedDraftTrimsMetadata() {
+        let draft = StagedPostDraft(
+            title: "  T  ", summary: "\n s \n", tags: [" a ", "", "b"],
+            body: "b", origin: .menu
+        )
+        XCTAssertEqual(draft.title, "T")
+        XCTAssertEqual(draft.summary, "s")
+        XCTAssertEqual(draft.tags, ["a", "b"])
+    }
+
+    // MARK: - Save-panel naming
+
+    @MainActor
+    func testSuggestedFileNameSlugsTheDraftTitle() {
+        XCTAssertEqual(
+            ComposeStagedDraft.suggestedFileName(
+                frontmatterPayload: "title: Field Notes\nsummary: s\ntags:\n  - travel"
+            ),
+            "field-notes.md"
+        )
+        XCTAssertEqual(
+            ComposeStagedDraft.suggestedFileName(frontmatterPayload: ""),
+            "untitled.md"
+        )
+    }
+
+    // MARK: - Router handoff
+
+    @MainActor
+    func testRouterQueuesUntilConsumerRegisters() {
+        let router = DraftRouter()
+        let staged = sample
+        router.deliver(staged)
+        var received: [StagedPostDraft] = []
+        router.register { received.append($0) }
+        XCTAssertEqual(received, [staged])
+
+        router.deliver(sample)
+        XCTAssertEqual(received, [staged, sample])
+        router.reset()
+    }
+
+    @MainActor
+    func testRouterDeliversInOrderWhenRegistered() {
+        let router = DraftRouter()
+        var received: [StagedPostDraft] = []
+        router.register { received.append($0) }
+        router.deliver(sample)
+        router.deliver(StagedPostDraft(title: "x", body: "y", origin: .menu))
+        XCTAssertEqual(received.count, 2)
+        XCTAssertEqual(received.first?.origin, .siri)
+        XCTAssertEqual(received.last?.origin, .menu)
+        router.reset()
+    }
+
+    // MARK: - Unavailability mapping
+
+    func testAvailabilityMappingSurfacesEveryReason() {
+        XCTAssertNil(PostDraftEngine.EngineError.from(.available))
+        XCTAssertEqual(
+            PostDraftEngine.EngineError.from(.unavailable(.deviceNotEligible)),
+            .unavailable(.deviceNotEligible)
+        )
+        XCTAssertEqual(
+            PostDraftEngine.EngineError.from(.unavailable(.appleIntelligenceNotEnabled)),
+            .unavailable(.appleIntelligenceNotEnabled)
+        )
+        XCTAssertEqual(
+            PostDraftEngine.EngineError.from(.unavailable(.modelNotReady)),
+            .unavailable(.modelNotReady)
+        )
+        // Every error carries human-readable copy — never swallowed.
+        for reason in [
+            PostDraftEngine.Unavailability.deviceNotEligible,
+            .appleIntelligenceNotEnabled,
+            .modelNotReady,
+        ] {
+            XCTAssertFalse(reason.message.isEmpty)
+        }
+    }
+}

--- a/docs/cards/M18-siri-drafts.md
+++ b/docs/cards/M18-siri-drafts.md
@@ -1,0 +1,54 @@
+# Card — Siri drafts posts (App Intents + Foundation Models)
+
+**Milestone:** M18 · **Lane:** `Sources/Intents/` (+ compose save seam).
+macOS 27 only: deployment target moves to 27.0 in the same PR.
+
+The new Siri speaks App Intents — SiriKit is dead, so an intent is the
+only door. The on-device model drafts; **compose stays the review
+surface**; nothing touches the content tree until an explicit ⌘S.
+
+## Owns
+
+- `Sources/Intents/StagedPostDraft.swift` — plain staged data + slug +
+  canonical frontmatter assembly (`ComposeFrontmatter.apply`)
+- `Sources/Intents/DraftRouter.swift` — deferred-delivery handoff
+  (same pattern as `AppDelegate.openFolder`)
+- `Sources/Intents/PostDraftEngine.swift` — FoundationModels session,
+  guided generation, typed unavailability errors
+- `Sources/Intents/DraftPostIntent.swift` — `DraftPostIntent` +
+  `AppShortcutsProvider` (“Draft a post in Solipsist …”); adopts the
+  journal-domain **`createEntry` schema** (`@AppIntent(schema:)`) so
+  Apple Intelligence routes entry requests here; `supportedModes =
+  [.foreground]` (openAppWhenRun is deprecated since macOS 26); the
+  File-menu path donates via `donateQuietly()` so suggestions track
+  real usage
+- `StagedDraftEntity` / `StagedDraftQuery` — the schema-required
+  journal entity; transient by design, resolves nothing after the fact
+- `Sources/Intents/PostDraftPrompt.swift` — File-menu topic prompt
+- File verb in `Commands.swift`; compose staged-draft mode + save panel
+
+## Boundaries honored
+
+1. **No boris repo touch, no semantics reimplemented** — frontmatter is
+   emitted through the repo's own closed-key emitter; `id` / `parent` /
+   `status` are left absent for the author's front-matter pane.
+2. **Boundary 4** — staging is memory-only; Save routes through
+   `ComposeSaveFlow` exactly like every other write.
+3. **Boundary 3** — model unavailable / failed = alert, never silent.
+4. Subprocess boundary untouched; the model call is not a Boris verb.
+
+## Do not
+
+- Let Siri write files directly (no autosave path)
+- Invent frontmatter keys or graph semantics to make drafting easier
+- Put an HTTP model client in the app (on-device model only)
+- Grow `MainWindow` for this
+
+## Gate
+
+“Hey Siri, draft a post in Solipsist about …” → Solipsist comes
+forward, Compose shows an untitled buffer with assembled frontmatter,
+status bar says *edited*; ⌘S asks where to save; cancel keeps the
+staged buffer. Same flow from `File → New Draft with Apple
+Intelligence…`. Apple Intelligence off → alert names it.
+`SKIP_EMBED_BORIS=1 make build` + `make test` green.

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -158,6 +158,18 @@ entry). Do not pick.
 | [M17-2 PR mailbox](M17-pr-mailbox.md) | #192 | ✅ |
 | [M17-3 Authoring entry](M17-pr-authoring.md) | #192 | ✅ |
 
+## M18 — Siri drafts posts (pickable)
+
+The new Siri speaks App Intents only; the on-device FoundationModels
+session drafts. Compose stays the review surface; nothing touches the
+content tree until an explicit ⌘S. macOS-27-only: deployment target
+moves to 27.0 in the same PR.
+
+| Card | Issue | Lane | Gate |
+|------|-------|------|------|
+| [Siri drafts posts](M18-siri-drafts.md) | — (file on pick) | `Sources/Intents/` + compose save seam | “Draft a post in Solipsist …” stages an untitled buffer; ⌘S asks where; Apple Intelligence off surfaces an alert |
+
+
 ## Editor accessibility — milestone 10 polish (pickable)
 
 VoiceOver across the editor surfaces, cut into five disjoint lanes from

--- a/docs/help.md
+++ b/docs/help.md
@@ -37,6 +37,7 @@ Every menu verb and keyboard shortcut:
 | New Project… | `⌘N` | Initialize a new Boris project in a folder (`boris init`) and add it as a source. |
 | Open… | `⌘O` | Open a Boris publication folder as a source. Same store as Settings → Sources. |
 | Clone Repository… | — | Clone a git URL into a chosen folder and add the result as a Local source. Also in Settings → Sources. |
+| New Draft with Apple Intelligence… | — | Ask for a topic, draft title / summary / tags / body with the on-device model, and stage the result as an untitled buffer in Compose. Nothing is written until you Save (⌘S), which asks where to put the file. Requires Apple Intelligence; failures surface as an alert. Also from Siri (typed or voice): “Draft a post in Solipsist about …” or “Create an entry in Solipsist …”. |
 | Open Recent | — | Re-open a folder from the system recent-documents list. Shows No Recent Folders when empty. Clear Menu wipes the list. |
 | Relocate Source… | — | Point an unreachable source at its new folder (enabled when the selected source is stale). Also in Settings → Sources. |
 | Remove Source | — | Remove the currently selected source from the workspace (enabled when a source is selected). Also in Settings → Sources. |
@@ -105,5 +106,6 @@ The sidebar also carries a **Filter folders** search field: it narrows trunk fol
 - **Preview Companion (`⌘⇧P`)**: Live preview of the full site, powered by Boris engine A1 `--watch-json` / `serve-started` stream with loopback URL validation and Server-Sent Events (SSE `event: reload`). The reading pane reuses this same watch stream for the selected page without starting a duplicate subprocess.
 - **Editor Companion (`⌘⇧E`)**: Token-isolated companion host for `boris-editor`. File → Edit Page opens it against the selected page with `open=` parameter targeting the page's source path.
 - **Compose Window (`⌘⇧C`)**: Native compose surface for the selected page's source file — Markdown / Textile / Cooklang editing with heuristic highlighting, an Oliver-rendered preview split (live, debounced; Render Options mirror Oliver's `ParseOptions` — wikilinks, callouts, smart typography, footnotes, task lists, frontmatter policy, raw-HTML policy, XHTML profile), and save-triggered validate through the coordinator. The renderer binary is located via `SOLIPSIST_OLIVER_BIN` → app bundle → sibling of `boris` → dev checkouts. Language is auto-detected from the file; the picker overrides it per session.
+- **Staged drafts**: A draft from Siri or `File → New Draft with Apple Intelligence…` opens Compose as an untitled buffer with canonical frontmatter (title / summary / tags only — trunk and status stay yours to set in the front-matter pane). The buffer is memory-only until an explicit Save; ⌘S asks for a destination inside your publication.
 
 For architecture and roadmap details, see [ROADMAP.md](https://github.com/drawmeanelephant/solipsist/blob/main/docs/ROADMAP.md).

--- a/scripts/embed-boris.sh
+++ b/scripts/embed-boris.sh
@@ -109,11 +109,14 @@ bundle_and_sign() {
   fi
 
   # Embed companion binaries (boris-editor, boris-package, boris-source-rag,
-  # boris-content-audit) from kit bin dirs when available.
+  # boris-content-audit) from kit bin dirs when available. A source-built
+  # checkout (the documented reproduction path) produces some of them in
+  # its zig-out — same trust level as the engine we already take there.
   local comp_candidates=(
     "$SRCROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin"
     "$SRCROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/bin"
     "$SRCROOT/../boris-agent-kit/bin"
+    "${BORIS_REPO_DIR:-$SRCROOT/../boris}/zig-out/bin"
   )
   local search_index_found=0
   for cdir in "${comp_candidates[@]}"; do


### PR DESCRIPTION
Closes the [M18 card](docs/cards/M18-siri-drafts.md). Tracker issue to follow.

## What shipped

**Siri / Shortcuts / File menu draft posts.** `DraftPostIntent` adopts the journal-domain `createEntry` schema (`@AppIntent(schema: .journal.createEntry)` + schema-shaped `StagedDraftEntity`) so Apple Intelligence routes "create an entry in Solipsist…" requests here; phrases also cover "Draft a post in Solipsist…". The on-device FoundationModels session (`LanguageModelSession` + guided generation) expands a topic into title/summary/tags/markdown body and stages it as an **untitled buffer** in Compose. Same pipeline from **File → New Draft with Apple Intelligence…** (menus first); the menu path donates so suggestions track real usage.

**Boundaries honored**
- Boundary 4: staging is memory-only; ⌘S asks for a destination (`ComposeStagedDraft.runSavePanel`, defaults to the source's content root), cancel writes nothing. A draft arriving over a dirty buffer gets the existing discard-confirm.
- No invented Boris semantics: frontmatter emitted via the repo's canonical closed-key emitter — title/summary/tags only; id/parent/status stay with the author's front-matter pane.
- Boundary 3: model unavailable / failed = typed alert copy, never swallowed.

**macOS 27 only**: deployment target 26.0 → 27.0. Probed: FoundationModels needs no extra entitlement locally under ad-hoc signing; App Store distribution will want `com.apple.developer.foundation-model-access` (#110 territory).

## Crash fix included

b6's AppKit hard-asserts `'A SplitView managed by a SplitViewController cannot have its delegate modified'` — our compose split-view helper stole SwiftUI's backing delegate for min-width enforcement since M10. Reproduced live from the unified log; fixed by enforcing the same minimums (230/280/240) with per-pane width constraints instead of delegate callbacks. Verified against the exact kill path.

## Build hygiene en route

- `make install-app`: installs to `/Applications` (Siri/Spotlight only register intents for indexed apps), deletes the product *before* building so newly-embedded binaries can't land outside the code signature, keeps `/Applications` the single indexed candidate for the bundle id.
- `embed-boris.sh`: takes companion tools from a source-built `zig-out` (the documented kit-reproduction path), not just kit dirs.

## Verification

- `SKIP_EMBED_BORIS=1 make build` ✅ · `make test` **518 tests / 0 failures** ✅ · lint 0 violations ✅
- Live on Xcode 27b6 (27A5252f): exported `Metadata.appintents` shows `journal / CreateJournalEntryIntent v1.0.0` + AssistantIntent protocol; app launches from `/Applications`, engine verbs live (`boris/0.8.1 · exit 0`), Compose crash path clean
- 14 new unit tests: slug/assembly round-trips through `ComposeFrontmatter.parse`, no-invented-keys assertion, router handoff ordering, unavailability mapping, save-panel naming

## Not this PR

Re-pinning boris to main (`ef23e37`): local dev runs it, but the vendor manifest/ROADMAP baseline still documents `bf464a0` — that update changes every decoded contract surface and should be its own card.