### PR TITLE
Bundle boris-editor + editor-ui and oliver with the app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,14 @@ SOLIPSIST_BORIS_BIN=SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin/b
   make run-spike
 ```
 
+Engine checkouts (boris + oliver) resolve via `BORIS_REPO_DIR` /
+`OLIVER_REPO_DIR` — required from worktrees — else derived from
+`SOLIPSIST_BORIS_BIN` inside a checkout, else `../boris` / `../oliver`
+siblings. `make build` bundles boris, boris-editor + editor-ui, and oliver
+into `Resources/`; a missing piece fails the build (`SKIP_EMBED_BORIS=1`
+opts out). Overrides: `SOLIPSIST_BORIS_EDITOR_BIN`,
+`SOLIPSIST_EDITOR_UI_DIR`, `SOLIPSIST_OLIVER_BIN`.
+
 Never hand-edit `Solipsist.xcodeproj` — edit `Project.yml`.
 
 ## Git

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # Solipsist — convenience targets.
 #
 # XcodeGen is vendored into .tools/ (project-local, no system install).
-# The Boris engine checkout must exist at ../boris (see scripts/embed-boris.sh).
+# Engine sources: boris + oliver checkouts. The embed script resolves them via
+# BORIS_REPO_DIR / OLIVER_REPO_DIR (required from worktrees), derives the boris
+# repo from SOLIPSIST_BORIS_BIN inside a checkout, then sibling fallbacks
+# (see scripts/embed-boris.sh). It bundles boris, boris-editor + editor-ui,
+# and oliver into Resources/ — a missing piece fails the build.
 
 XCODEGEN := .tools/xcodegen/xcodegen/bin/xcodegen
 PROJECT  := Solipsist.xcodeproj

--- a/Sources/Companions/Editor/EditorServerFactory.swift
+++ b/Sources/Companions/Editor/EditorServerFactory.swift
@@ -25,6 +25,7 @@ enum EditorServerFactory {
         return try engine.editorStart(
             editorBinary: editorBinary,
             workingDirectory: workingDirectory,
+            uiDir: findEditorUiDir(relativeTo: engine.binaryURL),
             port: 0
         )
     }
@@ -56,6 +57,38 @@ enum EditorServerFactory {
         for relative in devCandidates {
             let url = cwd.appendingPathComponent(relative).standardizedFileURL
             if FileManager.default.isExecutableFile(atPath: url.path) { return url }
+        }
+
+        return nil
+    }
+
+    /// Locates the compiled editor UI dir (`index.html` + `assets/`) backing
+    /// `--ui-dir`. Without it the host starts but serves 404s: its default
+    /// (`editor/ui/dist`, CWD-relative) never exists under a project root.
+    static func findEditorUiDir(
+        relativeTo engineBinary: URL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL? {
+        let fileManager = FileManager.default
+
+        func isUiDir(_ url: URL) -> Bool {
+            var isDir: ObjCBool = false
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
+                return false
+            }
+            return fileManager.fileExists(atPath: url.appendingPathComponent("index.html").path)
+        }
+
+        if let env = environment["SOLIPSIST_EDITOR_UI_DIR"], !env.isEmpty {
+            let url = URL(fileURLWithPath: env)
+            if isUiDir(url) { return url }
+        }
+
+        let sibling = engineBinary.deletingLastPathComponent().appendingPathComponent("editor-ui")
+        if isUiDir(sibling) { return sibling }
+
+        if let bundled = Bundle.main.url(forResource: "editor-ui", withExtension: nil) {
+            if isUiDir(bundled) { return bundled }
         }
 
         return nil

--- a/Tests/ContractTests/EngineBinaryLocatorTests.swift
+++ b/Tests/ContractTests/EngineBinaryLocatorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 
 final class EngineBinaryLocatorTests: XCTestCase {
@@ -68,5 +69,84 @@ final class EngineBinaryLocatorTests: XCTestCase {
         EngineBinaryDefaults.removeLegacyCustomPaths(defaults: defaults)
 
         XCTAssertEqual(defaults.string(forKey: "someUnrelatedKey"), "keep me")
+    }
+
+    // MARK: - Bundled editor UI + oliver sibling resolution
+
+    private func makeExecutable(at url: URL) -> Bool {
+        FileManager.default.createFile(atPath: url.path, contents: Data())
+        do {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: url.path
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func testEditorUiDirSiblingOfEngineWinsWithoutEnv() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let uiDir = root.appendingPathComponent("editor-ui")
+        try FileManager.default.createDirectory(at: uiDir, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        FileManager.default.createFile(
+            atPath: uiDir.appendingPathComponent("index.html").path,
+            contents: Data()
+        )
+
+        let url = EditorServerFactory.findEditorUiDir(
+            relativeTo: root.appendingPathComponent("boris"),
+            environment: [:]
+        )
+        XCTAssertEqual(url?.path, uiDir.path)
+    }
+
+    func testEditorUiDirEnvironmentOverrideWins() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        FileManager.default.createFile(
+            atPath: root.appendingPathComponent("index.html").path,
+            contents: Data()
+        )
+
+        let url = EditorServerFactory.findEditorUiDir(
+            relativeTo: URL(fileURLWithPath: "/usr/bin/boris"),
+            environment: ["SOLIPSIST_EDITOR_UI_DIR": root.path]
+        )
+        XCTAssertEqual(url?.path, root.path)
+    }
+
+    func testEditorUiDirNilWhenAbsent() {
+        let url = EditorServerFactory.findEditorUiDir(
+            relativeTo: URL(fileURLWithPath: "/nonexistent-dir-xyz/boris"),
+            environment: [:]
+        )
+        XCTAssertNil(url)
+    }
+
+    func testOliverSiblingOfEngineBinaryResolves() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let oliver = root.appendingPathComponent("oliver")
+        XCTAssertTrue(makeExecutable(at: oliver))
+
+        let url = OliverBinary.locate(
+            environment: [:],
+            borisBinary: root.appendingPathComponent("boris")
+        )
+        XCTAssertEqual(url?.path, oliver.path)
     }
 }

--- a/docs/issues/bundle-editor-oliver.md
+++ b/docs/issues/bundle-editor-oliver.md
@@ -1,0 +1,148 @@
+# Bundle boris-editor (+ UI) and oliver with the app
+
+**Track:** Engine bundling / release honesty
+**Milestone:** post-M18 — follows the engine-settings-truth residual (#292)
+**Issue:** file on `drawmeanelephant/solipsist` (next number)
+**Lane:** `scripts/embed-boris.sh` + `Sources/Companions/Editor/EditorServerFactory.swift` + `Sources/Engine/OliverBinary.swift` (+ release gate)
+
+## Problem
+
+A fresh `Solipsist.app` ships exactly one engine artifact —
+`Contents/Resources/boris`. The two processes the app actually shells out to
+besides it are silently absent:
+
+1. **`boris-editor`** (M6 author companion, A14): `EditorServerFactory.launch`
+   throws `editorBinaryNotFound` unless `SOLIPSIST_BORIS_EDITOR_BIN` is set or
+   a dev checkout happens to sit at a CWD-relative path. The Settings pane
+   ("Engine") then reports the editor host as missing on a clean machine.
+2. **The editor UI** (`editor/ui/dist`, compiled Svelte): even with a binary,
+   nothing passes `--ui-dir`. `boris-editor` defaults to `editor/ui/dist`
+   relative to its CWD — and Solipsist sets CWD to the user's *project root*,
+   where that path never exists. Result: the host starts, the URL connects,
+   and every `/` + `/assets/*` request 404s.
+3. **`oliver`** (compose preview, `oliver render --from …`): `OliverBinary`
+   falls through bundle → sibling → dev-checkout candidates and returns nil
+   on a clean machine; compose preview reports "oliver renderer not found".
+
+`scripts/embed-boris.sh` already *intends* to bundle both (companion loop +
+`bundle_oliver`), but three gaps defeat it:
+
+- The companion search roots are `$SRCROOT/../boris`-relative
+  (`${BORIS_REPO_DIR:-$SRCROOT/../boris}/zig-out/bin`). From a worktree
+  (`…/.t3/worktrees/solipsist/…`) or with `SOLIPSIST_BORIS_BIN` pointing at a
+  real checkout elsewhere, that directory does not exist — companions are
+  skipped with no warning. `BORIS_REPO_DIR` is read but never documented in
+  `AGENTS.md` / `Makefile`, so nobody sets it.
+- `zig build` at the boris root does **not** produce `boris-editor` (separate
+  `editor/build.zig`; never built in this flow) and never builds
+  `editor/ui/dist` (needs `npm ci && npm run build` in `editor/ui`). There is
+  nothing to bundle even when the directory resolves.
+- Same worktree problem for oliver: candidates are `$SRCROOT/../oliver`-style
+  paths; the real checkout (`/Users/tbuddy/t3/swift/oliver`) is never
+  consulted, and `SOLIPSIST_OLIVER_BIN` is the only override.
+
+## Verified current state
+
+- `scripts/embed-boris.sh:115-147` — companion loop copies `boris-editor`,
+  `boris-package`, `boris-source-rag`, `boris-content-audit` from kit dirs or
+  `${BORIS_REPO_DIR:-$SRCROOT/../boris}/zig-out/bin`. `boris/zig-out/bin/`
+  today holds `boris`, `boris-job-runner`, `boris-package`,
+  `boris-source-rag` (+ wasms) — **no `boris-editor`**.
+- `scripts/embed-boris.sh:149-196` — `find_oliver` / `bundle_oliver`;
+  absence is a notice, not a failure.
+- `Sources/Companions/Editor/EditorServerFactory.swift:32-62` — resolution:
+  env → sibling-of-engine → bundle → CWD-relative dev candidates. No UI dir
+  anywhere.
+- `Sources/Engine/EditorServer.swift:34-56` — `uiDir` is plumbed to
+  `--ui-dir` but defaults to nil and no caller passes it.
+- `Sources/Engine/BorisEngine.swift:604-618` — `editorStart(..., uiDir: nil,
+  ...)`.
+- `Sources/Engine/OliverBinary.swift:12-50` — env → `Resources/oliver` →
+  sibling-of-boris → CWD-relative dev candidates.
+- boris `editor/src/main.zig:21` — `--ui-dir` defaults to `editor/ui/dist`
+  (CWD-relative); `server.zig:657-662` serves `/` + `/assets/*` from it.
+- A Debug build from this worktree produces
+  `Solipsist.app/Contents/Resources/{boris,AppIcon.icns,Assets.car,help.md}`
+  — no `boris-editor`, no `oliver`, no UI dir. (Observed 2026-09-06.)
+
+## Scope
+
+### Must land
+
+- `embed-boris.sh` bundles, on every non-skipped build:
+  - `boris-editor` into `Resources/` (same sign path as `boris`);
+  - the compiled editor UI (`editor/ui/dist`) into `Resources/` (e.g.
+    `Resources/editor-ui/`), preserving the `index.html` + `assets/` layout
+    the host serves;
+  - `oliver` into `Resources/` (same sign path).
+- The script **fails the build** when any of the three is missing (same
+  posture as the engine: a release without them is a silent failure), except
+  under the existing `SKIP_EMBED_BORIS=1` opt-out.
+- Lookup honours explicit env overrides first:
+  `SOLIPSIST_BORIS_EDITOR_BIN`, `SOLIPSIST_EDITOR_UI_DIR`,
+  `SOLIPSIST_OLIVER_BIN`, then `BORIS_REPO_DIR` /
+  `OLIVER_REPO_DIR` checkouts (document both in `AGENTS.md` + `Makefile`
+  comment), then the existing kit/sibling fallbacks.
+- When the boris checkout has no built editor, the script builds it
+  (`zig build --build-file editor/build.zig`, in `BORIS_REPO_DIR/editor`) —
+  mirroring how it already builds the engine. UI `dist/` is **not**
+  npm-built by the script (needs node + network); a missing `dist/` is a
+  hard error telling the user to run `npm ci && npm run build` in
+  `editor/ui`.
+- Runtime: `EditorServerFactory.launch` resolves the bundled UI dir
+  (`Bundle.main.url(forResource: "editor-ui" …)`, then
+  `SOLIPSIST_EDITOR_UI_DIR`) and passes it as `uiDir`, so `--ui-dir` points
+  at the bundle. `OliverBinary` / editor-binary resolution already checks
+  `Resources/` first — no change needed there beyond the bundle existing.
+- Settings Engine pane reports all three (it already renders resolved
+  paths — verify green on a clean `make build` with no env overrides).
+
+### Nice-to-have (not gate)
+
+- Also bundle `boris-job-runner` (ships in `zig-out/bin/`, currently
+  ignored by the companion loop).
+- `boris --version` / `boris-editor --version` / `oliver --version`
+  provenance line in the build log.
+- Release-CI wiring for the new env vars (discrete-arch editor/oliver).
+
+### Must not land
+
+- Reimplementing Boris/editor/Oliver semantics in Swift (subprocess
+  boundary stays).
+- Patching the boris or oliver repos from here (build them, never edit).
+- npm-installing the editor UI as part of `make build` (networked,
+  slow, surprising — error with instructions instead).
+- Changing the `SKIP_EMBED_BORIS=1` CI compile-job escape hatch.
+
+## Gate
+
+Clean checkout, no engine env vars set:
+`make build` succeeds → `Contents/Resources/` contains `boris`,
+`boris-editor`, `oliver`, `editor-ui/{index.html,assets/…}` → launch the app
+with a fixture project → Editor companion connects and renders the shell
+(no 404s) → compose preview renders via bundled oliver → Settings/Engine
+shows all three binaries present → `make test` + `make lint` green.
+
+## Tests
+
+- Embed-script level: fixture `BORIS_REPO_DIR`/`OLIVER_REPO_DIR` with stub
+  binaries + stub `editor-ui/` → run `embed-boris.sh SRCROOT DEST` →
+  assert all artifacts land executable (new `ContractTests` case or a
+  `scripts/` self-test — whichever fits the harness; keep it hermetic, no
+  network, no real builds).
+- `testEditorFactoryPassesBundledUiDir` — bundled `editor-ui` present →
+  launch args contain `--ui-dir <bundle path>`.
+- `testOliverResolvesToBundledBinary` — `Resources/oliver` present → located
+  without env vars.
+- Existing `EditorServer` arg test still passes with `uiDir == nil`.
+
+## Edge cases
+
+- `SKIP_EMBED_BORIS=1` (CI compile job): no failure, no bundling — unchanged.
+- Ad-hoc vs release signing: companions + oliver + UI files need no signing,
+  binaries follow the existing `bundle_and_sign` path.
+- `editor/ui/dist` missing in the boris checkout: hard error with the exact
+  `npm ci && npm run build` remediation, not a silent editor-without-UI.
+- Worktree builds (`SRCROOT` not a sibling of checkouts): env vars are the
+  documented path; log the resolved provenance (`embed-boris: bundled
+  boris-editor (provenance: …)`) so misconfig is visible.

--- a/scripts/embed-boris.sh
+++ b/scripts/embed-boris.sh
@@ -14,6 +14,25 @@
 #   3. Existing zig-out in a boris checkout
 #   4. Build from BORIS_REPO_DIR (default: ../boris)
 #
+# boris-editor + editor UI + oliver are bundled alongside boris so the
+# release app ships a working Editor companion and compose preview with no
+# env overrides. Missing pieces FAIL the build (same posture as the engine),
+# except under SKIP_EMBED_BORIS=1.
+#
+# Env overrides (all optional, first match wins within each search):
+#   BORIS_REPO_DIR, OLIVER_REPO_DIR — engine/editor/oliver source checkouts.
+#     Required when SRCROOT is not a sibling of the checkouts (e.g. worktrees);
+#     when unset, the boris repo is derived from SOLIPSIST_BORIS_BIN if it
+#     points inside a checkout's zig-out/bin, then sibling fallbacks.
+#   SOLIPSIST_BORIS_EDITOR_BIN — exact boris-editor binary.
+#   SOLIPSIST_EDITOR_UI_DIR — exact compiled editor UI dir (index.html + assets/).
+#   SOLIPSIST_OLIVER_BIN — exact oliver binary.
+#
+# The editor binary builds from source when the checkout has none
+# (zig build --build-file editor/build.zig). The editor UI is NEVER npm-built
+# here (needs node + network): a missing editor/ui/dist is a hard error with
+# remediation instructions.
+#
 # Oliver (compose preview renderer) is embedded alongside boris so the
 # release app renders previews without SOLIPSIST_OLIVER_BIN. Provenance:
 # oliver is NOT shipped by the boris agent kit — source it from the oliver
@@ -118,6 +137,13 @@ bundle_and_sign() {
     "$SRCROOT/../boris-agent-kit/bin"
     "${BORIS_REPO_DIR:-$SRCROOT/../boris}/zig-out/bin"
   )
+  # Worktree builds: the checkout is rarely $SRCROOT/../boris. Resolve it
+  # the same way the editor/oliver lookups do.
+  local _resolved_repo=""
+  _resolved_repo="$(resolve_boris_repo)" || true
+  if [[ -n "$_resolved_repo" ]]; then
+    comp_candidates+=("$_resolved_repo/zig-out/bin" "$_resolved_repo/editor/zig-out/bin")
+  fi
   local search_index_found=0
   for cdir in "${comp_candidates[@]}"; do
     if [[ -d "$cdir" ]]; then
@@ -144,6 +170,171 @@ bundle_and_sign() {
   fi
 
   bundle_oliver "$sign_identity"
+  bundle_editor "$sign_identity"
+  bundle_editor_ui
+}
+
+# Resolves the boris source checkout: BORIS_REPO_DIR first, then derived
+# from SOLIPSIST_BORIS_BIN when it points inside a checkout's zig-out/bin
+# (worktree builds), then SRCROOT-relative siblings.
+resolve_boris_repo() {
+  if [[ -n "${BORIS_REPO_DIR:-}" && -d "${BORIS_REPO_DIR}" ]]; then
+    echo "${BORIS_REPO_DIR}"
+    return 0
+  fi
+
+  if [[ -n "${SOLIPSIST_BORIS_BIN:-}" ]]; then
+    local bindir
+    bindir="$(dirname "${SOLIPSIST_BORIS_BIN}")"
+    if [[ "$(basename "$bindir")" == "bin" && "$(basename "$(dirname "$bindir")")" == "zig-out" ]]; then
+      local repo
+      repo="$(dirname "$(dirname "$bindir")")"
+      if [[ -f "$repo/build.zig" && -d "$repo/editor" ]]; then
+        echo "$repo"
+        return 0
+      fi
+    fi
+  fi
+
+  local candidates=(
+    "$SRCROOT/../boris"
+    "$SRCROOT/../../boris"
+    "$SRCROOT/../../../boris"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    if [[ -f "$c/build.zig" && -d "$c/editor" ]]; then
+      echo "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Resolves the oliver source checkout: OLIVER_REPO_DIR first, then a sibling
+# of the resolved boris checkout, then SRCROOT-relative siblings.
+resolve_oliver_repo() {
+  if [[ -n "${OLIVER_REPO_DIR:-}" && -d "${OLIVER_REPO_DIR}" ]]; then
+    echo "${OLIVER_REPO_DIR}"
+    return 0
+  fi
+
+  local boris_repo=""
+  boris_repo="$(resolve_boris_repo)" || true
+  local candidates=()
+  if [[ -n "$boris_repo" ]]; then
+    candidates+=("$boris_repo/../oliver")
+  fi
+  candidates+=(
+    "$SRCROOT/../oliver"
+    "$SRCROOT/../../oliver"
+    "$SRCROOT/../../../oliver"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    if [[ -f "$c/build.zig" ]]; then
+      echo "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+find_editor_binary() {
+  if [[ -n "${SOLIPSIST_BORIS_EDITOR_BIN:-}" && -x "${SOLIPSIST_BORIS_EDITOR_BIN}" ]]; then
+    echo "${SOLIPSIST_BORIS_EDITOR_BIN}"
+    return 0
+  fi
+
+  local cdir
+  for cdir in \
+    "$SRCROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/boris-agent-kit/bin" \
+    "$SRCROOT/SUPPORT-NOT-FOR-GITHUB/boris-agent-kit/bin" \
+    "$SRCROOT/../boris-agent-kit/bin" \
+  ; do
+    if [[ -x "$cdir/boris-editor" ]]; then
+      echo "$cdir/boris-editor"
+      return 0
+    fi
+  done
+
+  local repo=""
+  repo="$(resolve_boris_repo)" || true
+  if [[ -n "$repo" ]]; then
+    local bin="$repo/editor/zig-out/bin/boris-editor"
+    if [[ ! -x "$bin" ]]; then
+      echo "embed-boris: building boris-editor (first run takes a few minutes)…"
+      (cd "$repo" && zig build --build-file editor/build.zig) || {
+        echo "embed-boris: FAILED to build boris-editor from $repo" >&2
+        return 1
+      }
+    fi
+    if [[ -x "$bin" ]]; then
+      echo "$bin"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# The compiled Svelte shell (index.html + assets/) the host serves for
+# GET / and /assets/*. Never npm-built here — see header.
+find_editor_ui() {
+  if [[ -n "${SOLIPSIST_EDITOR_UI_DIR:-}" && -f "${SOLIPSIST_EDITOR_UI_DIR}/index.html" ]]; then
+    echo "${SOLIPSIST_EDITOR_UI_DIR}"
+    return 0
+  fi
+
+  local repo=""
+  repo="$(resolve_boris_repo)" || true
+  if [[ -n "$repo" ]]; then
+    if [[ -f "$repo/editor/ui/dist/index.html" ]]; then
+      echo "$repo/editor/ui/dist"
+      return 0
+    fi
+    echo "embed-boris: FAILED: editor UI not built in $repo" >&2
+    echo "embed-boris: build it once with:" >&2
+    echo "embed-boris:   cd $repo/editor/ui && npm ci && npm run build" >&2
+    return 1
+  fi
+  return 1
+}
+
+# Bundles the boris-editor host with the same codesign identity/path as boris.
+bundle_editor() {
+  local sign_identity="${1:--}"
+  if [[ -f "$DEST_DIR/boris-editor" ]]; then
+    return 0
+  fi
+  local editor
+  if ! editor="$(find_editor_binary)"; then
+    echo "embed-boris: FAILED: no boris-editor binary found" >&2
+    echo "embed-boris: set SOLIPSIST_BORIS_EDITOR_BIN or BORIS_REPO_DIR" >&2
+    return 1
+  fi
+  cp "$editor" "$DEST_DIR/boris-editor"
+  chmod +x "$DEST_DIR/boris-editor"
+  if [[ -n "$sign_identity" ]]; then
+    codesign --force --options runtime --sign "$sign_identity" "$DEST_DIR/boris-editor" 2>/dev/null || \
+    codesign --force --options runtime --sign - "$DEST_DIR/boris-editor" 2>/dev/null || true
+  fi
+  echo "embed-boris: bundled boris-editor (provenance: $editor)"
+}
+
+# Bundles the compiled editor UI as Resources/editor-ui/.
+bundle_editor_ui() {
+  if [[ -f "$DEST_DIR/editor-ui/index.html" ]]; then
+    return 0
+  fi
+  local ui
+  if ! ui="$(find_editor_ui)"; then
+    echo "embed-boris: FAILED: no compiled editor UI found" >&2
+    echo "embed-boris: set SOLIPSIST_EDITOR_UI_DIR or BORIS_REPO_DIR" >&2
+    return 1
+  fi
+  mkdir -p "$DEST_DIR/editor-ui"
+  cp -R "$ui/." "$DEST_DIR/editor-ui/"
+  echo "embed-boris: bundled editor-ui (provenance: $ui)"
 }
 
 find_oliver() {
@@ -170,12 +361,28 @@ find_oliver() {
       return 0
     fi
   done
+
+  local repo=""
+  repo="$(resolve_oliver_repo)" || true
+  if [[ -n "$repo" ]]; then
+    local bin="$repo/zig-out/bin/oliver"
+    if [[ ! -x "$bin" ]]; then
+      echo "embed-boris: building oliver (first run takes a few minutes)…"
+      (cd "$repo" && zig build) || {
+        echo "embed-boris: FAILED to build oliver from $repo" >&2
+        return 1
+      }
+    fi
+    if [[ -x "$bin" ]]; then
+      echo "$bin"
+      return 0
+    fi
+  fi
   return 1
 }
 
 # Bundles the oliver renderer with the same codesign identity/path as boris.
-# Skips when already present (companion/kit path won). Absence is a notice,
-# not a failure: preview falls back to SOLIPSIST_OLIVER_BIN / dev checkouts.
+# Missing oliver FAILS the build (compose preview depends on it).
 bundle_oliver() {
   local sign_identity="${1:--}"
   if [[ -f "$DEST_DIR/oliver" ]]; then
@@ -183,8 +390,9 @@ bundle_oliver() {
   fi
   local oliver
   if ! oliver="$(find_oliver)"; then
-    echo "embed-boris: notice: no oliver binary found — compose preview falls back to SOLIPSIST_OLIVER_BIN"
-    return 0
+    echo "embed-boris: FAILED: no oliver binary found" >&2
+    echo "embed-boris: set SOLIPSIST_OLIVER_BIN or OLIVER_REPO_DIR" >&2
+    return 1
   fi
   cp "$oliver" "$DEST_DIR/oliver"
   chmod +x "$DEST_DIR/oliver"


### PR DESCRIPTION
The release app shipped only `Resources/boris`:

- Editor companion threw `editorBinaryNotFound` on a clean machine.
- `--ui-dir` was never passed, and the host default (`editor/ui/dist`, CWD-relative) can never resolve under a project root, so the shell 404s even with a binary.
- Compose preview found no oliver.

This PR (spec: `docs/issues/bundle-editor-oliver.md`):
- `scripts/embed-boris.sh` bundles `boris-editor`, `editor-ui/`, and `oliver` into `Resources/`, signed like the engine. Checkout resolution: `BORIS_REPO_DIR`/`OLIVER_REPO_DIR` → derived from `SOLIPSIST_BORIS_BIN` inside a checkout → sibling fallbacks (worktree-safe). Builds editor/oliver from source when absent; missing pieces fail the build (`SKIP_EMBED_BORIS=1` opts out).
- `EditorServerFactory` resolves the bundled UI dir (env → sibling of engine → bundle) and passes it as `--ui-dir`.
- 4 new locator tests; `AGENTS.md`/`Makefile` document the resolution + overrides.

Verified: fresh build bundles boris 0.8.2 + boris-editor + oliver 1.1.0 + editor-ui; host serves the shell, `/api/health` ok, `/api/version` → boris/0.8.2; `make test` 550/0, `make lint` clean.