### PR TITLE
docs: sync status to reality — M18 landed, #110/#111 closed, tracker empty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,5 +75,12 @@ Settings / File clone verb, sandbox-safe git)
 #144/#145/#146)
 · **M14** watch contract ✅
 ([#143](https://github.com/drawmeanelephant/solipsist/issues/143) —
-#147/#148).
-Remaining ship is Apple-account only (#110 / #111).
+#147/#148) · **M15** GitHub source ✅ (#179, PRs #180–#184) ·
+**M16** write the remote ✅ (#185, PRs #187–#190) · **M17** Pull
+Requests mailbox ✅ (#192, PRs #194–#196) · **M18** Siri drafts ✅
+(PR [#294](https://github.com/drawmeanelephant/solipsist/pull/294) —
+App Intents + on-device FoundationModels, macOS 27).
+The milestone-10 editor polish batch (#225–#238) and the
+accessibility tracker (#236 + children #239–#243) are merged.
+The Apple-account ship blockers #110 / #111 are closed. The
+tracker is empty.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -340,11 +340,11 @@ mailbox sidebar, reading place, drawer, Preview / Editor companions,
 Compose window. Help and first-run / empty-state copy match that
 window.
 
-Do not expand Apple-account ship
+The Apple-account ship blockers
 ([#110](https://github.com/drawmeanelephant/solipsist/issues/110),
 [#111](https://github.com/drawmeanelephant/solipsist/issues/111))
-into this chrome. #78 is closed. Next product lanes: M12 clone
-(`Sources/Workspace/Git/` + Settings), M13 graph folders
-(sidebar + `Play/Local/` filter), M14 watch contract (`Engine/`
-`WatchServer` then the reading pane). Paths in [`ROADMAP.md`](ROADMAP.md)
-§5 / [`cards/README.md`](cards/README.md).
+are closed. M12 clone, M13 graph folders, M14 watch contract, M15–M17,
+and M18 (Siri drafts, macOS 27) all landed. The milestone-10 editor
+polish batch (#225–#238) and the accessibility tracker (#236 +
+children #239–#243) are merged. The tracker is empty. Paths for any
+next-layer work in [`ROADMAP.md`](ROADMAP.md) §3 / §5 / [`cards/README.md`](cards/README.md).

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -74,11 +74,13 @@ compiler repo. Solipsist is the complementary **native desktop citizen**:
   `recipe-scale`, ship pipeline (#78), Mail body
   ([#98](https://github.com/drawmeanelephant/solipsist/issues/98) —
   Settings, mailboxes, reading, compose #106), prove (#123).
-  Remaining **ship** is Apple-account only (#110 / #111).
-  Next **product cut:** M12 clone
-  ([#131](https://github.com/drawmeanelephant/solipsist/issues/131)).
-  Then M13 graph folders and M14 watch contract. Sequence:
-  [ROADMAP.md](ROADMAP.md) §8.
+  The Apple-account **ship** blockers (#110 / #111) are closed.
+  M12 clone, M13 graph folders, M14 watch contract, M15–M17, and
+  M18 (Siri drafts posts, macOS 27) all landed. The milestone-10
+  editor polish batch (#225–#238) and the accessibility tracker
+  (#236 + children #239–#243) are merged. The tracker is empty;
+  next-layer candidates are the named-but-unscheduled items in
+  [ROADMAP.md](ROADMAP.md) §3. Sequence: [ROADMAP.md](ROADMAP.md) §8.
 - **Engine baseline:** afterparty `boris/0.8.1`. Kit pin `bf464a0`
   (contains A1/A14/A7 + A3/A4/A13 + A15 `open=` + A5 `validate --watch`).
 - Roadmap **P** is withdrawn — the public site ships via Cloudflare

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Solipsist — Roadmap
 
-**Date:** 2026-08-18
+**Date:** 2026-08-31
 **Status:** the goals document. Spatial model:
 [`HARNESS.md`](HARNESS.md). Boris surface:
 [`BORIS-CAPABILITIES.md`](BORIS-CAPABILITIES.md).
@@ -89,7 +89,7 @@ No scraped prose. No homegrown graph. No third settings store.
 | Pages folders from the graph | Trunks as mailbox folders. From `graph.parent` only — never a disk walk. Dogfood gate is 7 trunks. |
 | Watch events from the A1 contract | Pin `6b930b7` contains `--watch-json` / `serve-started`. Preview and the letter take port / ready from the contract + SSE — no port regex. |
 | Sandboxed, bundled, pinned | D6, D7. Unknown `schemaVersion` degrades (D8). Pipeline ✅ (#78). |
-| Notarized DMG a stranger can download | Operator. First `v*` release + clean-Mac proof (#110 / #111). |
+| Notarized DMG a stranger can download | Operator. First `v*` release + clean-Mac proof (#110 / #111, both closed). |
 
 ### v1 must not
 
@@ -151,7 +151,7 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M6** Author | ✅ gate — `boris-editor` host + link-out (#75, #81) |
 | **M7** Outputs | ✅ gate — Build this / Build all fan-out (#76, #81) |
 | **M8** Publish | ✅ gate — stdin secrets, Standard.site / Nostr buttons (#77, #82/#84) |
-| **M9** Ship | ✅ release pipeline, testdata, pin bump (#78); notarized `v*` + clean-Mac proof are #110/#111 (Apple-account only) |
+| **M9** Ship | ✅ release pipeline, testdata, pin bump (#78); notarized `v*` + clean-Mac proof #110/#111 closed |
 | **M10** Mail body | ✅ Settings, mailboxes, reading pane, hosted Edit, native Compose ([#98](https://github.com/drawmeanelephant/solipsist/issues/98); children #99–#102, #106) |
 | **M11** Prove the Mail body | ✅ Help audit + test pass ([#123](https://github.com/drawmeanelephant/solipsist/issues/123); #124/#125 → PRs #126/#127/#128) |
 | **M12** Clone | ✅ Add Git Repository… → Local source ([#131](https://github.com/drawmeanelephant/solipsist/issues/131); PRs #152/#153) |
@@ -160,6 +160,7 @@ No scraped prose. No homegrown graph. No third settings store.
 | **M15** GitHub source | ✅ OAuth device flow + `SourceKind.github` payload, working copy, Remote mailbox Sync, sign-out ([#179](https://github.com/drawmeanelephant/solipsist/issues/179); PRs #180–#184) |
 | **M16** Write the remote | ✅ commit / push / PR authoring / issues mailbox ([#185](https://github.com/drawmeanelephant/solipsist/issues/185); PRs #187–#190) |
 | **M17** Pull Requests mailbox | ✅ `/pulls` list seam + github-only `pulls` mailbox + authoring entry ([#192](https://github.com/drawmeanelephant/solipsist/issues/192); PRs #194–#196) |
+| **M18** Siri drafts | ✅ App Intents + on-device FoundationModels drafting staged into Compose (PR [#294](https://github.com/drawmeanelephant/solipsist/pull/294)); macOS 27 target |
 
 **Gates plus depth.** M3–M8 closed as gates (#72–#77). The #87 depth
 batch then landed: first-run and problem→page (#88/#94), graph filter /
@@ -168,9 +169,14 @@ activity / plan document (#89/#96), profile 1:1 + execution knobs +
 proof (#91/#93). Then **M9 ship** (#78), the **M10 Mail-body cut**
 (#98 + #99–#102, #106), **M11 prove** (#123), **M12 clone**
 (#131), **M13 graph folders** (#142), and **M14 watch contract**
-(#143) all landed and closed. Remaining ship is Apple-account only
-(#110 notarized `v*` DMG, #111 clean-Mac proof) — operator,
-blocked on a paid team ID. Do not grow `MainWindow`.
+(#143) all landed and closed. **M15** (GitHub source), **M16** (remote
+write verbs), and **M17** (Pull Requests mailbox) followed. **M18**
+(Siri drafts posts via App Intents + on-device FoundationModels, macOS
+27) landed as PR #294. The milestone-10 editor polish batch (#225–#238)
+and the accessibility tracker (#236 + children #239–#243) all merged.
+The Apple-account ship blockers #110 (notarized `v*` DMG) and #111
+(clean-Mac proof) are closed. The tracker is empty. Do not grow
+`MainWindow`.
 
 ---
 
@@ -382,9 +388,11 @@ not block the local publish flows.
 **Gate.** Download the build on a machine without this repo, open a
 folder, plan, validate, build, preview.
 
-Landed 2026-08-18 (#78). Remaining ship is Apple-account only
-(#110 notarized `v*` DMG, #111 clean-Mac proof — operator, blocked on
-a paid team ID).
+Landed 2026-08-18 (#78). The Apple-account ship blockers — #110
+(notarized `v*` DMG) and #111 (clean-Mac proof) — are now closed.
+M18 (Siri drafts, macOS 27) carries the residual `com.apple.developer.
+foundation-model-access` entitlement review into the App Store posture.
+Do not grow #78 into the chrome.
 
 ### M10 — Mail body ✅
 
@@ -475,10 +483,12 @@ shows git’s exit / stderr. No live clone in CI.
 **Lane.** Settings / `Sources/Workspace/Git/`. Card:
 [`cards/GIT-CLONE.md`](cards/GIT-CLONE.md). Issue
 [#131](https://github.com/drawmeanelephant/solipsist/issues/131).
-Parallel with #110. Do not share files with M13 or M14.
+Parallel with the Apple-account ship track (#110, now closed). Do not
+share files with M13 or M14.
 
 **Not this milestone.** Commit / push / pull / fetch UI. GitHub
-app password or OAuth. Fake **Add GitHub…**. Expanding #110 / #111.
+app password or OAuth. Fake **Add GitHub…**. Expanding the
+Apple-account ship posture (#110 / #111, now closed).
 
 Landed 2026-08-18 (#131 → PRs #152/#153). The live gate also
 caught and fixed the sandboxed-git trap: `/usr/bin/git` is an
@@ -613,17 +623,26 @@ here, it is not a v1 promise.
 
 ## 8. Pickup (what to do next)
 
-M10–M14, the post-ship batch (#165/#166/#167), **M15** (GitHub
-source, PRs #180–#184), **M16** (remote write verbs — commit /
-push / PR authoring / issues mailbox, PRs #187–#190), and **M17**
-(the Pull Requests mailbox, PRs #194–#196) all landed. Remaining is
-**ship**, Apple-account only: notarization (#110) then the clean-Mac
-proof (#111).
+**The tracker is empty.** M10–M14, the post-ship batch
+(#165/#166/#167), **M15** (GitHub source, PRs #180–#184), **M16**
+(remote write verbs — commit / push / PR authoring / issues mailbox,
+PRs #187–#190), **M17** (the Pull Requests mailbox, PRs #194–#196),
+the milestone-10 editor polish batch (#225–#238), the accessibility
+tracker (#236 + children #239–#243), the engine-settings-truth
+cleanup (#292, PR #293), and **M18** (Siri drafts posts via App
+Intents + on-device FoundationModels, macOS 27 — PR #294) all landed.
+The Apple-account ship blockers #110 (notarized `v*` DMG) and #111
+(clean-Mac proof) are closed. There are no open issues and no open
+PRs on the tracker.
+
+Nothing is pre-flagged. The named-but-unscheduled items in §3
+(Cooklang recipe-scale mailbox, width-adaptive list-left-of-letter
+split, theme authoring) are the honest next-layer candidates — cut
+an issue draft for one of those before picking up a card.
 
 | Order | Track | Issue | Why this next |
 |------:|-------|-------|----------------|
-| 1 | Notarize | [#110](https://github.com/drawmeanelephant/solipsist/issues/110) | Apple secrets + first `v*` DMG. Operator. |
-| 2 | Proof | [#111](https://github.com/drawmeanelephant/solipsist/issues/111) | Clean-Mac; blocked on #110. |
+| — | (none open) | — | The tracker is clear. Cut a fresh issue for a §3 "Later" item or a dogfood-driven finding. |
 
 ### Landed depth (do not redo)
 
@@ -655,7 +674,13 @@ GitHub source is M15 (landed); its remote *write* verbs are M16
 (landed — commit / push / PR authoring / issues mailbox, PRs
 #187–#190). A Pull Requests mailbox is M17 (landed, PRs #194–#196).
 Compose **depth** (diagnostics, bundle `oliver`) landed as #167
-(PRs #173–#177); the M10 compose window is #106 / #108.
+(PRs #173–#177); the M10 compose window is #106 / #108. **M18** —
+Siri drafts posts via App Intents + on-device FoundationModels,
+macOS 27 — landed as PR #294. The milestone-10 editor polish batch
+(#225–#238) and the accessibility tracker (#236 + children
+#239–#243) are merged. The Apple-account ship blockers #110 / #111
+are closed; the engine-settings-truth cleanup landed as #292 (PR
+#293).
 
 #30 is a pr-cop dump, not a card.
 

--- a/docs/cards/GIT-CLONE.md
+++ b/docs/cards/GIT-CLONE.md
@@ -65,7 +65,7 @@ source kind stays a follow-on.
 - Clone into `SUPPORT-NOT-FOR-GITHUB/` or any kit path.
 - Auto-open a default GitHub account.
 - Walk `content/` as Finder.
-- Expand #110 / #111.
+- Expand the Apple-account ship posture (#110 / #111, now closed).
 
 ## Gate
 

--- a/docs/cards/M18-siri-drafts.md
+++ b/docs/cards/M18-siri-drafts.md
@@ -1,7 +1,11 @@
-# Card — Siri drafts posts (App Intents + Foundation Models)
+# Card — Siri drafts posts (App Intents + Foundation Models) ✅
 
 **Milestone:** M18 · **Lane:** `Sources/Intents/` (+ compose save seam).
 macOS 27 only: deployment target moves to 27.0 in the same PR.
+
+**Landed** — PR [#294](https://github.com/drawmeanelephant/solipsist/pull/294).
+Journal-schema `DraftPostIntent` + on-device FoundationModels
+session; File → New Draft with Apple Intelligence…; macOS 27 target.
 
 The new Siri speaks App Intents — SiriKit is dead, so an intent is the
 only door. The on-device model drafts; **compose stays the review

--- a/docs/cards/README.md
+++ b/docs/cards/README.md
@@ -20,12 +20,19 @@ with a dispatch comment — [#72 M3](https://github.com/drawmeanelephant/solipsi
 
 M3–M8 **gates** are closed (#72–#77). The #87 depth batch is closed
 (#88/#94 · #89/#96 · #90/#95 · #91/#93). **M9 ship** (#78), **M10
-Mail body** (#98), and **M11 prove** (#123) landed. Remaining ship
-is Apple-account only (#110 / #111). Pickable product: **M12
-clone** ([#131](https://github.com/drawmeanelephant/solipsist/issues/131)).
-M13 graph folders and M14 watch contract are filed below. The milestone-10
-editor-polish **accessibility cards** (five lanes, tracker #236) are pickable
-below.
+Mail body** (#98), **M11 prove** (#123), **M12 clone** (#131),
+**M13 graph folders** (#142), and **M14 watch contract** (#143) all
+landed. **M15** (GitHub source), **M16** (remote write verbs), and
+**M17** (Pull Requests mailbox) followed. The milestone-10 editor
+polish batch (#225–#238) and the accessibility tracker (#236 +
+children #239–#243) are merged. The engine-settings-truth cleanup
+(#292, PR #293) landed. **M18** (Siri drafts posts via App Intents +
+on-device FoundationModels, macOS 27) landed as PR #294. The
+Apple-account ship blockers #110 / #111 are closed. **The tracker is
+empty** — no pickable cards remain. The named-but-unscheduled items in
+ROADMAP §3 (Cooklang recipe-scale mailbox, width-adaptive
+list-left-of-letter split, theme authoring) are the honest next-layer
+candidates; cut an issue draft for one of those before picking up a card.
 
 **Legacy board (landed or withdrawn — do not pick):**
 
@@ -84,11 +91,11 @@ letter-URL contract tests pin the recut. Do not pick.
 | [M11-1 Chrome/Help audit](M11-chrome-audit.md) | [#124](https://github.com/drawmeanelephant/solipsist/issues/124) | ✅ PR [#126](https://github.com/drawmeanelephant/solipsist/pull/126) |
 | [M11-2 Test pass](M11-test-pass.md) | [#125](https://github.com/drawmeanelephant/solipsist/issues/125) | ✅ PRs [#127](https://github.com/drawmeanelephant/solipsist/pull/127), [#128](https://github.com/drawmeanelephant/solipsist/pull/128) |
 
-## M12 — Clone (pickable)
+## M12 — Clone ✅
 
 | Card | Issue | Lane | Parallel with | Gate |
 |------|-------|------|----------------|------|
-| [Add Git Repository…](GIT-CLONE.md) | [#131](https://github.com/drawmeanelephant/solipsist/issues/131) | Settings / workspace | #110 | clone URL → folder → Local source; branch in Settings |
+| [Add Git Repository…](GIT-CLONE.md) | [#131](https://github.com/drawmeanelephant/solipsist/issues/131) | Settings / workspace | #110 (closed) | clone URL → folder → Local source; branch in Settings |
 
 ## M13 — Graph folders (filed; pick after M12 or in a second worktree)
 
@@ -158,7 +165,7 @@ entry). Do not pick.
 | [M17-2 PR mailbox](M17-pr-mailbox.md) | #192 | ✅ |
 | [M17-3 Authoring entry](M17-pr-authoring.md) | #192 | ✅ |
 
-## M18 — Siri drafts posts (pickable)
+## M18 — Siri drafts posts ✅
 
 The new Siri speaks App Intents only; the on-device FoundationModels
 session drafts. Compose stays the review surface; nothing touches the
@@ -167,10 +174,10 @@ moves to 27.0 in the same PR.
 
 | Card | Issue | Lane | Gate |
 |------|-------|------|------|
-| [Siri drafts posts](M18-siri-drafts.md) | — (file on pick) | `Sources/Intents/` + compose save seam | “Draft a post in Solipsist …” stages an untitled buffer; ⌘S asks where; Apple Intelligence off surfaces an alert |
+| [Siri drafts posts](M18-siri-drafts.md) | — (PR [#294](https://github.com/drawmeanelephant/solipsist/pull/294)) | `Sources/Intents/` + compose save seam | “Draft a post in Solipsist …” stages an untitled buffer; ⌘S asks where; Apple Intelligence off surfaces an alert |
 
 
-## Editor accessibility — milestone 10 polish (pickable)
+## Editor accessibility — milestone 10 polish ✅
 
 VoiceOver across the editor surfaces, cut into five disjoint lanes from
 tracker [#236](https://github.com/drawmeanelephant/solipsist/issues/236).

--- a/docs/cards/parallel/README.md
+++ b/docs/cards/parallel/README.md
@@ -74,10 +74,12 @@ the agent-pack, `plan --out`.
 
 New work lives in the [delegation queue](../queue/README.md) — batch 2
 is landed and the queue is empty. M12 clone (#131), M13 graph folders
-(#142), and M14 watch contract (#143) all landed and closed. Apple-
-account ship (#110 / #111) is operator, not this lane. The two
-pin-follow trackers are now shipped: #160 (A15 `open=`, boris#649)
-and #161 (A5 `validate --watch`, boris#647).
+(#142), M14 watch contract (#143), M15–M17, and M18 (PR #294) all
+landed and closed. The milestone-10 editor polish batch (#225–#238)
+and the accessibility tracker (#236 + children #239–#243) are
+merged. The Apple-account ship blockers #110 / #111 are closed — the
+tracker is empty. The two pin-follow trackers are now shipped: #160
+(A15 `open=`, boris#649) and #161 (A5 `validate --watch`, boris#647).
 
 Skip: fart app (`make fart` must keep failing). Skip GitHub-as-source.
 Skip publication flows. Skip Wasm in the app.

--- a/docs/cards/queue/README.md
+++ b/docs/cards/queue/README.md
@@ -70,9 +70,13 @@ lives in the issue tracker (#58–#61; briefs in
 queue cards.
 
 The depth batch (#88–#91) landed. M9 (#78), M10 (#98), M11
-(#123), M12 (#131), M13 (#142), and M14 (#143) all landed and
-closed. Remaining ship is Apple-account only (#110 / #111) — not
-this queue. The two pin-follow trackers are now shipped: [#160](https://github.com/drawmeanelephant/solipsist/issues/160)
+(#123), M12 (#131), M13 (#142), M14 (#143), M15 (#179), M16
+(#185), M17 (#192), and M18 (PR #294) all landed and closed. The
+milestone-10 editor polish batch (#225–#238) and the accessibility
+tracker (#236 + children #239–#243) are merged. The engine-settings-
+truth cleanup landed as #292 (PR #293). The Apple-account ship
+blockers #110 / #111 are closed — the tracker is empty. The two
+pin-follow trackers are now shipped: [#160](https://github.com/drawmeanelephant/solipsist/issues/160)
 (A15 `open=`, boris#649) and [#161](https://github.com/drawmeanelephant/solipsist/issues/161)
 (A5 `validate --watch`, boris#647). The queue stays empty unless
 someone cuts a docs-only or `Tests/`-only slice.


### PR DESCRIPTION
docs: sync status to reality — M18 landed, #110/#111 closed, tracker empty

The tracker is fully cleared but the docs still presented M12/M18 as
pickable and #110/#111 as the remaining ship work. Bring nine files in
line: M18 (Siri drafts, PR #294, macOS 27) is landed; the Apple-account
ship blockers #110/#111 are closed; the milestone-10 editor polish
batch (#225-#238) and accessibility tracker (#236 + children #239-#243)
are merged; the engine-settings-truth cleanup (#292, PR #293) landed.
Section 8 Pickup now honestly says the tracker is empty and points at
the Roadmap section 3 "Later" items as the next-layer candidates.

Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>
