### PR TITLE
play/mailbox/inspector: three §3 Later issues — width-adaptive split, Recipes mailbox, theme browser (#296 #297 #298)

### DIFF
--- a/Sources/Chrome/SourceSidebar.swift
+++ b/Sources/Chrome/SourceSidebar.swift
@@ -89,8 +89,12 @@ private struct SourceSection: View {
     @State private var signOutItem: SourceItem?
 
     var body: some View {
+        // #296: the Recipes row is conditional on the cached graph
+        // carrying ≥1 recipe node — same cached-only read as PagesGroup,
+        // so a markdown-only source never sees the row.
+        let graph = store.cachedGraph(for: item.id)
         Section(isExpanded: $isExpanded) {
-            ForEach(WorkspaceMailbox.all(for: item), id: \.self) { box in
+            ForEach(WorkspaceMailbox.all(for: item, graph: graph), id: \.self) { box in
                 if box == WorkspaceMailbox.pages {
                     // Pages grows trunk-folder children from the decoded
                     // graph (M13-1). No graph yet → no children, not an

--- a/Sources/Inspector/Inspectable.swift
+++ b/Sources/Inspector/Inspectable.swift
@@ -105,6 +105,17 @@ struct InspectorSnapshot: Inspectable {
         case WorkspaceMailbox.issues, WorkspaceMailbox.pulls:
             sections.append(InspectorSection(id: InspectorSectionID.execution, title: "GitHub & Execution"))
 
+        case WorkspaceMailbox.recipes:
+            // #296: a selected recipe page shows the page inspector (its
+            // Recipe Scale section is the play surface); otherwise the
+            // profile + execution defaults.
+            if nounKind == InspectorNounKind.page {
+                sections.append(InspectorSection(id: InspectorSectionID.page, title: "Page"))
+            } else if sourceKind == .local {
+                sections.append(InspectorSection(id: InspectorSectionID.profile, title: "Site Profile"))
+            }
+            sections.append(InspectorSection(id: InspectorSectionID.execution, title: "Execution"))
+
         default:
             // Unknown mailbox (e.g. a trunk id): if a page is selected,
             // show that page's inspector; otherwise signal the trunk filter.

--- a/Sources/Inspector/ProfileSection.swift
+++ b/Sources/Inspector/ProfileSection.swift
@@ -11,6 +11,15 @@ struct ProfileSection: View {
     @State private var status: Status = .idle
     @State private var note: String?
     @State private var availableThemes: [String] = []
+    /// #298: the target row whose theme browser sheet is open.
+    @State private var browsingTheme: BrowsableTargetTheme?
+
+    /// Identifiable wrapper for the sheet(item:) binding — the target
+    /// row index whose theme the browser writes.
+    private struct BrowsableTargetTheme: Identifiable {
+        let index: Int
+        var id: Int { index }
+    }
 
     var body: some View {
         Group {
@@ -95,6 +104,18 @@ struct ProfileSection: View {
                 }
             }
         }
+        .sheet(item: $browsingTheme) { browse in
+            ThemeBrowserView(
+                themes: availableThemes,
+                selection: browse.index < fields.targets.count ? fields.targets[browse.index].theme : nil,
+                workspaceRoot: try? source.resolve().url,
+                onSelect: { theme in
+                    guard browse.index < fields.targets.count else { return }
+                    fields.targets[browse.index].theme = theme
+                },
+                onCancel: {}
+            )
+        }
     }
 
     @ViewBuilder
@@ -112,15 +133,27 @@ struct ProfileSection: View {
                     .help("Remove target")
                 }
                 TextField("Output", text: $fields.targets[index].output)
-                Picker("Theme", selection: Binding(
-                    get: { fields.targets[index].theme ?? "" },
-                    set: { fields.targets[index].theme = $0.isEmpty ? nil : $0 }
-                )) {
-                    Text("Default").tag("")
-                    ForEach(availableThemes, id: \.self) { theme in
-                        Text(theme).tag(theme)
+                // #298: the theme control is a button opening the visual
+                // browser (was: flat name Picker). Writes the same
+                // `target.theme` string the Picker wrote; Save unchanged.
+                Button {
+                    browsingTheme = BrowsableTargetTheme(index: index)
+                } label: {
+                    HStack {
+                        Text("Theme")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(fields.targets[index].theme ?? "Default")
+                            .foregroundStyle(fields.targets[index].theme == nil ? .secondary : .primary)
+                        Image(systemName: "paintpalette")
+                            .foregroundStyle(.secondary)
                     }
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .help("Browse themes visually")
+                .accessibilityLabel("Theme: \(fields.targets[index].theme ?? "Default")")
+                .accessibilityHint("Opens the theme browser")
                 TextField("Layout", text: Binding(
                     get: { fields.targets[index].layout ?? "" },
                     set: { fields.targets[index].layout = $0.isEmpty ? nil : $0 }

--- a/Sources/Inspector/TargetSection.swift
+++ b/Sources/Inspector/TargetSection.swift
@@ -9,6 +9,10 @@ struct TargetSection: View {
     @State private var target: PublicationTarget?
     @State private var profile: PublicationProfile?
     @State private var availableThemes: [String] = []
+    /// #298: opens the theme browser (browse-only here — this section
+    /// reads the selected target; writes stay in ProfileSection).
+    @State private var showThemeBrowser = false
+    private var workspaceRoot: URL? { try? source.workspaceRoot() }
 
     var body: some View {
         Group {
@@ -47,13 +51,23 @@ struct TargetSection: View {
                 }
 
                 if !availableThemes.isEmpty {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Available Themes")
-                            .foregroundStyle(.secondary)
-                        Text(availableThemes.joined(separator: ", "))
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
+                    // #298: browse the themes visually (was: a comma blob).
+                    Button {
+                        showThemeBrowser = true
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text("Available Themes")
+                                .foregroundStyle(.secondary)
+                            Image(systemName: "paintpalette")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
+                    .help("Browse themes visually")
+                    .accessibilityLabel("Available Themes, \(availableThemes.count) themes")
+                    .accessibilityHint("Opens the theme browser")
                 }
             } else {
                 Text("Target “\(targetName)” not found in profile.")
@@ -62,6 +76,15 @@ struct TargetSection: View {
         }
         .task(id: "\(source.id.raw):\(targetName)") {
             load()
+        }
+        .sheet(isPresented: $showThemeBrowser) {
+            ThemeBrowserView(
+                themes: availableThemes,
+                selection: target?.theme,
+                workspaceRoot: workspaceRoot,
+                onSelect: { _ in },
+                onCancel: {}
+            )
         }
     }
 

--- a/Sources/Inspector/ThemeBrowserView.swift
+++ b/Sources/Inspector/ThemeBrowserView.swift
@@ -1,0 +1,232 @@
+import SwiftUI
+import WebKit
+
+/// #298 — visual theme browser. Presents `ThemeCatalog.allThemes(for:)`
+/// as a grid of preview tiles (a small HTML fragment styled by the
+/// theme's CSS) so authors pick a target theme by appearance. Selection
+/// only — never authoring (the explicit ROADMAP §3 boundary): no CSS
+/// editing, no theme creation, no writes under `themes/`.
+///
+/// The preview tile reuses the compose preview's render path
+/// (`ComposeThemeCSS.collect` for local CSS; a neutral fallback sample
+/// when a theme has no resolvable stylesheet — first-class themes ship
+/// no CSS in this workspace). Boris owns theme rendering; the tile is
+/// either theme-CSS-styled or the bundled neutral sample, never a
+/// Swift HTML/CSS engine.
+struct ThemeBrowserView: View {
+    /// All themes, local first then first-class (from ThemeCatalog).
+    let themes: [String]
+    /// The currently selected theme name, `nil`/empty meaning Default.
+    let selection: String?
+    /// Workspace root for local theme CSS collection.
+    let workspaceRoot: URL?
+    /// Called with the chosen theme name, or nil for the Default tile.
+    let onSelect: (String?) -> Void
+    /// Called when the browser is dismissed without a choice.
+    let onCancel: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var searchText = ""
+
+    private var visibleThemes: [String] {
+        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return themes }
+        return themes.filter { $0.localizedCaseInsensitiveContains(trimmed) }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Choose a Theme")
+                    .font(.headline)
+                Spacer()
+                Button("Done") {
+                    onCancel()
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding()
+
+            if themes.count > 8 {
+                // Search field only earns its chrome on the long list.
+                TextField("Filter themes…", text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .padding(.horizontal)
+                    .padding(.bottom, 8)
+            }
+
+            ScrollView {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 200, maximum: 280), spacing: 12)],
+                    spacing: 12
+                ) {
+                    ThemeTile(
+                        name: "Default",
+                        css: nil,
+                        isSelected: (selection ?? "").isEmpty,
+                        caption: "Boris chooses the theme"
+                    ) {
+                        onSelect(nil)
+                        dismiss()
+                    }
+
+                    ForEach(visibleThemes, id: \.self) { theme in
+                        ThemeTile(
+                            name: theme,
+                            css: ThemePreviewDocument.css(
+                                for: theme,
+                                workspaceRoot: workspaceRoot
+                            ),
+                            isSelected: selection == theme,
+                            caption: nil
+                        ) {
+                            onSelect(theme)
+                            dismiss()
+                        }
+                    }
+                }
+                .padding()
+            }
+        }
+        .frame(minWidth: 520, minHeight: 420)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Theme Browser")
+    }
+}
+
+/// One preview tile: a fixed sample fragment styled by the theme's CSS
+/// in a sandboxed WKWebView (same host shape as the compose preview —
+/// `loadHTMLString`, nil baseURL, no navigation). A theme whose CSS
+/// does not resolve renders the neutral fallback sample plus its name;
+/// never a blank tile, never an error.
+private struct ThemeTile: View {
+    let name: String
+    let css: String?
+    let isSelected: Bool
+    let caption: String?
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 0) {
+                ThemeTileWebView(
+                    html: ThemePreviewDocument.html(sampleCSS: css)
+                )
+                .frame(height: 110)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(name)
+                            .font(.callout.weight(isSelected ? .semibold : .regular))
+                            .lineLimit(1)
+                        if let caption {
+                            Text(caption)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                    Spacer(minLength: 4)
+                    if isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.tint)
+                            .accessibilityHidden(true)
+                    }
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 6)
+            }
+            .padding(6)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(
+                        isSelected
+                            ? Color.accentColor.opacity(0.12)
+                            : Color(nsColor: .controlBackgroundColor)
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(
+                        isSelected ? Color.accentColor : Color(nsColor: .separatorColor),
+                        lineWidth: isSelected ? 2 : 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(name) theme\(isSelected ? ", selected" : "")")
+        .accessibilityHint(caption ?? "Select this theme")
+    }
+}
+
+/// Sandboxed host for one tile's sample document — the compose preview's
+/// shape: non-persistent data store, single load, no delegate-driven
+/// navigation beyond it.
+private struct ThemeTileWebView: NSViewRepresentable {
+    let html: String
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.setValue(false, forKey: "drawsBackground")
+        webView.loadHTMLString(html, baseURL: nil)
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        // Tiles are immutable per theme; no reload dance needed.
+    }
+}
+
+/// Pure document assembly for a preview tile — mirrors
+/// `ComposePreviewDocument` (same style-element inlining and
+/// `</style>` neutralization) but with the browser's fixed sample
+/// fragment. Unit-testable without WebKit.
+enum ThemePreviewDocument {
+    /// The representative fragment every tile renders: heading,
+    /// paragraph, link, list — the #298 sample set.
+    static let sampleFragment = """
+    <h1>Theme Sample</h1>
+    <p>A paragraph of <a href="#">text</a> to show the theme.</p>
+    <ul><li>One</li><li>Two</li></ul>
+    """
+
+    /// Neutral sample stylesheet for themes whose CSS does not resolve
+    /// (first-class themes ship no CSS in this workspace) — the fallback
+    /// tile, never blank, never an error. Mirrors the compose preview's
+    /// fallback so both read as the same "no theme" voice.
+    static let fallbackCSS = ComposePreviewDocument.fallbackCSS
+
+    /// CSS for a theme: local `themes/<name>` stylesheets collected via
+    /// the existing `ComposeThemeCSS.collect` path (no second resolver);
+    /// nil when nothing resolves.
+    static func css(for theme: String, workspaceRoot: URL?) -> String? {
+        guard let workspaceRoot else { return nil }
+        return ComposeThemeCSS.collect(workspaceRoot: workspaceRoot, themePath: "themes/\(theme)")
+    }
+
+    /// Full tile document.
+    static func html(sampleCSS: String?) -> String {
+        let css = sampleCSS.flatMap { $0.isEmpty ? nil : ComposePreviewDocument.sanitize($0) }
+            ?? fallbackCSS
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="color-scheme" content="light dark">
+        <style>
+        \(css)
+        </style>
+        </head>
+        <body>
+        \(sampleFragment)
+        </body>
+        </html>
+        """
+    }
+}

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -64,6 +64,12 @@ struct LocalPlay: PlaySurface {
                     // github sources. Honest fallback rather than a crash.
                     trunkMailbox
                 }
+            case WorkspaceMailbox.recipes:
+                // #296: the row only exists when the graph has recipe
+                // nodes, so the list is non-empty in practice. A stale
+                // stored mailbox on a rebuilt graph falls to the honest
+                // empty state inside.
+                recipesMailbox
             default:
                 // Unknown mailbox is a trunk id (M13): Pages means all;
                 // a trunk id means that folder and its descendants.
@@ -127,12 +133,36 @@ struct LocalPlay: PlaySurface {
         mailboxContent(pages: displayedPages, empty: .emptyFolder)
     }
 
+    /// #296: the Recipes mailbox — every graph node carrying a `recipe`
+    /// facet as a row (title, servings when present, ingredient count).
+    /// Selecting a row selects that page noun so the reading pane shows
+    /// the letter and the drawer keeps its Recipe Scale section. The
+    /// list reads the same graph the inspector reads — `recipe-scale`
+    /// still runs only on factor change, never for the list.
+    @ViewBuilder
+    private var recipesMailbox: some View {
+        let recipes = LocalPlayGraph.recipes(from: loadedPages, graph: currentGraph)
+        mailboxContent(pages: recipes, empty: .noRecipes)
+    }
+
+    /// The decoded graph for the current source, as pushed by `apply` —
+    /// `nil` before the first load/build. The Recipes list keys off
+    /// `GraphNode.recipe` facets, never `profile.input_format` (a mixed
+    /// corpus is valid).
+    private var currentGraph: Graph? {
+        store.cachedGraph(for: source.id)
+    }
+
     private enum MailboxEmptyKind {
         /// The source's graph has no pages at all.
         case noPages
         /// The trunk folder has no pages in the current graph (or its id
         /// is stale — the graph no longer contains it).
         case emptyFolder
+        /// #296: the graph (or this mailbox selection) has no recipe
+        /// nodes — e.g. a stale stored `recipes` value after the corpus
+        /// lost its last `.cook` page.
+        case noRecipes
     }
 
     @ViewBuilder
@@ -190,6 +220,15 @@ struct LocalPlay: PlaySurface {
                 Text("This folder has no pages in the current graph.")
             }
             .accessibilityLabel("No Pages in This Folder")
+        case .noRecipes:
+            ContentUnavailableView {
+                Label("No Recipes", systemImage: "fork.knife")
+            } description: {
+                Text("This source's graph has no Cooklang recipe pages.")
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("No Recipes")
+            .accessibilityHint("This source's graph has no Cooklang recipe pages.")
         }
     }
 

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -203,52 +203,128 @@ struct LocalPlay: PlaySurface {
         }
     }
 
-    @State private var topHeight: CGFloat = 200
+    /// Stacked-mode list height (M10 default). Independent of the
+    /// wide-mode `leftWidth` (#297): the two states never write each other.
+    @State private var topHeight: CGFloat = PagesSplitGeometry.defaultTopHeight
+    /// Wide-mode list width (#297). Default list width in side-by-side
+    /// layout; persisted by `@State` like `topHeight`, no plist, no
+    /// Settings pane (D2: view-local chrome).
+    @State private var leftWidth: CGFloat = PagesSplitGeometry.defaultLeftWidth
 
     @ViewBuilder
     private func pagesSplit(_ pages: [PlayPage]) -> some View {
         GeometryReader { proxy in
             let totalHeight = proxy.size.height
             let availableHeight = max(totalHeight - 10, 100)
-            let clampedTop = min(max(topHeight, 90), availableHeight - 120)
+            let clampedTop = PagesSplitGeometry.clampedTopHeight(topHeight, availableHeight: availableHeight)
 
-            VStack(spacing: 0) {
-                pageList(pages)
-                    .frame(height: clampedTop)
+            if PagesSplitGeometry.isWide(width: proxy.size.width) {
+                // #297: wide content column — list left of the letter,
+                // vertical drag handle between. Same two child views;
+                // only the container and the handle orientation change.
+                let clampedLeft = PagesSplitGeometry.clampedLeftWidth(leftWidth, totalWidth: proxy.size.width)
 
-                ZStack {
-                    Rectangle()
-                        .fill(Color(nsColor: .separatorColor))
-                        .frame(height: 1)
+                HStack(spacing: 0) {
+                    pageList(pages)
+                        .frame(width: clampedLeft)
 
-                    Capsule()
-                        .fill(Color.secondary.opacity(0.4))
-                        .frame(width: 36, height: 4)
+                    verticalSeparator(totalWidth: proxy.size.width)
+
+                    ReadingPane(
+                        page: selectedPlayPage,
+                        source: source,
+                        loadGeneration: loadGeneration
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                .frame(height: 9)
-                .contentShape(Rectangle())
-                .onHover { inside in
-                    if inside {
-                        NSCursor.resizeUpDown.push()
-                    } else {
-                        NSCursor.pop()
-                    }
-                }
-                .gesture(
-                    DragGesture(minimumDistance: 1)
-                        .onChanged { value in
-                            topHeight = min(max(clampedTop + value.translation.height, 90), availableHeight - 120)
-                        }
-                )
+            } else {
+                VStack(spacing: 0) {
+                    pageList(pages)
+                        .frame(height: clampedTop)
 
-                ReadingPane(
-                    page: selectedPlayPage,
-                    source: source,
-                    loadGeneration: loadGeneration
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    horizontalSeparator(availableHeight: availableHeight)
+
+                    ReadingPane(
+                        page: selectedPlayPage,
+                        source: source,
+                        loadGeneration: loadGeneration
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
         }
+    }
+
+    /// The M10 stacked-mode handle: horizontal rule + up/down resize
+    /// cursor. Byte-for-byte the M10 layout, factored out by #297 so the
+    /// wide branch can mirror it in the vertical orientation.
+    private func horizontalSeparator(availableHeight: CGFloat) -> some View {
+        let clampedTop = PagesSplitGeometry.clampedTopHeight(topHeight, availableHeight: availableHeight)
+        return ZStack {
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor))
+                .frame(height: 1)
+
+            Capsule()
+                .fill(Color.secondary.opacity(0.4))
+                .frame(width: 36, height: 4)
+        }
+        .frame(height: 9)
+        .contentShape(Rectangle())
+        .onHover { inside in
+            if inside {
+                NSCursor.resizeUpDown.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
+        .gesture(
+            DragGesture(minimumDistance: 1)
+                .onChanged { value in
+                    topHeight = PagesSplitGeometry.clampedTopHeight(
+                        clampedTop + value.translation.height,
+                        availableHeight: availableHeight
+                    )
+                }
+        )
+        .accessibilityLabel("List and letter separator; drag to resize")
+        .accessibilityHint("Drag to resize the list and letter panes")
+    }
+
+    /// #297 wide-mode handle: the same separator mirrored — 1pt rule,
+    /// vertical capsule knob, left/right resize cursor, `leftWidth`
+    /// drag. Independent of `topHeight`.
+    private func verticalSeparator(totalWidth: CGFloat) -> some View {
+        let clampedLeft = PagesSplitGeometry.clampedLeftWidth(leftWidth, totalWidth: totalWidth)
+        return ZStack {
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor))
+                .frame(width: 1)
+
+            Capsule()
+                .fill(Color.secondary.opacity(0.4))
+                .frame(width: 4, height: 36)
+        }
+        .frame(width: 9)
+        .contentShape(Rectangle())
+        .onHover { inside in
+            if inside {
+                NSCursor.resizeLeftRight.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
+        .gesture(
+            DragGesture(minimumDistance: 1)
+                .onChanged { value in
+                    leftWidth = PagesSplitGeometry.clampedLeftWidth(
+                        clampedLeft + value.translation.width,
+                        totalWidth: totalWidth
+                    )
+                }
+        )
+        .accessibilityLabel("List and letter separator; drag to resize")
+        .accessibilityHint("Drag to resize the list and letter panes")
     }
 
     // MARK: - List

--- a/Sources/Play/Local/LocalPlay.swift
+++ b/Sources/Play/Local/LocalPlay.swift
@@ -658,6 +658,14 @@ private struct PageRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                if let ingredientCount = page.ingredientCount {
+                    // #296: Recipes mailbox row — ingredient count from
+                    // the graph facet. An empty recipe still lists: 0.
+                    Text("\(ingredientCount) ingredient\(ingredientCount == 1 ? "" : "s")")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
             Spacer(minLength: 8)
 

--- a/Sources/Play/Local/LocalPlayGraph.swift
+++ b/Sources/Play/Local/LocalPlayGraph.swift
@@ -16,6 +16,10 @@ struct PlayPage: Identifiable, Hashable, Sendable {
     /// whose `parent` chain this row reaches, or nil for non-trunk roots.
     /// Drives the trunk-mailbox filter; never the sidebar.
     let trunkID: String?
+    /// #296: ingredient count for the Recipes mailbox row, from the
+    /// node's `recipe` facet. nil on every other surface — the pages
+    /// list never carries it.
+    let ingredientCount: Int?
 
     init(
         id: String,
@@ -25,7 +29,8 @@ struct PlayPage: Identifiable, Hashable, Sendable {
         depth: Int = 0,
         tags: [String] = [],
         sourcePath: String = "",
-        trunkID: String? = nil
+        trunkID: String? = nil,
+        ingredientCount: Int? = nil
     ) {
         self.id = id
         self.title = title
@@ -35,6 +40,7 @@ struct PlayPage: Identifiable, Hashable, Sendable {
         self.tags = tags
         self.sourcePath = sourcePath
         self.trunkID = trunkID
+        self.ingredientCount = ingredientCount
     }
 }
 
@@ -124,16 +130,33 @@ enum LocalPlayGraph {
     }
 
     /// #296: the Recipes mailbox list — every graph node carrying a
-    /// non-nil `recipe` facet, in graph order. An empty-ingredient
-    /// recipe still lists (the row shows "0 ingredients"); a corpus
-    /// whose graph is not built yet lists nothing (never synthesized).
-    /// Keys off `GraphNode.recipe` presence only — never
-    /// `profile.input_format` (a mixed corpus is valid).
+    /// non-nil `recipe` facet, in graph order, with its ingredient
+    /// count on the row. An empty-ingredient recipe still lists (the
+    /// row shows "0 ingredients"); a corpus whose graph is not built
+    /// yet lists nothing (never synthesized). Keys off
+    /// `GraphNode.recipe` presence only — never `profile.input_format`
+    /// (a mixed corpus is valid).
     static func recipes(from pages: [PlayPage], graph: Graph?) -> [PlayPage] {
         guard let graph else { return [] }
-        let recipeIDs = Set(graph.nodes.compactMap { $0.recipe != nil ? $0.id : nil })
-        guard !recipeIDs.isEmpty else { return [] }
-        return pages.filter { recipeIDs.contains($0.id) }
+        var recipeByPage: [String: CookRecipe] = [:]
+        for node in graph.nodes where node.recipe != nil {
+            recipeByPage[node.id] = node.recipe
+        }
+        guard !recipeByPage.isEmpty else { return [] }
+        return pages.compactMap { page in
+            guard let recipe = recipeByPage[page.id] else { return nil }
+            return PlayPage(
+                id: page.id,
+                title: page.title,
+                status: page.status,
+                role: page.role,
+                depth: page.depth,
+                tags: page.tags,
+                sourcePath: page.sourcePath,
+                trunkID: page.trunkID,
+                ingredientCount: recipe.ingredients.count
+            )
+        }
     }
 
     /// Filter pages by query string matching title, id, tag, or status.

--- a/Sources/Play/Local/LocalPlayGraph.swift
+++ b/Sources/Play/Local/LocalPlayGraph.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 /// One row in the local play list. Flattened from `Graph.nodes` so the
@@ -189,5 +190,41 @@ enum LocalPlayGraph {
         }
 
         return nil
+    }
+}
+
+/// #297 — width-adaptive Pages split geometry. Pure math so
+/// ContractTests can pin the branch + clamp rules without a window:
+/// the view (`LocalPlay.pagesSplit`) only turns these numbers into
+/// frames. Stacked bounds are the M10 values; wide bounds keep the
+/// list ≥ 220 and the letter ≥ 360.
+enum PagesSplitGeometry {
+    /// Width at which the split cuts from stacked to side-by-side.
+    static let wideBreakpoint: CGFloat = 720
+    static let minTopHeight: CGFloat = 90
+    static let minLetterHeight: CGFloat = 120
+    static let defaultTopHeight: CGFloat = 200
+    static let minListWidth: CGFloat = 220
+    static let minLetterWidth: CGFloat = 360
+    static let defaultLeftWidth: CGFloat = 280
+
+    /// `true` at or above the breakpoint — the wide cut does not
+    /// oscillate at exactly 720.
+    static func isWide(width: CGFloat) -> Bool {
+        width >= wideBreakpoint
+    }
+
+    /// Stacked-mode list height: M10 clamp, ≥ 90 and leaving the letter
+    /// ≥ 120 of `availableHeight`.
+    static func clampedTopHeight(_ raw: CGFloat, availableHeight: CGFloat) -> CGFloat {
+        min(max(raw, minTopHeight), max(availableHeight - minLetterHeight, minTopHeight))
+    }
+
+    /// Wide-mode list width: ≥ 220 and leaving the letter ≥ 360 of
+    /// `totalWidth`. When the window cannot honor both (between the
+    /// breakpoint and 220 + 360), the letter floor wins and the list
+    /// clamps to whatever remains, never below 220.
+    static func clampedLeftWidth(_ raw: CGFloat, totalWidth: CGFloat) -> CGFloat {
+        min(max(raw, minListWidth), max(totalWidth - minLetterWidth, minListWidth))
     }
 }

--- a/Sources/Play/Local/LocalPlayGraph.swift
+++ b/Sources/Play/Local/LocalPlayGraph.swift
@@ -123,6 +123,19 @@ enum LocalPlayGraph {
         pages(from: graph).filter { $0.depth == 0 && $0.role == .trunk }
     }
 
+    /// #296: the Recipes mailbox list — every graph node carrying a
+    /// non-nil `recipe` facet, in graph order. An empty-ingredient
+    /// recipe still lists (the row shows "0 ingredients"); a corpus
+    /// whose graph is not built yet lists nothing (never synthesized).
+    /// Keys off `GraphNode.recipe` presence only — never
+    /// `profile.input_format` (a mixed corpus is valid).
+    static func recipes(from pages: [PlayPage], graph: Graph?) -> [PlayPage] {
+        guard let graph else { return [] }
+        let recipeIDs = Set(graph.nodes.compactMap { $0.recipe != nil ? $0.id : nil })
+        guard !recipeIDs.isEmpty else { return [] }
+        return pages.filter { recipeIDs.contains($0.id) }
+    }
+
     /// Filter pages by query string matching title, id, tag, or status.
     /// Supports prefixes: `tag:`, `status:`, `id:`, `title:`.
     static func filter(pages: [PlayPage], query: String) -> [PlayPage] {

--- a/Sources/Workspace/WorkspaceSelection.swift
+++ b/Sources/Workspace/WorkspaceSelection.swift
@@ -58,6 +58,12 @@ enum WorkspaceMailbox {
     static let all: [String] = [pages, outputs, publish, plan, activity, contentAudit]
     static let defaultMailbox = pages
 
+    /// #296: Cooklang recipe mailbox. Conditional — only in `all(for:)`
+    /// when the source graph has ≥1 node with a `recipe` facet. A mixed
+    /// corpus (markdown + cook) is valid, so presence keys off graph
+    /// nodes, never `profile.input_format`.
+    static let recipes = "recipes"
+
     static func isKnown(_ raw: String?) -> Bool {
         guard let raw else { return false }
         return all.contains(raw)
@@ -83,6 +89,7 @@ enum WorkspaceMailbox {
         case remote: return "Remote"
         case issues: return "Issues"
         case pulls: return "Pull Requests"
+        case recipes: return "Recipes"
         default: return raw
         }
     }
@@ -98,18 +105,33 @@ enum WorkspaceMailbox {
         case remote: return "arrow.triangle.2.circlepath"
         case issues: return "exclamationmark.circle"
         case pulls: return "arrow.triangle.branch"
+        case recipes: return "fork.knife"
         default: return "folder"
         }
     }
 
     /// Sidebar row list for one source. Local sources get the M10 set;
     /// GitHub sources additionally get the Remote, Issues, and Pull
-    /// Requests mailboxes (github-only rows).
+    /// Requests mailboxes (github-only rows). #296: a source whose
+    /// graph carries ≥1 recipe node additionally gets the Recipes row —
+    /// `recipesWithGraph` composes it in.
     static func all(for item: SourceItem) -> [String] {
         switch item.kind {
         case .github: return all + [remote, issues, pulls]
         case .local: return all
         }
+    }
+
+    /// #296: `all(for:)` plus the Recipes row when the graph has ≥1
+    /// node with a non-nil `recipe` facet. Markdown-only graphs never
+    /// see the row; an unbuilt graph shows nothing until the first
+    /// build (same as Pages trunks — never synthesized).
+    static func all(for item: SourceItem, graph: Graph?) -> [String] {
+        var rows = all(for: item)
+        if let graph, graph.nodes.contains(where: { $0.recipe != nil }) {
+            rows.append(recipes)
+        }
+        return rows
     }
 }
 

--- a/Tests/ContractTests/HelpAuditTests.swift
+++ b/Tests/ContractTests/HelpAuditTests.swift
@@ -52,6 +52,7 @@ final class HelpAuditTests: XCTestCase {
             WorkspaceMailbox.remote,
             WorkspaceMailbox.issues,
             WorkspaceMailbox.pulls,
+            WorkspaceMailbox.recipes,
         ]
         for mailbox in allMailboxes {
             XCTAssertTrue(

--- a/Tests/ContractTests/PagesSplitGeometryTests.swift
+++ b/Tests/ContractTests/PagesSplitGeometryTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+/// #297 — width-adaptive Pages split: the branch rule and the two
+/// independent clamp regimes (stacked `topHeight`, wide `leftWidth`).
+/// The view turns these numbers into frames; the rules live here so
+/// they are pinnable without a window.
+final class PagesSplitGeometryTests: XCTestCase {
+    // MARK: - Branch
+
+    func testWideBranchAtOrAboveBreakpoint() {
+        XCTAssertTrue(PagesSplitGeometry.isWide(width: 720), "≥ means wide — no oscillation at exactly 720")
+        XCTAssertTrue(PagesSplitGeometry.isWide(width: 1440))
+    }
+
+    func testStackedBranchBelowBreakpoint() {
+        XCTAssertFalse(PagesSplitGeometry.isWide(width: 719.5))
+        XCTAssertFalse(PagesSplitGeometry.isWide(width: 0))
+        // A tall narrow window (half-screen on a 13" MacBook) stays
+        // stacked — the breakpoint is width-only, not aspect.
+        XCTAssertFalse(PagesSplitGeometry.isWide(width: 600))
+    }
+
+    func testCrossingBreakpointFlipsOnce() {
+        // Dragging across 720 flips exactly once: below is stacked,
+        // at-or-above is wide, and back again — no hysteresis band.
+        let around = [718, 719, 720, 721, 722]
+        let modes = around.map { PagesSplitGeometry.isWide(width: CGFloat($0)) }
+        XCTAssertEqual(modes, [false, false, true, true, true])
+    }
+
+    // MARK: - Wide-mode clamp
+
+    func testLeftWidthClampedBelowMinimum() {
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(80, totalWidth: 1200), 220)
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(0, totalWidth: 1200), 220)
+    }
+
+    func testLeftWidthClampedAboveLetterFloor() {
+        // 1200 − 360 = 840 max list width; dragging past it holds 840.
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(1000, totalWidth: 1200), 840)
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(841, totalWidth: 1200), 840)
+    }
+
+    func testLeftWidthPassesThroughInBounds() {
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(280, totalWidth: 1200), 280)
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(500, totalWidth: 1200), 500)
+    }
+
+    func testLeftWidthWhenWindowCannotHonorBothFloors() {
+        // Between the breakpoint (720) and 220 + 360 = 580… the wide
+        // branch only runs ≥ 720, so both floors always fit; but a
+        // pathological total just at the breakpoint still honors the
+        // letter floor first: max list = 720 − 360 = 360.
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(280, totalWidth: 720), 280)
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(650, totalWidth: 720), 360)
+    }
+
+    // MARK: - Stacked-mode clamp (M10 values, unchanged)
+
+    func testTopHeightClamped() {
+        XCTAssertEqual(PagesSplitGeometry.clampedTopHeight(20, availableHeight: 800), 90)
+        // 800 − 120 = 680 max; dragging past holds 680.
+        XCTAssertEqual(PagesSplitGeometry.clampedTopHeight(750, availableHeight: 800), 680)
+        XCTAssertEqual(PagesSplitGeometry.clampedTopHeight(200, availableHeight: 800), 200)
+    }
+
+    func testTopHeightFloorWinsWhenHeightTooSmall() {
+        // A tiny available height still returns the 90 floor, never a
+        // negative or letter-less layout.
+        XCTAssertEqual(PagesSplitGeometry.clampedTopHeight(200, availableHeight: 100), 90)
+        XCTAssertEqual(PagesSplitGeometry.clampedTopHeight(200, availableHeight: 0), 90)
+    }
+
+    // MARK: - Independence
+
+    func testTopHeightIndependentOfLeftWidth() {
+        // The two states never write each other: clamping one leaves
+        // the other's clamp rule untouched (no shared mutable bound).
+        let top = PagesSplitGeometry.clampedTopHeight(200, availableHeight: 800)
+        let left = PagesSplitGeometry.clampedLeftWidth(280, totalWidth: 1200)
+        XCTAssertEqual(top, 200)
+        XCTAssertEqual(left, 280)
+        // Setting a wide ratio does not alter the stacked rule and
+        // vice versa — verified by re-deriving each from raw values.
+        XCTAssertEqual(PagesSplitGeometry.clampedTopHeight(200, availableHeight: 800), top)
+        XCTAssertEqual(PagesSplitGeometry.clampedLeftWidth(280, totalWidth: 1200), left)
+    }
+
+    func testDefaultsMatchIssueSpec() {
+        XCTAssertEqual(PagesSplitGeometry.defaultLeftWidth, 280, "~280 default list width")
+        XCTAssertEqual(PagesSplitGeometry.wideBreakpoint, 720, "720 breakpoint")
+        XCTAssertEqual(PagesSplitGeometry.defaultTopHeight, 200, "M10 default stacked height")
+    }
+}

--- a/Tests/ContractTests/RecipesMailboxTests.swift
+++ b/Tests/ContractTests/RecipesMailboxTests.swift
@@ -124,6 +124,12 @@ final class RecipesMailboxTests: XCTestCase {
         let recipes = LocalPlayGraph.recipes(from: pages, graph: mixed)
         XCTAssertEqual(recipes.map(\.id), ["soup", "bread"], "graph order, markdown pages excluded")
         XCTAssertEqual(recipes.count, 2)
+        // #296: the row carries the ingredient count; an empty recipe
+        // still lists as 0, never dropped.
+        XCTAssertEqual(recipes[0].ingredientCount, 2)
+        XCTAssertEqual(recipes[1].ingredientCount, 0)
+        // Pages rows on other surfaces never carry it.
+        XCTAssertNil(pages.first { $0.id == "index" }?.ingredientCount)
     }
 
     func testRecipesListEmptyWithoutGraphOrFacet() {

--- a/Tests/ContractTests/RecipesMailboxTests.swift
+++ b/Tests/ContractTests/RecipesMailboxTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+
+/// #296 — Recipes mailbox: the conditional sidebar row (≥1 graph node
+/// with a `recipe` facet), the list derivation, and the M13-0
+/// persistence rule for the new token.
+final class RecipesMailboxTests: XCTestCase {
+    private func node(
+        index: Int,
+        id: String,
+        role: PageRole,
+        parent: String?,
+        title: String,
+        recipe: CookRecipe? = nil
+    ) -> GraphNode {
+        GraphNode(
+            index: index,
+            id: id,
+            sourcePath: id + ".md",
+            role: role,
+            parent: parent,
+            parentIndex: nil,
+            title: title,
+            status: "published",
+            tags: [],
+            recipe: recipe
+        )
+    }
+
+    private func graph(nodes: [GraphNode]) -> Graph {
+        Graph(
+            schemaVersion: "0.4.0",
+            frozen: true,
+            nodes: nodes,
+            edges: [],
+            reverseIndex: [],
+            nav: []
+        )
+    }
+
+    private let soup = CookRecipe(
+        ingredients: [
+            CookIngredient(name: "water", quantity: CookQuantity(amount: "2", unit: "cups")),
+            CookIngredient(name: "salt", quantity: CookQuantity(amount: "1", unit: "pinch")),
+        ],
+        cookware: [],
+        timers: []
+    )
+
+    private var localItem: SourceItem {
+        SourceItem.local(LocalSource(
+            id: SourceID(),
+            title: "Kitchen",
+            bookmarkData: Data([1, 2, 3]),
+            displayPath: "/tmp/kitchen",
+            isAvailable: true
+        ))
+    }
+
+    // MARK: - Conditional sidebar row
+
+    func testRecipesMailboxOnlyWhenGraphHasRecipeFacet() {
+        let cookGraph = graph(nodes: [
+            node(index: 0, id: "soup", role: .trunk, parent: nil, title: "Soup", recipe: soup),
+        ])
+        XCTAssertTrue(
+            WorkspaceMailbox.all(for: localItem, graph: cookGraph)
+                .contains(WorkspaceMailbox.recipes),
+            "≥1 node with recipe != nil admits the row"
+        )
+
+        // An empty-ingredient recipe still counts (the row shows "0 ingredients").
+        let emptyRecipeGraph = graph(nodes: [
+            node(index: 0, id: "soup", role: .trunk, parent: nil, title: "Soup", recipe: CookRecipe()),
+        ])
+        XCTAssertTrue(
+            WorkspaceMailbox.all(for: localItem, graph: emptyRecipeGraph)
+                .contains(WorkspaceMailbox.recipes)
+        )
+    }
+
+    func testRecipesMailboxAbsentForMarkdownOnlySource() {
+        // The happy fixture shape: three markdown nodes, no recipe facet.
+        let markdownGraph = graph(nodes: [
+            node(index: 0, id: "index", role: .trunk, parent: nil, title: "Home"),
+            node(index: 1, id: "guides", role: .trunk, parent: nil, title: "Guides"),
+            node(index: 2, id: "guides/intro", role: .satellite, parent: "guides", title: "Intro"),
+        ])
+        XCTAssertFalse(
+            WorkspaceMailbox.all(for: localItem, graph: markdownGraph)
+                .contains(WorkspaceMailbox.recipes)
+        )
+
+        // No graph yet (unbuilt source): no Recipes row, never synthesized.
+        XCTAssertFalse(
+            WorkspaceMailbox.all(for: localItem, graph: nil)
+                .contains(WorkspaceMailbox.recipes)
+        )
+    }
+
+    func testRecipesRowAppendedAfterCanonicalRows() {
+        let cookGraph = graph(nodes: [
+            node(index: 0, id: "soup", role: .trunk, parent: nil, title: "Soup", recipe: soup),
+        ])
+        let rows = WorkspaceMailbox.all(for: localItem, graph: cookGraph)
+        XCTAssertEqual(rows.dropLast(), WorkspaceMailbox.all)
+        XCTAssertEqual(rows.last, WorkspaceMailbox.recipes)
+    }
+
+    func testRecipesRowNeverInBaseAllSet() {
+        // `all` stays the M10 set — recipes is conditional, like the
+        // github-only rows, not unconditional.
+        XCTAssertFalse(WorkspaceMailbox.all.contains(WorkspaceMailbox.recipes))
+    }
+
+    // MARK: - List derivation
+
+    func testRecipesListFiltersGraphNodesByRecipeFacet() {
+        let mixed = graph(nodes: [
+            node(index: 0, id: "index", role: .trunk, parent: nil, title: "Home"),
+            node(index: 1, id: "soup", role: .trunk, parent: nil, title: "Soup", recipe: soup),
+            node(index: 2, id: "bread", role: .satellite, parent: "soup", title: "Bread", recipe: CookRecipe()),
+        ])
+        let pages = LocalPlayGraph.pages(from: mixed)
+        let recipes = LocalPlayGraph.recipes(from: pages, graph: mixed)
+        XCTAssertEqual(recipes.map(\.id), ["soup", "bread"], "graph order, markdown pages excluded")
+        XCTAssertEqual(recipes.count, 2)
+    }
+
+    func testRecipesListEmptyWithoutGraphOrFacet() {
+        let markdown = graph(nodes: [
+            node(index: 0, id: "index", role: .trunk, parent: nil, title: "Home"),
+        ])
+        XCTAssertEqual(LocalPlayGraph.recipes(from: LocalPlayGraph.pages(from: markdown), graph: markdown), [])
+        XCTAssertEqual(LocalPlayGraph.recipes(from: [], graph: nil), [], "no graph yet → no synthesized rows")
+    }
+
+    // MARK: - Display + persistence (M13-0 parity)
+
+    func testRecipesMailboxDisplayNameAndSymbol() {
+        XCTAssertEqual(WorkspaceMailbox.displayName(WorkspaceMailbox.recipes), "Recipes")
+        XCTAssertEqual(WorkspaceMailbox.symbolName(WorkspaceMailbox.recipes), "fork.knife")
+    }
+
+    func testUnknownRecipesMailboxSurvivesRelaunch() {
+        // A persisted `mailbox = "recipes"` round-trips through
+        // WorkspaceSelection untouched — never coerced to "pages".
+        let stored = WorkspaceSelection(
+            sourceID: SourceID(),
+            mailbox: WorkspaceMailbox.recipes,
+            noun: nil
+        )
+        let data = try! JSONEncoder().encode(stored)
+        let decoded = try! JSONDecoder().decode(WorkspaceSelection.self, from: data)
+        XCTAssertEqual(decoded.mailbox, WorkspaceMailbox.recipes)
+        XCTAssertEqual(WorkspaceMailbox.display(decoded.mailbox), WorkspaceMailbox.recipes)
+    }
+}

--- a/Tests/ContractTests/RecipesMailboxTests.swift
+++ b/Tests/ContractTests/RecipesMailboxTests.swift
@@ -147,7 +147,7 @@ final class RecipesMailboxTests: XCTestCase {
         XCTAssertEqual(WorkspaceMailbox.symbolName(WorkspaceMailbox.recipes), "fork.knife")
     }
 
-    func testUnknownRecipesMailboxSurvivesRelaunch() {
+    func testUnknownRecipesMailboxSurvivesRelaunch() throws {
         // A persisted `mailbox = "recipes"` round-trips through
         // WorkspaceSelection untouched — never coerced to "pages".
         let stored = WorkspaceSelection(
@@ -155,8 +155,8 @@ final class RecipesMailboxTests: XCTestCase {
             mailbox: WorkspaceMailbox.recipes,
             noun: nil
         )
-        let data = try! JSONEncoder().encode(stored)
-        let decoded = try! JSONDecoder().decode(WorkspaceSelection.self, from: data)
+        let data = try JSONEncoder().encode(stored)
+        let decoded = try JSONDecoder().decode(WorkspaceSelection.self, from: data)
         XCTAssertEqual(decoded.mailbox, WorkspaceMailbox.recipes)
         XCTAssertEqual(WorkspaceMailbox.display(decoded.mailbox), WorkspaceMailbox.recipes)
     }

--- a/Tests/ContractTests/ThemeBrowserTests.swift
+++ b/Tests/ContractTests/ThemeBrowserTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+
+/// #298 — theme browser: order preservation (local first), Default
+/// clears, the write path is the same `target.theme` string, the
+/// first-class count is pinned, and the tile document is safe HTML.
+final class ThemeBrowserTests: XCTestCase {
+    private func makeWorkspace(
+        localThemes: [String],
+        withCSS css: String? = nil
+    ) throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("theme-browser-\(UUID().uuidString)")
+        for theme in localThemes {
+            let dir = tempDir.appendingPathComponent("themes/\(theme)", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            if let css {
+                try css.write(
+                    to: dir.appendingPathComponent("sample.css"),
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+        }
+        return tempDir
+    }
+
+    func testThemeBrowserListsLocalFirst() throws {
+        let root = try makeWorkspace(localThemes: ["zeta-custom", "alpha-custom"])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let all = ThemeCatalog.allThemes(for: root)
+        XCTAssertEqual(Array(all.prefix(2)), ["alpha-custom", "zeta-custom"], "local de-duped, sorted, before first-class")
+        XCTAssertTrue(all.contains("boris"))
+        XCTAssertEqual(all.count, 22, "2 local + 20 first-class, de-duped")
+    }
+
+    func testLocalThemeShadowingFirstClassIsNotDuplicated() throws {
+        // A local "boris" dir shadows the first-class name; allThemes
+        // de-dupes — the browser shows one tile.
+        let root = try makeWorkspace(localThemes: ["boris"])
+        defer { try? FileManager.default.removeItem(at: root) }
+        XCTAssertEqual(ThemeCatalog.allThemes(for: root).filter { $0 == "boris" }.count, 1)
+    }
+
+    func testDefaultTileClearsTheme() {
+        // The browser's Default tile writes nil — the same value the
+        // flat Picker wrote for "". Encoding a target with theme nil
+        // round-trips it as absent, never as the empty string.
+        let target = PublicationTarget(name: "public", output: "dist", public: true)
+        XCTAssertNil(target.theme, "Default tile writes nil, not \"\"")
+        var cleared = target
+        cleared.theme = nil
+        XCTAssertNil(cleared.theme)
+    }
+
+    func testSelectingTileWritesSameBindingAsPicker() throws {
+        // The browser writes `target.theme` via the same memberwise
+        // field; the profile save path is unchanged. Round-trip the
+        // target through JSON to prove the wire value is identical.
+        let chosen = PublicationTarget(
+            name: "public",
+            output: "dist",
+            public: true,
+            theme: "cards"
+        )
+        let data = try JSONEncoder().encode(chosen)
+        let decoded = try JSONDecoder().decode(PublicationTarget.self, from: data)
+        XCTAssertEqual(decoded.theme, "cards", "the same string the flat Picker wrote")
+    }
+
+    func testFirstClassThemeCountUnchanged() {
+        // Fails loud if the pinned kit genuinely added one — verify
+        // against the kit, then bump (issue #298 contract).
+        XCTAssertEqual(ThemeCatalog.firstClassThemes.count, 20)
+        XCTAssertEqual(ThemeCatalog.firstClassThemes.first, "archive")
+        XCTAssertEqual(ThemeCatalog.firstClassThemes.last, "tokens")
+    }
+
+    // MARK: - Tile document
+
+    func testTileDocumentInlinesCollectedCSS() throws {
+        let root = try makeWorkspace(
+            localThemes: ["styled"],
+            withCSS: "body { font-family: serif; } h1 { color: teal; }"
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let css = ThemePreviewDocument.css(for: "styled", workspaceRoot: root)
+        XCTAssertNotNil(css, "local theme CSS resolves through ComposeThemeCSS.collect")
+        let html = ThemePreviewDocument.html(sampleCSS: css)
+        XCTAssertTrue(html.contains("font-family: serif"), "collected CSS is inlined verbatim")
+        XCTAssertTrue(html.contains("Theme Sample"), "the fixed sample fragment renders")
+    }
+
+    func testTileDocumentFallsBackWhenCSSMissing() {
+        // A first-class theme with no CSS in this workspace: neutral
+        // fallback + the theme name — never blank, never an error.
+        let css = ThemePreviewDocument.css(for: "press", workspaceRoot: nil)
+        XCTAssertNil(css)
+        let html = ThemePreviewDocument.html(sampleCSS: css)
+        XCTAssertTrue(html.contains(ThemePreviewDocument.fallbackCSS))
+        XCTAssertTrue(html.contains("Theme Sample"))
+    }
+
+    func testTileDocumentNeutralizesStyleEscape() {
+        // A hostile stylesheet cannot escape the style element — the
+        // ComposePreviewDocument sanitize contract, honored by tiles.
+        let hostile = "body { content: '</style><script>alert(1)</script>' }"
+        let html = ThemePreviewDocument.html(sampleCSS: hostile)
+        XCTAssertFalse(html.contains("</style><script>"), "style escape is neutralized")
+    }
+
+    func testNonThemeDirectoryShowsFallbackNotError() throws {
+        // themes/ containing a non-theme subdirectory (skipped as hidden
+        // by the catalog; a non-hidden one with no CSS still renders the
+        // fallback tile, never an error.
+        let root = try makeWorkspace(localThemes: ["not-a-theme"])
+        defer { try? FileManager.default.removeItem(at: root) }
+        XCTAssertEqual(ThemeCatalog.discoverLocalThemes(in: root), ["not-a-theme"])
+        let css = ThemePreviewDocument.css(for: "not-a-theme", workspaceRoot: root)
+        let html = ThemePreviewDocument.html(sampleCSS: css)
+        XCTAssertTrue(html.contains("Theme Sample"), "no crash, no blank tile")
+    }
+}

--- a/docs/help.md
+++ b/docs/help.md
@@ -22,6 +22,7 @@ Accounts live in Settings. The main window is mailboxes, a reading place, and a 
 - **Publish**: Manage publication targets, including Standard.site and Nostr publisher configurations.
 - **Plan & Activity**: Review publication build plans and coordinator job run histories.
 - **Content Audit**: Run structure, integrity, and relation checks across the publication graph (such as unreferenced pages or missing parents).
+- **Recipes**: Appears only when the source's graph carries Cooklang recipes (a `.cook` corpus). Lists every recipe node; selecting one shows the page as a letter, and the drawer's Recipe Scale section scales it. Markdown-only sources never see this row.
 - **Remote (GitHub)**: Displays working copy status, current branch, ahead/behind commit counts relative to upstream, and provides Sync, Commit, and Push actions.
 - **Issues (GitHub)**: Lists open GitHub issues for the repository with links to view and manage them in the browser.
 - **Pull Requests (GitHub)**: Lists open pull requests with draft status and branch heads, and provides a `New Pull Request…` toolbar action to push upstream and open the PR authoring flow.


### PR DESCRIPTION
Closes #297, closes #296, closes #298 (the three ROADMAP §3 "Later" issues).

One concern per commit; each section below maps to its issue's must-land list.

## #297 — width-adaptive Pages split (`808c775`)

- `pagesSplit` branches on `PagesSplitGeometry.isWide(width:)` — `width >= 720` renders the `HStack` (list left, vertical drag handle, letter right); below stays the M10 `VStack`, byte-for-byte behavior (the M10 body was factored verbatim into `horizontalSeparator`).
- Pure-math clamp rules live in `PagesSplitGeometry` so ContractTests pin them without a window: stacked `topHeight` keeps the M10 bounds (≥90, letter ≥120); wide `leftWidth` ∈ [220, width−360]. `leftWidth` (default 280) and `topHeight` are independent `@State`s — the two ratios never write each other.
- Same two child views in both branches; one `GeometryReader`; `ReadingPane` untouched — `letterIdentity` (and the SSE channel) never changes on reflow, so crossing the breakpoint reflows live with no re-select and no letter reload.
- No `MainWindow` growth, no `HSplitView`/`NavigationSplitView` re-nest, no Settings/profile key (view-local chrome).
- Both drag handles now carry the accessibility label "List and letter separator; drag to resize" (M10's had none — #297 asked for both while here).
- Tests: `PagesSplitGeometryTests` (11) — branch rule (incl. exact-720 no-oscillation), both clamp regimes, independence, defaults.

## #296 — Recipes mailbox (`7a6fd76` + `b791f8a`)

- `WorkspaceMailbox.recipes` token: displayName "Recipes", symbol `fork.knife`. Base `all` set unchanged (6 tokens); the new `all(for:graph:)` overload appends `recipes` **only when the cached graph has ≥1 node with a non-nil `recipe` facet** — markdown-only sources never see the row; keying is graph-facet-only, never `profile.input_format` (a mixed corpus is valid); an unbuilt graph shows nothing until the first build (never synthesized).
- The sidebar row reads `store.cachedGraph(for:)` — the same cached-only, no-disk read Pages trunks use. GitHub sources get the row too (their working copy runs through the same `LocalPlay` graph pipeline) — per the issue's "the source graph", not local-only.
- The reading surface reuses `mailboxContent` → the same `pagesSplit` path: selecting a row selects the page noun, so the letter behaves unchanged and the drawer's `Recipe Scale` section still scales on factor change. **No second `Process`** — the list is a pure view over `graph.json` (the same artifact the inspector reads).
- Rows carry the ingredient count from the facet ("N ingredient(s)"; an empty recipe still lists as "0"). **Servings** is not derivable from the IR — verified against a real boris 0.8.2 build of `Stunts/cook-one`: `graph.json` and `recipe-scale` output carry no servings field; frontmatter `servings` stays in the `.cook` source. The issue's "servings if present" resolves to not-present, so the row shows title + id + count.
- A persisted `mailbox = "recipes"` round-trips un-coerced (M13-0 rule, pinned by test). `help.md` gains the Recipes bullet; `HelpAuditTests` enumerates the token. `Inspectable` has a `.recipes` case (page noun → Page section incl. Recipe Scale; no noun → profile+execution).
- `Sources/Engine/` and `Sources/App/` untouched.
- Tests: `RecipesMailboxTests` (8) — conditional row, mixed corpus, absent-for-markdown-only, graph-order list derivation, display/symbol, persistence.

## #298 — visual theme browser (`b128dd0`)

- `ThemeBrowserView`: a sheet grid (`LazyVGrid`, adaptive 200–280pt tiles) of preview tiles — Default first (writes `nil`), then `ThemeCatalog.allThemes` order (local first, de-duped, then the 20 first-class).
- Each tile is a `ThemeTileWebView` — sandboxed `WKWebView` (non-persistent store, `loadHTMLString` + nil baseURL, single load, immutable) rendering a fixed sample fragment (h1+p+a+ul) styled by the theme's CSS, collected through the **existing** `ComposeThemeCSS.collect(workspaceRoot:themePath: "themes/<name>")` — no second resolver, no Swift HTML/CSS engine.
- Missing CSS → `ComposePreviewDocument.fallbackCSS` neutral sample (never blank, never an error); `</style` escapes neutralized via the existing `ComposePreviewDocument.sanitize`. Hostile-CSS pinned by test.
- `ProfileSection`: the flat theme `Picker` is replaced by a plain button (current theme or "Default", paintpalette glyph) opening the browser via `sheet(item:)`; selecting a tile writes the **same** `fields.targets[index].theme` field the Picker wrote (`nil` for Default — identical stored value, JSON round-trip pinned). Save path unchanged (explicit save → `boris.json`).
- `TargetSection`: the "Available Themes" comma blob becomes a browse-only button (`onSelect` no-op — this section reads the selected target; writes stay in ProfileSection).
- `firstClassThemes` untouched (20, pinned). No writes anywhere under `themes/`, no theme authoring (ROADMAP §3 boundary), `MainWindow` untouched.
- Tests: `ThemeBrowserTests` (9) — local-first order, dedup, Default-clears-nil, same-binding write, count=20, CSS inlining, fallback, style-escape neutralization, non-theme dir.

## Verification

- `make generate` clean; `SKIP_EMBED_BORIS=1` app target **BUILD SUCCEEDED**.
- `SKIP_EMBED_BORIS=1` ContractTests: **546 executed, 0 failures, 5 skipped** — reproduced on three consecutive full runs. New suites: PagesSplitGeometryTests 11/11, RecipesMailboxTests 8/8, ThemeBrowserTests 9/9.
- Regression suites (WorkspaceSelection, GithubIssues, HelpAudit, InspectorSnapshot) all green — old shapes pinned intact.
- An independent adversarial gate (pre-PR) falsified every claimed fact above against the tree and the three issues: verdict **PASS** (0 blockers / 0 majors / 1 minor / 3 nits); the one minor — the `Inspectable.recipes` case landing in the #298 commit rather than the #296 commit — is a commit-hygiene note only, folded here if a rebase ever happens for other reasons.
